### PR TITLE
build(install): improve binary installation process with temporary staging

### DIFF
--- a/clients/web/apps/marketing/public/install
+++ b/clients/web/apps/marketing/public/install
@@ -360,19 +360,18 @@ extract_or_copy_binary() {
   local asset_base="$2"
   local target_path="$3"
   local extract_dir="$4"
+  local parent_return_trap="$5"
   local archive_entry=""
   local staged_path=""
   local source_path=""
-  local previous_return_trap=""
 
   staged_path="$(mktemp "${target_path}.tmp.XXXXXX")"
-  previous_return_trap="$(trap -p RETURN || true)"
   trap '
     if [ -n "${staged_path:-}" ] && [ -e "$staged_path" ]; then
       rm -f "$staged_path"
     fi
-    if [ -n "${previous_return_trap:-}" ]; then
-      eval "$previous_return_trap"
+    if [ -n "${parent_return_trap:-}" ]; then
+      trap "$parent_return_trap" RETURN
     else
       trap - RETURN
     fi
@@ -398,12 +397,6 @@ extract_or_copy_binary() {
   fi
   mv -f "$staged_path" "$target_path"
   staged_path=""
-
-  if [ -n "$previous_return_trap" ]; then
-    eval "$previous_return_trap"
-  else
-    trap - RETURN
-  fi
 }
 
 install_via_binary() {
@@ -414,6 +407,7 @@ install_via_binary() {
   local target_path=""
   local download_path=""
   local extract_dir=""
+  local install_cleanup_trap=""
 
   asset="$(detect_binary_asset)"
   release_tag="$REQUESTED_VERSION"
@@ -428,11 +422,12 @@ install_via_binary() {
   target_path="${install_dir}/corvus"
   download_path="$(mktemp "${TMPDIR:-/tmp}/corvus-download.XXXXXX")"
   extract_dir="$(mktemp -d "${TMPDIR:-/tmp}/corvus-extract.XXXXXX")"
-  trap "rm -f '$download_path'; rm -rf '$extract_dir'; trap - RETURN" RETURN
+  install_cleanup_trap="rm -f '$download_path'; rm -rf '$extract_dir'; trap - RETURN"
+  trap "$install_cleanup_trap" RETURN
 
   download_binary_from_releases "$normalized_release_tag" "$asset" "$download_path"
   verify_checksum "$download_path" "$RESOLVED_CHECKSUM_URL"
-  extract_or_copy_binary "$download_path" "$asset" "$target_path" "$extract_dir"
+  extract_or_copy_binary "$download_path" "$asset" "$target_path" "$extract_dir" "$install_cleanup_trap"
 
   INSTALLED_BINARY_PATH="$target_path"
 


### PR DESCRIPTION
This pull request refactors the binary extraction and installation logic in the `clients/web/apps/marketing/public/install` script to improve reliability and ensure correct file permissions. The main change is to stage the binary in a temporary file with the correct permissions before moving it to its final destination, replacing the previous approach of copying and then changing permissions.

**Improvements to binary extraction and installation:**

* Refactored `extract_or_copy_binary()` to stage the extracted or copied binary in a temporary file (`$staged_path`), set executable permissions using `install -m 755` (if available) or `chmod 755`, and then move it atomically to the target path. This ensures correct permissions and reduces the risk of partial updates. [[1]](diffhunk://#diff-cf25dac8ae6e00275f3ba162e0ffcb75449171be558fb34559dd566a5d97dec6R364-R368) [[2]](diffhunk://#diff-cf25dac8ae6e00275f3ba162e0ffcb75449171be558fb34559dd566a5d97dec6L372-R388)
* Removed the redundant `chmod 755` call from `install_via_binary()`, as permissions are now handled during extraction/copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable binary installations via atomic placement to avoid partial or corrupted installs.
  * Correct handling of archived (tar.gz) vs single-file assets so the intended file is installed.
  * Improved cleanup on exit to remove temporary artifacts if installation is interrupted.
  * Preserved file permissions and placement semantics during install to prevent incorrect modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->