### PR TITLE
fix(ci): desplegar docs en release publicado

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,9 +8,9 @@ This directory contains all GitHub Actions workflows for the starter-gradle proj
 | --------------- | ------------------------------------ | ------------------------------------ | --------------------------------------- |
 | **CI/CD**       | `pull-request-check.yml`             | Main CI checks for PRs and pushes    | Push to any branch, PR to main/minor/\* |
 | **CI/CD**       | `pull-request-check-build-logic.yml` | Checks for build-logic changes       | Changes to `gradle/build-logic/**`      |
-| **CI/CD**       | `deploy-docs.yml`                    | Deploy documentation to GitHub Pages | Push to `main`                          |
+| **CI/CD**       | `deploy-docs.yml`                    | Deploy documentation to GitHub Pages | Push docs to `main`, Release published  |
 | **Security**    | `codeql-analysis.yml`                | Security scanning with CodeQL        | Push to main/minor, daily schedule      |
-| **Publishing**  | `publish-release.yml`                | Publish release to Maven Central     | Tag push `v*.*.*`                       |
+| **Publishing**  | `publish-release.yml`                | Publish release (Maven, Cargo, npm, Docker)     | Tag push `v*.*.*`                       |
 | **Publishing**  | `publish-snapshot.yml`               | Publish snapshot versions            | Manual, daily schedule                  |
 | **Publishing**  | `_publish.yml`                       | Reusable publish workflow            | Called by other workflows               |
 | **Automation**  | `auto-fix-lockfile.yml`              | Auto-update lockfiles                | Daily schedule, manual                  |
@@ -88,7 +88,8 @@ This directory contains all GitHub Actions workflows for the starter-gradle proj
 
 **Triggers**:
 
-- Push to `main` branch
+- Push to `main` branch (docs-related paths only)
+- Release published
 - Manual trigger
 
 **What it does**:
@@ -97,13 +98,15 @@ This directory contains all GitHub Actions workflows for the starter-gradle proj
 2. 📦 Sets up pnpm 10
 3. 📦 Sets up Node.js 24 with pnpm caching
 4. 📥 Installs dependencies (`pnpm install`)
-5. 🏗 Builds the site (`pnpm run build` in `website/docs`)
+5. 🏗 Builds the site (`pnpm run build` in `clients/web/apps/docs`)
 6. ⬆️ Uploads artifact for deployment
 7. 🚀 Deploys to GitHub Pages
 
 **Key Points**:
 
 - Requires `contents: read`, `pages: write`, `id-token: write` permissions
+- Uses path filters on push to avoid unnecessary deployments
+- Also deploys on release publication to keep release docs aligned
 - Uses GitHub Pages artifact upload and deployment actions
 - Output available at GitHub Pages URL
 
@@ -146,7 +149,7 @@ This directory contains all GitHub Actions workflows for the starter-gradle proj
 
 ### `publish-release.yml` - Release Publishing
 
-**Purpose**: Publishes a release version to Maven Central and creates GitHub release.
+**Purpose**: Publishes release artifacts to Maven Central, crates.io, npm, Docker Hub, and GHCR, then creates a GitHub release.
 
 **Triggers**:
 
@@ -160,7 +163,7 @@ Calls the reusable `_publish.yml` workflow with:
 
 **Restrictions**:
 
-- Only runs on `dallay/starter-gradle` repository
+- Only runs on `dallay/corvus` repository
 - Requires tag starting with `v`
 
 ---
@@ -182,13 +185,13 @@ Calls the reusable `_publish.yml` workflow with:
 
 **Restrictions**:
 
-- Only runs on `dallay/starter-gradle` repository
+- Only runs on `dallay/corvus` repository
 
 ---
 
 ### `_publish.yml` - Reusable Publishing Workflow
 
-**Purpose**: Internal reusable workflow for publishing artifacts.
+**Purpose**: Internal reusable workflow for publishing release/snapshot artifacts.
 
 **Called by**: `publish-release.yml`, `publish-snapshot.yml`
 
@@ -204,15 +207,20 @@ Calls the reusable `_publish.yml` workflow with:
 - `SIGNING_IN_MEMORY_KEY_PASSWORD` - GPG key password
 - `MAVEN_CENTRAL_USERNAME` - Maven Central username
 - `MAVEN_CENTRAL_PASSWORD` - Maven Central password
+- `CARGO_REGISTRY_TOKEN` - crates.io publish token (release)
+- `NPM_TOKEN` - npm publish token (release)
+- `DOCKERHUB_USERNAME` - Docker Hub namespace/user (release)
+- `DOCKERHUB_TOKEN` - Docker Hub access token (release)
 
 **What it does**:
 
 1. 📦 Sets up build environment
 2. 🌿 Generates changelog (if enabled) using `release-changelog-builder-action`
 3. 👻 Publishes to Maven Central using Gradle
-   - For `dallay/starter-gradle`: also publishes build-logic
-   - For forks: only publishes main project
-4. 🚀 Creates GitHub release (if enabled)
+4. 🦀 Publishes Rust crate to crates.io (release only)
+5. 📦 Publishes npm package `@corvus/cli` to npm (release only)
+6. 🐳 Builds and publishes multi-arch Docker image to Docker Hub + GHCR (release only)
+7. 🚀 Creates GitHub release (if enabled)
 
 **Key Points**:
 
@@ -584,7 +592,7 @@ Other workflows call dallay/common-actions:
 
 For issues with GitHub Actions:
 
-1. Check the [Actions tab](https://github.com/dallay/starter-gradle/actions) for failed runs
+1. Check the [Actions tab](https://github.com/dallay/corvus/actions) for failed runs
 2. Review workflow logs for error details
 3. Check [GitHub Status](https://www.githubstatus.com/) for service disruptions
 4. Open an issue with the `ci|actions` label

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -19,10 +19,21 @@ on:
         required: true
       MAVEN_CENTRAL_PASSWORD:
         required: true
+      CARGO_REGISTRY_TOKEN:
+        required: false
+      NPM_TOKEN:
+        required: false
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
 
     steps:
       - name: ✈ Checkout repository
@@ -34,6 +45,12 @@ jobs:
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: "24"
+
+      - name: 🦀 Setup Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          cargo --version
 
       - name: ☕ Setup Java
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
@@ -74,6 +91,55 @@ jobs:
             echo "</details>"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: 🔎 Validate release version consistency
+        if: ${{ inputs.release }}
+        env:
+          TAG_VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$TAG_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release tag: $TAG_VERSION"
+            exit 1
+          fi
+
+          expected_version="${TAG_VERSION#v}"
+          gradle_version="$(awk -F= '/^VERSION=/{print $2}' gradle.properties)"
+          cargo_version="$(awk -F' = ' '/^version = /{gsub(/\"/, "", $2); print $2; exit}' clients/agent-runtime/Cargo.toml)"
+          npm_version="$(awk -F'"' '/"version"/{print $4; exit}' clients/agent-runtime/npm/corvus-cli/package.json)"
+
+          for item in \
+            "gradle.properties:$gradle_version" \
+            "clients/agent-runtime/Cargo.toml:$cargo_version" \
+            "clients/agent-runtime/npm/corvus-cli/package.json:$npm_version"; do
+            file="${item%%:*}"
+            actual="${item#*:}"
+            if [[ "$actual" != "$expected_version" ]]; then
+              echo "Version mismatch in ${file}: expected ${expected_version}, got ${actual}"
+              exit 1
+            fi
+          done
+
+      - name: 🔐 Validate release credentials
+        if: ${{ inputs.release }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for secret in CARGO_REGISTRY_TOKEN NPM_TOKEN DOCKERHUB_USERNAME DOCKERHUB_TOKEN; do
+            if [[ -z "${!secret:-}" ]]; then
+              echo "Missing required secret for releases: ${secret}"
+              missing=1
+            fi
+          done
+          if [[ "$missing" -ne 0 ]]; then
+            exit 1
+          fi
+
       - name: 👻 Publish to Maven Central
         env:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
@@ -82,7 +148,7 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: |
-          if [ "${GITHUB_REPOSITORY}" = "dallay/starter-gradle" ]; then
+          if [ "${GITHUB_REPOSITORY}" = "dallay/corvus" ]; then
             if [ "${{ inputs.release }}" = "true" ]; then
               ./gradlew :build-logic:publishPluginMavenPublicationToMavenCentralRepository publishToMavenCentral
             else
@@ -91,6 +157,74 @@ jobs:
           else
             ./gradlew publishToMavenCentral
           fi
+
+      - name: 📦 Publish Rust crate to crates.io
+        if: ${{ inputs.release }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cd clients/agent-runtime
+          cargo publish --locked
+
+      - name: 📦 Publish npm package
+        if: ${{ inputs.release }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cat <<EOF > "$HOME/.npmrc"
+          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+          EOF
+          cd clients/agent-runtime/npm/corvus-cli
+          npm publish --access public
+
+      - name: 🐳 Set up QEMU
+        if: ${{ inputs.release }}
+        uses: docker/setup-qemu-action@e474179bdfa42213eab2f8c674c6daef42f43a09 # v3.6.0
+
+      - name: 🐳 Set up Docker Buildx
+        if: ${{ inputs.release }}
+        uses: docker/setup-buildx-action@f4f5800b94467d3a33e1d9b90bba96fd39e8564e # v3.11.1
+
+      - name: 🔐 Login to Docker Hub
+        if: ${{ inputs.release }}
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.5.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: 🔐 Login to GitHub Container Registry
+        if: ${{ inputs.release }}
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🏷️ Generate Docker tags and labels
+        if: ${{ inputs.release }}
+        id: docker-meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84cc7b29e5c6ea6f7eb9e81 # v5.8.0
+        with:
+          images: |
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/corvus
+            ghcr.io/${{ github.repository_owner }}/corvus
+          tags: |
+            type=semver,pattern={{version}},value=${{ github.ref_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ github.ref_name }}
+            type=semver,pattern={{major}},value=${{ github.ref_name }}
+            type=raw,value=latest
+
+      - name: 🐳 Build and push Docker image
+        if: ${{ inputs.release }}
+        uses: docker/build-push-action@95139e6fce77e460f7d1d9c03d096667e6bfca44 # v6.17.0
+        with:
+          context: .
+          file: clients/agent-runtime/Dockerfile
+          target: release
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
 
       - name: 🚀 Create GitHub Release
         if: ${{ inputs.release }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,12 +1,19 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Trigger the workflow every time you push to the `main` branch
-  # Using a different branch name? Replace `main` with your branch's name
   push:
     branches: [main]
-  # Allows you to run this workflow manually from the Actions tab on GitHub.
+    paths:
+      - "clients/web/apps/docs/**"
+      - "clients/web/packages/shared/**"
+      - ".github/workflows/deploy-docs.yml"
+  release:
+    types: [published]
   workflow_dispatch:
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
 
 # Allow this job to clone the repo and create a page deployment
 permissions:
@@ -16,13 +23,14 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'dallay/corvus'
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: clients/web/apps/docs
     steps:
-      - name: Checkout your repository using git
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
@@ -30,7 +38,7 @@ jobs:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,7 @@ jobs:
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/v') &&
-      github.repository == 'dallay/starter-gradle'
+      github.repository == 'dallay/corvus'
     uses: ./.github/workflows/_publish.yml
     with:
       release: true

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish-snapshot:
-    if: github.repository == 'dallay/starter-gradle'
+    if: github.repository == 'dallay/corvus'
     uses: ./.github/workflows/_publish.yml
     with:
       release: false

--- a/sync-version-with-tag.sh
+++ b/sync-version-with-tag.sh
@@ -8,7 +8,9 @@ readonly TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
 readonly TARGETS=(
   "properties:gradle.properties:VERSION"
   "properties:gradle/build-logic/gradle.properties:VERSION"
-  "json:apps/docs/website/package.json:version"
+  "json:clients/web/apps/docs/package.json:version"
+  "toml:clients/agent-runtime/Cargo.toml:version"
+  "json:clients/agent-runtime/npm/corvus-cli/package.json:version"
 )
 
 declare -a CHANGED_FILES=()
@@ -51,6 +53,40 @@ update_properties_key() {
       if (!updated) print prefix value
     }
   ' "$file" > "$temp_file"
+  write_if_changed "$file" "$temp_file"
+}
+
+update_toml_string_key() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  local temp_file
+
+  if [[ ! -f "$file" ]]; then
+    echo "ERROR: $file not found"
+    exit 1
+  fi
+
+  temp_file="$(mktemp "$(dirname "$file")/.sync-version.XXXXXX")"
+  awk -v key="$key" -v value="$value" '
+    BEGIN { updated = 0 }
+    {
+      line = $0
+      pattern = "^[[:space:]]*" key "[[:space:]]*=[[:space:]]*\"[^\"]*\"[[:space:]]*$"
+      if (!updated && line ~ pattern) {
+        sub("^([[:space:]]*" key "[[:space:]]*=[[:space:]]*)\"[^\"]*\"", "\\1\"" value "\"", line)
+        updated = 1
+      }
+      print line
+    }
+    END {
+      if (!updated) exit 1
+    }
+  ' "$file" > "$temp_file" || {
+    rm -f "$temp_file"
+    echo "ERROR: Could not find TOML string key \"$key\" in $file"
+    exit 1
+  }
   write_if_changed "$file" "$temp_file"
 }
 
@@ -102,6 +138,9 @@ apply_target_update() {
     json)
       update_json_string_key "$file" "$key" "$version"
       ;;
+    toml)
+      update_toml_string_key "$file" "$key" "$version"
+      ;;
     *)
       echo "ERROR: Unsupported target type '$target_type' in '$target'"
       exit 1
@@ -136,15 +175,15 @@ fi
 # Helpful next-steps message
 diff_files="${CHANGED_FILES[*]}"
 if [[ ${#CHANGED_FILES[@]} -eq 0 ]]; then
-  diff_files="gradle.properties gradle/build-logic/gradle.properties apps/docs/website/package.json"
+  diff_files="gradle.properties gradle/build-logic/gradle.properties clients/web/apps/docs/package.json clients/agent-runtime/Cargo.toml clients/agent-runtime/npm/corvus-cli/package.json"
 fi
 
-cat <<EOF
+cat <<NEXT_STEPS
 Next steps (recommended):
   1) Review the changes: git diff "$diff_files"
-  2) Commit the change: git add gradle.properties gradle/build-logic/gradle.properties apps/docs/website/package.json && git commit -m "chore: sync version to $version"
+  2) Commit the change: git add gradle.properties gradle/build-logic/gradle.properties clients/web/apps/docs/package.json clients/agent-runtime/Cargo.toml clients/agent-runtime/npm/corvus-cli/package.json && git commit -m "chore: sync version to $version"
   3) Push your branch and tag as appropriate.
      If tag v$version already exists but points at the wrong commit, prefer creating a new patch version.
      Only force-update a tag after confirming no one else depends on it and with explicit confirmation.
-     See "Version already exists" troubleshooting guidance in apps/docs/website/src/content/docs/guides/release.md.
-EOF
+     See "Version already exists" troubleshooting guidance in clients/web/apps/docs/src/content/docs/guides/release.md.
+NEXT_STEPS


### PR DESCRIPTION
### Motivation

- Evitar despliegues de documentación innecesarios en `main` y asegurar que la documentación pública se alinee con una versión liberada. 
- Limitar y controlar ejecuciones de Pages para cambios que afectan solo a la documentación. 
- Asegurar que el pipeline reutilizable de publicación soporte y valide artefactos adicionales (Rust, npm, Docker) y la coherencia de versiones. 

### Description

- Actualicé `deploy-docs.yml` para añadir filtros por `paths`, disparar también en `release: published`, agregar `concurrency` para despliegues de Pages y aplicar un guard (`if: github.repository == 'dallay/corvus'`) y versiones fijas de acciones; además ajusté el `working-directory` y pasos de build a `clients/web/apps/docs`. 
- Documentación de workflows actualizada en `.github/workflows/README.md` para reflejar el nuevo comportamiento (push por paths + deploy en release) y correcciones de referencias a `dallay/corvus`. 
- Extensión del workflow reusable `/.github/workflows/_publish.yml` para: preparar Rust, validar consistencia de versión frente al tag `vX.Y.Z`, validar la presencia de secretos de publicación, publicar a `crates.io` (`cargo publish`), publicar paquete `npm` (`npm publish`) y construir/pushear imagen multi-arch a Docker Hub y GHCR, además de ajustar permisos y setup de herramientas. 
- Actualicé `publish-release.yml` y `publish-snapshot.yml` para apuntar al repositorio correcto (`dallay/corvus`). 
- Mejoré `sync-version-with-tag.sh` añadiendo soporte TOML (`update_toml_string_key`) y objetivos para `clients/agent-runtime/Cargo.toml` y `clients/agent-runtime/npm/corvus-cli/package.json`, y actualicé los mensajes de pasos siguientes. 

### Testing

- Validé la sintaxis YAML de `deploy-docs.yml` con `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy-docs.yml')"` y obtuvo `OK_yaml_deploy_docs` (éxito). 
- Ejecuté `git diff --check` para verificar espacios en blanco y problemas de diff y no se reportaron errores (éxito). 
- Ejecuté `./gradlew -q help` para comprobar el entorno Gradle básico y la tarea respondió correctamente (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699420a8e4c0832190c33967e1ae8af1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to support publishing across multiple package registries
  * Enhanced release automation with multi-artifact version consistency validation
  * Reflected project reorganization in workflow configurations

* **Documentation**
  * Updated GitHub Actions workflow documentation with expanded publishing targets and instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->