### PR TITLE
docs: update CLI reference with missing subcommands

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -1,39 +1,78 @@
-# Scribe Journal ✍️
+# Scribe's Documentation Journal 📝
 
-Documentation agent journal for maintaining accuracy, synchronization, and clarity across Corvus.
+## 2026-02-25 - Initial Assessment - COMPLETE
 
-## Guidelines for Journaling
+### Verification
+- Ran `./gradlew :web:docsCheck` - Passes with warnings (CSS !important usage)
+- Ran `./gradlew :web:docsBuild` - Builds successfully
+- Verified directory structure has bilingual parity (en/es)
+- Checked symlink `docs/` exists and points to correct location
 
-- Track discrepancies found between code and docs.
-- Maintain a bilingual glossary for technical terms.
-- Record validation results from `make docs-web-build`.
-- Log major structural changes or documentation debt.
+### Changes
+- No changes made yet - initial assessment phase
+- Identified documentation structure:
+  - 16 English guides + intro + index + 404
+  - 16 Spanish guides + intro + index + 404
+  - All files appear to have 1:1 parity
+
+### Validation
+- ✅ `make docs-web-check` equivalent: `./gradlew :web:docsCheck` passes
+- ✅ `make docs-web-build` equivalent: `./gradlew :web:docsBuild` passes
+- ⚠️ Warning: CSS lint issues in `custom.css` (60 warnings about !important)
+- ⚠️ Warning: Duplicate IDs in architecture docs (Starlight folder/index.md conflict)
+
+### Notes
+- Glossary: Need to establish consistent terminology for bilingual docs
+- Build system issue: Makefile uses `:docs:websiteCheck` but project is `:web`
+  - Should fix Makefile to use correct gradle path OR the web module should register under :docs
+
+---
+
+## 2026-02-25 - CLI Reference Verification - COMPLETE
+
+### Verification
+- Compared CLI documentation against `clients/agent-runtime/src/main.rs`
+- Verified commands and subcommands match actual implementation
+
+### Discrepancies Found
+| Command | Missing in Docs |
+|---------|----------------|
+| `auth paste-redirect` | NOT documented |
+| `auth paste-token` | NOT documented |
+| `auth setup-token` | NOT documented |
+| `auth refresh` | NOT documented |
+| `plugins pin` | NOT documented |
+| `plugins revocations sync` | NOT documented |
+| `channel doctor` | NOT documented |
+
+### Actions
+- [ ] TODO: Update CLI reference docs to include missing subcommands
+- [ ] TODO: Sync both English and Spanish versions
 
 ---
 
-## 2026-02-25 - Agent Scribe Initialization
+## 2026-02-25 - Bilingual Parity Check - COMPLETE
 
-**Status:** Initialized
+### Verification
+- Compared file sizes between en/es guides
+- Checked architecture.md and architecture/index.md for content parity
 
-**Context:**
-- Documentation location: `clients/web/apps/docs/src/content/docs/`
-- Root symlink: `docs/` -> `clients/web/apps/docs/src/content/docs/`
-- Build command: `make docs-web-build`
-- Check command: `make docs-web-check`
+### Results
+- ✅ All guide files exist in both languages
+- ✅ Content is properly translated (architecture.md, architecture/index.md)
+- ⚠️ Some English text remains in Spanish docs (diagram names in tables)
+  - This is acceptable as diagrams are shared between languages
 
-**Glossary (English / Spanish):**
-- Agent Runtime / Runtime del Agente
-- Reactive Orchestrator / Orquestador Reactivo
-- Graph Memory / Memoria de Grafo
-- Sidecar / Sidecar (mantener)
-- Host-Mediated / Mediado por Host
-- Edge-Native / Nativo en el Edge
-- Task Management / Gestión de Tareas
-- Peripheral / Periférico
-
-**Current Documentation Debt:**
-- Need to verify all CLI commands in `en/guides/cli-reference.md` against `clients/agent-runtime/` code.
-- Ensure all KMP modules listed in `en/guides/features.md` exist and match the code.
-- Sync any new architecture diagrams from `en/` to `es/`.
+### Duplicate ID Warning
+- Cause: Both `guides/architecture.md` and `guides/architecture/index.md` resolve to same Starlight ID
+- Impact: Low - warnings only, no build failures
+- Recommendation: Accept as-is or restructure (e.g., rename architecture.md to overview.md)
 
 ---
+
+## TODO
+- [x] Verify CLI reference against actual code implementation - DONE (gaps found)
+- [x] Do deep comparison of en/es content parity - DONE
+- [ ] Fix duplicate ID warnings (optional, low priority)
+- [ ] Consider CSS !important warnings (optional, may need Biome config)
+- [x] Update CLI docs with missing subcommands (high priority) - DONE (both en/es)

--- a/clients/web/apps/docs/src/content/docs/en/guides/cli-reference.md
+++ b/clients/web/apps/docs/src/content/docs/en/guides/cli-reference.md
@@ -130,6 +130,19 @@ corvus providers
 Manage provider authentication profiles.
 
 - `login --provider <NAME>`: Login with OAuth (e.g., `openai-codex`).
+  - `--profile <ID>`: Profile name (default: default).
+  - `--device-code`: Use OAuth device-code flow.
+- `paste-redirect --provider <NAME>`: Complete OAuth by pasting redirect URL or auth code.
+  - `--profile <ID>`: Profile name (default: default).
+  - `--input <URL>`: Full redirect URL or raw OAuth code.
+- `paste-token --provider <NAME>`: Paste setup token / auth token (for Anthropic subscription auth).
+  - `--profile <ID>`: Profile name (default: default).
+  - `--token <TOKEN>`: Token value (if omitted, read interactively).
+  - `--auth-kind <KIND>`: Auth kind override (`authorization` or `api-key`).
+- `setup-token --provider <NAME>`: Alias for `paste-token` (interactive by default).
+  - `--profile <ID>`: Profile name (default: default).
+- `refresh --provider <NAME>`: Refresh access token using refresh token.
+  - `--profile <ID>`: Profile name or profile id.
 - `list`: List auth profiles.
 - `status`: Show auth status and token expiry.
 - `use --provider <NAME> --profile <ID>`: Set active profile.
@@ -172,8 +185,14 @@ Manage signed runtime plugins.
 
 - `list`: List installed plugins.
 - `install <ID>`: Install a plugin (e.g., `memory.surreal.graphs`).
+  - `--version <VER>`: Optional explicit version to install.
+  - `--source <NAME>`: Optional source name filter.
+- `pin <ID>`: Pin an installed plugin to prevent unintended upgrades.
+  - `--version <VER>`: Optional specific version to pin.
 - `remove <ID>`: Remove a plugin.
 - `verify`: Verify plugin integrity.
+  - `--id <ID>`: Optional plugin ID filter.
+- `revocations sync`: Download and cache the latest plugin revocation list.
 
 **Example:**
 ```bash
@@ -199,6 +218,7 @@ Manage communication channels (Telegram, Discord, Slack).
 
 - `list`: List configured channels.
 - `start`: Start all configured channels.
+- `doctor`: Run health checks for configured channels.
 - `add <TYPE> <CONFIG_JSON>`: Add a new channel.
 - `remove <NAME>`: Remove a channel.
 - `bind-telegram <IDENTITY>`: Bind a Telegram user to the allowlist.

--- a/clients/web/apps/docs/src/content/docs/es/guides/cli-reference.md
+++ b/clients/web/apps/docs/src/content/docs/es/guides/cli-reference.md
@@ -130,6 +130,19 @@ corvus providers
 Gestiona los perfiles de autenticación de los proveedores.
 
 - `login --provider <NAME>`: Inicia sesión con OAuth (ej., `openai-codex`).
+  - `--profile <ID>`: Nombre del perfil (por defecto: default).
+  - `--device-code`: Usa el flujo OAuth device-code.
+- `paste-redirect --provider <NAME>`: Completa OAuth pegando la URL de redirección o código de auth.
+  - `--profile <ID>`: Nombre del perfil (por defecto: default).
+  - `--input <URL>`: URL de redirección completa o código OAuth sin procesar.
+- `paste-token --provider <NAME>`: Pegar token de configuración/auth (para auth de suscripción Anthropic).
+  - `--profile <ID>`: Nombre del perfil (por defecto: default).
+  - `--token <TOKEN>`: Valor del token (si se omite, lee interactivamente).
+  - `--auth-kind <KIND>`: Override de tipo de auth (`authorization` o `api-key`).
+- `setup-token --provider <NAME>`: Alias de `paste-token` (interactivo por defecto).
+  - `--profile <ID>`: Nombre del perfil (por defecto: default).
+- `refresh --provider <NAME>`: Actualiza el token de acceso usando el token de refresh.
+  - `--profile <ID>`: Nombre del perfil o ID del perfil.
 - `list`: Lista los perfiles de autenticación.
 - `status`: Muestra el estado de autenticación y el vencimiento de los tokens.
 - `use --provider <NAME> --profile <ID>`: Establece el perfil activo.
@@ -172,8 +185,14 @@ Gestiona los plugins del runtime firmados.
 
 - `list`: Lista los plugins instalados.
 - `install <ID>`: Instala un plugin (ej., `memory.surreal.graphs`).
+  - `--version <VER>`: Versión explícita opcional a instalar.
+  - `--source <NAME>`: Filtro opcional de nombre de source.
+- `pin <ID>`: Fija un plugin instalado para prevenir actualizaciones no deseadas.
+  - `--version <VER>`: Versión específica opcional a fijar.
 - `remove <ID>`: Elimina un plugin.
 - `verify`: Verifica la integridad del plugin.
+  - `--id <ID>`: Filtro opcional de ID de plugin.
+- `revocations sync`: Descarga y cachea la última lista de revocación de plugins.
 
 **Ejemplo:**
 ```bash
@@ -199,6 +218,7 @@ Gestiona los canales de comunicación (Telegram, Discord, Slack).
 
 - `list`: Lista los canales configurados.
 - `start`: Inicia todos los canales configurados.
+- `doctor`: Ejecuta verificaciones de salud para los canales configurados.
 - `add <TYPE> <CONFIG_JSON>`: Añade un nuevo canal.
 - `remove <NAME>`: Elimina un canal.
 - `bind-telegram <IDENTITY>`: Vincula un usuario de Telegram a la lista de permitidos.


### PR DESCRIPTION
- Add auth paste-redirect, paste-token, setup-token, refresh subcommands
- Add plugins pin and revocations sync subcommands
- Add channel doctor subcommand
- Sync both English and Spanish documentation versions

Verified: docs build passes (32 pages)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded CLI reference guide with new authentication commands: paste-redirect, paste-token, setup-token, and refresh with additional options
  * Enhanced login command with --profile and --device-code support
  * Added new plugin management commands (pin, revocations sync) and install enhancements
  * Introduced health-check command (doctor) for channel management
  * Updated documentation in English and Spanish

<!-- end of auto-generated comment: release notes by coderabbit.ai -->