### PR TITLE
docs: Add CLI Reference Documentation (EN/ES)

### DIFF
--- a/clients/web/apps/docs/astro.config.mjs
+++ b/clients/web/apps/docs/astro.config.mjs
@@ -116,6 +116,13 @@ export default defineConfig({
                 es: "Plugins del Runtime",
               },
             },
+            {
+              label: "CLI Reference",
+              slug: "guides/cli-reference",
+              translations: {
+                es: "Referencia de la CLI",
+              },
+            },
           ],
         },
         {

--- a/clients/web/apps/docs/src/content/docs/en/guides/cli-reference.md
+++ b/clients/web/apps/docs/src/content/docs/en/guides/cli-reference.md
@@ -1,0 +1,252 @@
+---
+title: CLI Reference
+description: Comprehensive guide to the Corvus Agent CLI commands and options.
+---
+
+The Corvus CLI (`corvus`) is the primary interface for managing your agents, hardware, and services.
+
+## Core Commands
+
+### `onboard`
+Initialize your workspace and configuration.
+
+- `--interactive`: Run the full interactive wizard (default is quick setup).
+- `--channels-only`: Reconfigure channels only.
+- `--api-key <KEY>`: API key for quick setup.
+- `--provider <NAME>`: Provider name (default: openrouter).
+- `--memory <TYPE>`: Memory backend (sqlite, lucid, surreal-graphs, surreal, markdown, none).
+
+**Example:**
+```bash
+corvus onboard --interactive
+```
+
+### `agent`
+Start the AI agent loop.
+
+- `-m, --message <TEXT>`: Single message mode.
+- `-p, --provider <NAME>`: Provider to use.
+- `--model <MODEL>`: Specific model to use.
+- `-t, --temperature <VALUE>`: Temperature (0.0 - 2.0).
+- `--peripheral <BOARD:PATH>`: Attach a peripheral (e.g., `nucleo-f401re:/dev/ttyACM0`).
+
+**Example:**
+```bash
+corvus agent -m "Hello, how can you help me today?"
+```
+
+### `daemon`
+Start the long-running autonomous runtime (gateway + channels + heartbeat + scheduler).
+
+- `-p, --port <PORT>`: Port to listen on.
+- `--host <HOST>`: Host to bind to.
+
+**Example:**
+```bash
+corvus daemon --port 3000
+```
+
+### `gateway`
+Start only the gateway server (webhooks, websockets).
+
+- `-p, --port <PORT>`: Port to listen on.
+- `--host <HOST>`: Host to bind to.
+
+**Example:**
+```bash
+corvus gateway --port 3001
+```
+
+---
+
+## System & Service
+
+### `status`
+Show full system status details.
+
+**Example:**
+```bash
+corvus status
+```
+
+### `doctor`
+Run diagnostics for daemon, scheduler, and channel freshness.
+
+**Example:**
+```bash
+corvus doctor
+```
+
+### `service`
+Manage the OS service lifecycle (systemd/launchd).
+
+- `install`: Install the daemon service.
+  - `--linger <MODE>`: Linux only: keep service active (Keep, On, Off).
+- `start`: Start the service.
+- `stop`: Stop the service.
+- `restart`: Restart the service.
+- `status`: Check service status.
+- `uninstall`: Remove the service unit.
+
+**Example:**
+```bash
+corvus service install --linger on
+```
+
+---
+
+## Task Management
+
+### `cron`
+Configure and manage scheduled tasks.
+
+- `list`: List all scheduled tasks.
+- `add <EXPR> <CMD>`: Add a task using a cron expression.
+- `add-at <TIMESTAMP> <CMD>`: Add a one-shot task at a specific RFC3339 time.
+- `add-every <MS> <CMD>`: Add a fixed-interval task.
+- `once <DELAY> <CMD>`: Add a delayed one-shot task (e.g., "30m", "2h").
+- `remove <ID>`: Remove a task.
+- `pause <ID>`: Pause a task.
+- `resume <ID>`: Resume a task.
+
+**Example:**
+```bash
+corvus cron add "0 9 * * *" "corvus agent -m 'Daily update'"
+```
+
+---
+
+## Providers & Auth
+
+### `providers`
+List all supported AI providers.
+
+**Example:**
+```bash
+corvus providers
+```
+
+### `auth`
+Manage provider authentication profiles.
+
+- `login --provider <NAME>`: Login with OAuth (e.g., `openai-codex`).
+- `list`: List auth profiles.
+- `status`: Show auth status and token expiry.
+- `use --provider <NAME> --profile <ID>`: Set active profile.
+- `logout --provider <NAME>`: Remove a profile.
+
+**Example:**
+```bash
+corvus auth list
+```
+
+### `models`
+Manage provider model catalogs.
+
+- `refresh`: Refresh and cache provider models.
+  - `--force`: Force live refresh.
+
+**Example:**
+```bash
+corvus models refresh --provider anthropic
+```
+
+---
+
+## Capabilities & Integrations
+
+### `skills`
+Manage user-defined capabilities.
+
+- `list`: List installed skills.
+- `install <SOURCE>`: Install from a GitHub URL or local path.
+- `remove <NAME>`: Remove a skill.
+
+**Example:**
+```bash
+corvus skills install https://github.com/user/my-skill
+```
+
+### `plugins`
+Manage signed runtime plugins.
+
+- `list`: List installed plugins.
+- `install <ID>`: Install a plugin (e.g., `memory.surreal.graphs`).
+- `remove <ID>`: Remove a plugin.
+- `verify`: Verify plugin integrity.
+
+**Example:**
+```bash
+corvus plugins install memory.surreal.graphs
+```
+
+### `integrations`
+Browse available integrations.
+
+- `info <NAME>`: Show details about a specific integration.
+
+**Example:**
+```bash
+corvus integrations info telegram
+```
+
+---
+
+## Communication
+
+### `channel`
+Manage communication channels (Telegram, Discord, Slack).
+
+- `list`: List configured channels.
+- `start`: Start all configured channels.
+- `add <TYPE> <CONFIG_JSON>`: Add a new channel.
+- `remove <NAME>`: Remove a channel.
+- `bind-telegram <IDENTITY>`: Bind a Telegram user to the allowlist.
+
+**Example:**
+```bash
+corvus channel list
+```
+
+---
+
+## Hardware & Peripherals
+
+### `hardware`
+Discover and introspect USB hardware.
+
+- `discover`: Enumerate USB devices and show known boards.
+- `introspect <PATH>`: Details about a device at a specific path.
+- `info`: Get chip info via USB (probe-rs).
+
+**Example:**
+```bash
+corvus hardware discover
+```
+
+### `peripheral`
+Manage hardware peripherals (STM32, RPi, etc.).
+
+- `list`: List configured peripherals.
+- `add <BOARD> <PATH>`: Add a peripheral.
+- `flash-nucleo`: Flash Corvus firmware to Nucleo-F401RE.
+- `flash`: Flash Corvus firmware to Arduino.
+
+**Example:**
+```bash
+corvus peripheral add nucleo-f401re /dev/ttyACM0
+```
+
+---
+
+## Utilities
+
+### `migrate`
+Migrate data from other agent runtimes.
+
+- `openclaw`: Import memory from an OpenClaw workspace.
+
+**Example:**
+```bash
+corvus migrate openclaw --source ~/.openclaw/workspace
+```

--- a/clients/web/apps/docs/src/content/docs/es/guides/cli-reference.md
+++ b/clients/web/apps/docs/src/content/docs/es/guides/cli-reference.md
@@ -1,0 +1,252 @@
+---
+title: Referencia de la CLI
+description: Guía completa de los comandos y opciones de la CLI del agente Corvus.
+---
+
+La CLI de Corvus (`corvus`) es la interfaz principal para gestionar tus agentes, hardware y servicios.
+
+## Comandos Principales
+
+### `onboard`
+Inicializa tu espacio de trabajo y configuración.
+
+- `--interactive`: Ejecuta el asistente interactivo completo (por defecto es configuración rápida).
+- `--channels-only`: Reconfigura solo los canales.
+- `--api-key <KEY>`: Clave de API para configuración rápida.
+- `--provider <NAME>`: Nombre del proveedor (por defecto: openrouter).
+- `--memory <TYPE>`: Backend de memoria (sqlite, lucid, surreal-graphs, surreal, markdown, none).
+
+**Ejemplo:**
+```bash
+corvus onboard --interactive
+```
+
+### `agent`
+Inicia el bucle del agente de IA.
+
+- `-m, --message <TEXT>`: Modo de mensaje único.
+- `-p, --provider <NAME>`: Proveedor a utilizar.
+- `--model <MODEL>`: Modelo específico a utilizar.
+- `-t, --temperature <VALUE>`: Temperatura (0.0 - 2.0).
+- `--peripheral <BOARD:PATH>`: Conecta un periférico (ej., `nucleo-f401re:/dev/ttyACM0`).
+
+**Ejemplo:**
+```bash
+corvus agent -m "Hola, ¿cómo puedes ayudarme hoy?"
+```
+
+### `daemon`
+Inicia el runtime autónomo de larga duración (gateway + canales + heartbeat + planificador).
+
+- `-p, --port <PORT>`: Puerto para escuchar.
+- `--host <HOST>`: Host para vincularse.
+
+**Ejemplo:**
+```bash
+corvus daemon --port 3000
+```
+
+### `gateway`
+Inicia solo el servidor gateway (webhooks, websockets).
+
+- `-p, --port <PORT>`: Puerto para escuchar.
+- `--host <HOST>`: Host para vincularse.
+
+**Ejemplo:**
+```bash
+corvus gateway --port 3001
+```
+
+---
+
+## Sistema y Servicio
+
+### `status`
+Muestra los detalles completos del estado del sistema.
+
+**Ejemplo:**
+```bash
+corvus status
+```
+
+### `doctor`
+Ejecuta diagnósticos para el daemon, el planificador y la frescura de los canales.
+
+**Ejemplo:**
+```bash
+corvus doctor
+```
+
+### `service`
+Gestiona el ciclo de vida del servicio del SO (systemd/launchd).
+
+- `install`: Instala la unidad de servicio del daemon.
+  - `--linger <MODE>`: Solo Linux: mantiene el servicio activo (Keep, On, Off).
+- `start`: Inicia el servicio.
+- `stop`: Detiene el servicio.
+- `restart`: Reinicia el servicio.
+- `status`: Verifica el estado del servicio.
+- `uninstall`: Elimina la unidad de servicio.
+
+**Ejemplo:**
+```bash
+corvus service install --linger on
+```
+
+---
+
+## Gestión de Tareas
+
+### `cron`
+Configura y gestiona tareas programadas.
+
+- `list`: Lista todas las tareas programadas.
+- `add <EXPR> <CMD>`: Añade una tarea usando una expresión cron.
+- `add-at <TIMESTAMP> <CMD>`: Añade una tarea de un solo uso en un tiempo RFC3339 específico.
+- `add-every <MS> <CMD>`: Añade una tarea de intervalo fijo.
+- `once <DELAY> <CMD>`: Añade una tarea retrasada de un solo uso (ej., "30m", "2h").
+- `remove <ID>`: Elimina una tarea.
+- `pause <ID>`: Pausa una tarea.
+- `resume <ID>`: Reanuda una tarea pausada.
+
+**Ejemplo:**
+```bash
+corvus cron add "0 9 * * *" "corvus agent -m 'Actualización diaria'"
+```
+
+---
+
+## Proveedores y Autenticación
+
+### `providers`
+Lista todos los proveedores de IA soportados.
+
+**Ejemplo:**
+```bash
+corvus providers
+```
+
+### `auth`
+Gestiona los perfiles de autenticación de los proveedores.
+
+- `login --provider <NAME>`: Inicia sesión con OAuth (ej., `openai-codex`).
+- `list`: Lista los perfiles de autenticación.
+- `status`: Muestra el estado de autenticación y el vencimiento de los tokens.
+- `use --provider <NAME> --profile <ID>`: Establece el perfil activo.
+- `logout --provider <NAME>`: Elimina un perfil.
+
+**Ejemplo:**
+```bash
+corvus auth list
+```
+
+### `models`
+Gestiona los catálogos de modelos de los proveedores.
+
+- `refresh`: Actualiza y cachea los modelos del proveedor.
+  - `--force`: Fuerza la actualización en vivo.
+
+**Ejemplo:**
+```bash
+corvus models refresh --provider anthropic
+```
+
+---
+
+## Capacidades e Integraciones
+
+### `skills`
+Gestiona las capacidades definidas por el usuario.
+
+- `list`: Lista las habilidades instaladas.
+- `install <SOURCE>`: Instala desde una URL de GitHub o una ruta local.
+- `remove <NAME>`: Elimina una habilidad.
+
+**Ejemplo:**
+```bash
+corvus skills install https://github.com/user/my-skill
+```
+
+### `plugins`
+Gestiona los plugins del runtime firmados.
+
+- `list`: Lista los plugins instalados.
+- `install <ID>`: Instala un plugin (ej., `memory.surreal.graphs`).
+- `remove <ID>`: Elimina un plugin.
+- `verify`: Verifica la integridad del plugin.
+
+**Ejemplo:**
+```bash
+corvus plugins install memory.surreal.graphs
+```
+
+### `integrations`
+Explora las integraciones disponibles.
+
+- `info <NAME>`: Muestra detalles sobre una integración específica.
+
+**Ejemplo:**
+```bash
+corvus integrations info telegram
+```
+
+---
+
+## Comunicación
+
+### `channel`
+Gestiona los canales de comunicación (Telegram, Discord, Slack).
+
+- `list`: Lista los canales configurados.
+- `start`: Inicia todos los canales configurados.
+- `add <TYPE> <CONFIG_JSON>`: Añade un nuevo canal.
+- `remove <NAME>`: Elimina un canal.
+- `bind-telegram <IDENTITY>`: Vincula un usuario de Telegram a la lista de permitidos.
+
+**Ejemplo:**
+```bash
+corvus channel list
+```
+
+---
+
+## Hardware y Periféricos
+
+### `hardware`
+Descubre e introspecciona el hardware USB.
+
+- `discover`: Enumera los dispositivos USB y muestra las placas conocidas.
+- `introspect <PATH>`: Detalles sobre un dispositivo en una ruta específica.
+- `info`: Obtiene información del chip vía USB (probe-rs).
+
+**Ejemplo:**
+```bash
+corvus hardware discover
+```
+
+### `peripheral`
+Gestiona periféricos de hardware (STM32, RPi, etc.).
+
+- `list`: Lista los periféricos configurados.
+- `add <BOARD> <PATH>`: Añade un periférico.
+- `flash-nucleo`: Flashea el firmware de Corvus al Nucleo-F401RE.
+- `flash`: Flashea el firmware de Corvus al Arduino.
+
+**Ejemplo:**
+```bash
+corvus peripheral add nucleo-f401re /dev/ttyACM0
+```
+
+---
+
+## Utilidades
+
+### `migrate`
+Migra datos desde otros runtimes de agentes.
+
+- `openclaw`: Importa memoria desde un espacio de trabajo de OpenClaw.
+
+**Ejemplo:**
+```bash
+corvus migrate openclaw --source ~/.openclaw/workspace
+```


### PR DESCRIPTION
This PR adds a comprehensive CLI reference guide to the Corvus documentation.
It covers all available commands, subcommands, and options for the Corvus Agent CLI.
The documentation is provided in both English and Spanish to match the project's internationalization standards.
Exact examples and descriptions are included for each command.
The Starlight sidebar has been updated to include the new guides.

---
*PR created automatically by Jules for task [17510594810375989799](https://jules.google.com/task/17510594810375989799) started by @yacosta738*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CLI Reference documentation covering all Corvus CLI commands with available flags, arguments, and usage examples.
  * Content is organized by command categories including core operations, system services, task management, authentication, and hardware configuration.
  * Reference is now available in both English and Spanish.
  * Accessible via the Guides section in the documentation sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->