### PR TITLE
feat: add functions to collect and apply restart fields for various configurations

### DIFF
--- a/.agents/skills/android-expert/scripts/analyze-apk-size.sh
+++ b/.agents/skills/android-expert/scripts/analyze-apk-size.sh
@@ -21,7 +21,7 @@ DEFAULT_APK="amethyst/build/outputs/apk/release/amethyst-release.apk"
 APK_PATH="${1:-$DEFAULT_APK}"
 
 # Check if APK exists
-if [ ! -f "$APK_PATH" ]; then
+if [[ ! -f "$APK_PATH" ]]; then
     echo -e "${RED}Error: APK not found at $APK_PATH${NC}"
     echo "Build the APK first: ./gradlew :amethyst:assembleRelease"
     exit 1
@@ -58,7 +58,7 @@ echo -e "${BLUE}  DEX Files (Code)${NC}"
 echo -e "${BLUE}═══════════════════════════════════════════════════════${NC}"
 DEX_TOTAL=0
 for dex in "$TEMP_DIR"/*.dex; do
-    if [ -f "$dex" ]; then
+    if [[ -f "$dex" ]]; then
         DEX_NAME=$(basename "$dex")
         DEX_SIZE=$(stat -f%z "$dex" 2>/dev/null || stat -c%s "$dex" 2>/dev/null)
         DEX_SIZE_MB=$(echo "scale=2; $DEX_SIZE / 1024 / 1024" | bc)
@@ -74,7 +74,7 @@ echo
 echo -e "${BLUE}═══════════════════════════════════════════════════════${NC}"
 echo -e "${BLUE}  Resources${NC}"
 echo -e "${BLUE}═══════════════════════════════════════════════════════${NC}"
-if [ -d "$TEMP_DIR/res" ]; then
+if [[ -d "$TEMP_DIR/res" ]]; then
     RES_SIZE=$(du -sh "$TEMP_DIR/res" | cut -f1)
     echo -e "  res/: ${GREEN}$RES_SIZE${NC}"
 
@@ -85,7 +85,7 @@ fi
 
 # Analyze assets
 echo
-if [ -d "$TEMP_DIR/assets" ]; then
+if [[ -d "$TEMP_DIR/assets" ]]; then
     ASSETS_SIZE=$(du -sh "$TEMP_DIR/assets" | cut -f1)
     echo -e "  assets/: ${GREEN}$ASSETS_SIZE${NC}"
 
@@ -99,13 +99,13 @@ echo
 echo -e "${BLUE}═══════════════════════════════════════════════════════${NC}"
 echo -e "${BLUE}  Native Libraries${NC}"
 echo -e "${BLUE}═══════════════════════════════════════════════════════${NC}"
-if [ -d "$TEMP_DIR/lib" ]; then
+if [[ -d "$TEMP_DIR/lib" ]]; then
     LIB_SIZE=$(du -sh "$TEMP_DIR/lib" | cut -f1)
     echo -e "  lib/: ${GREEN}$LIB_SIZE${NC}"
 
     # By architecture
     for arch in "$TEMP_DIR/lib"/*; do
-        if [ -d "$arch" ]; then
+        if [[ -d "$arch" ]]; then
             ARCH_NAME=$(basename "$arch")
             ARCH_SIZE=$(du -sh "$arch" | cut -f1)
             echo -e "    $ARCH_NAME: ${GREEN}$ARCH_SIZE${NC}"
@@ -123,7 +123,7 @@ echo
 echo -e "${BLUE}═══════════════════════════════════════════════════════${NC}"
 echo -e "${BLUE}  Kotlin Metadata${NC}"
 echo -e "${BLUE}═══════════════════════════════════════════════════════${NC}"
-if [ -d "$TEMP_DIR/kotlin" ]; then
+if [[ -d "$TEMP_DIR/kotlin" ]]; then
     KOTLIN_SIZE=$(du -sh "$TEMP_DIR/kotlin" | cut -f1)
     echo -e "  kotlin/: ${GREEN}$KOTLIN_SIZE${NC}"
 fi
@@ -137,10 +137,10 @@ echo -e "${BLUE}═════════════════════�
 # Try to find dexdump
 DEXDUMP=$(which dexdump 2>/dev/null || find "$ANDROID_HOME/build-tools" -name dexdump 2>/dev/null | head -1 || echo "")
 
-if [ -n "$DEXDUMP" ] && [ -x "$DEXDUMP" ]; then
+if [[ -n "$DEXDUMP" && -x "$DEXDUMP" ]]; then
     TOTAL_METHODS=0
     for dex in "$TEMP_DIR"/*.dex; do
-        if [ -f "$dex" ]; then
+        if [[ -f "$dex" ]]; then
             DEX_NAME=$(basename "$dex")
             METHOD_COUNT=$("$DEXDUMP" -l xml "$dex" | grep -c "<method " || echo "0")
             echo -e "  $DEX_NAME: ${GREEN}$METHOD_COUNT methods${NC}"
@@ -150,7 +150,7 @@ if [ -n "$DEXDUMP" ] && [ -x "$DEXDUMP" ]; then
     echo -e "${YELLOW}Total methods: $TOTAL_METHODS${NC}"
 
     # Check multidex threshold
-    if [ $TOTAL_METHODS -gt 65536 ]; then
+    if [[ $TOTAL_METHODS -gt 65536 ]]; then
         echo -e "${RED}  ⚠ Exceeded 64K method limit (multidex required)${NC}"
     else
         REMAINING=$((65536 - TOTAL_METHODS))
@@ -192,7 +192,7 @@ echo -e "${BLUE}  Optimization Recommendations${NC}"
 echo -e "${BLUE}═══════════════════════════════════════════════════════${NC}"
 
 # Check if resources are large
-if [ $(echo "$RES_PCT > 30" | bc 2>/dev/null || echo "0") -eq 1 ]; then
+if [[ $(echo "$RES_PCT > 30" | bc 2>/dev/null || echo "0") -eq 1 ]]; then
     echo -e "${YELLOW}  • Resources are ${RES_PCT}% of APK - consider:${NC}"
     echo "    - Enable resource shrinking (shrinkResources = true)"
     echo "    - Use WebP for images instead of PNG/JPG"
@@ -200,14 +200,14 @@ if [ $(echo "$RES_PCT > 30" | bc 2>/dev/null || echo "0") -eq 1 ]; then
 fi
 
 # Check if native libs are large
-if [ $(echo "$LIB_PCT > 40" | bc 2>/dev/null || echo "0") -eq 1 ]; then
+if [[ $(echo "$LIB_PCT > 40" | bc 2>/dev/null || echo "0") -eq 1 ]]; then
     echo -e "${YELLOW}  • Native libraries are ${LIB_PCT}% of APK - consider:${NC}"
     echo "    - Use App Bundle to serve ABI-specific APKs"
     echo "    - Remove unused ABIs"
 fi
 
 # Check if code is large
-if [ $(echo "$CODE_PCT > 40" | bc 2>/dev/null || echo "0") -eq 1 ]; then
+if [[ $(echo "$CODE_PCT > 40" | bc 2>/dev/null || echo "0") -eq 1 ]]; then
     echo -e "${YELLOW}  • Code is ${CODE_PCT}% of APK - consider:${NC}"
     echo "    - Enable Proguard/R8 (minifyEnabled = true)"
     echo "    - Review dependencies for bloat"

--- a/.agents/skills/web-quality-audit/scripts/analyze.sh
+++ b/.agents/skills/web-quality-audit/scripts/analyze.sh
@@ -7,11 +7,12 @@ set -e
 usage() {
   echo "Usage: $0 <file_or_directory>" >&2
   echo "Analyzes HTML files for web quality issues." >&2
-  exit 1
+  return 1
 }
 
 if [[ -z "$1" ]]; then
   usage
+  exit 1
 fi
 
 TARGET="$1"

--- a/.github/workflows/sonarqube-analysis.yml
+++ b/.github/workflows/sonarqube-analysis.yml
@@ -71,13 +71,13 @@ jobs:
 
       - name: 🦀 Setup Rust
         if: env.SONAR_TOKEN != ''
-        uses: dtolnay/rust-toolchain@HEAD
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # HEAD as of 2026-03-04
         with:
           toolchain: 1.92
 
       - name: 📦 Install cargo-llvm-cov
         if: env.SONAR_TOKEN != ''
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@2834d6555cea49e0759c35c2a877ea0228e73e06 # cargo-llvm-cov
 
       - name: 📁 Create coverage directory
         if: env.SONAR_TOKEN != ''

--- a/clients/agent-runtime/src/gateway/admin.rs
+++ b/clients/agent-runtime/src/gateway/admin.rs
@@ -534,6 +534,22 @@ pub fn restart_required_updates(
 ) -> Vec<&'static str> {
     let mut fields = Vec::new();
 
+    collect_core_restart_fields(cfg, patch, &mut fields);
+    collect_runtime_identity_restart_fields(cfg, patch, &mut fields);
+    collect_scheduler_gateway_restart_fields(cfg, patch, &mut fields);
+    collect_webhook_restart_fields(cfg, patch, &mut fields);
+    collect_secret_restart_fields(cfg, patch, &mut fields);
+
+    fields.sort_unstable();
+    fields.dedup();
+    fields
+}
+
+fn collect_core_restart_fields(
+    cfg: &Config,
+    patch: &AdminConfigUpdateRequest,
+    fields: &mut Vec<&'static str>,
+) {
     if let Some(provider) = patch.default_provider.as_ref() {
         let next = normalize_optional_string(provider);
         if next.as_deref() != cfg.default_provider.as_deref() {
@@ -562,13 +578,13 @@ pub fn restart_required_updates(
             fields.push("memory_backend");
         }
     }
-    if let Some(provider) = patch.provider.as_ref() {
-        if let Some(api_key) = provider.api_key.as_ref() {
-            if secret_update_changes(cfg.api_key.as_deref(), api_key) {
-                fields.push("provider.api_key");
-            }
-        }
-    }
+}
+
+fn collect_runtime_identity_restart_fields(
+    cfg: &Config,
+    patch: &AdminConfigUpdateRequest,
+    fields: &mut Vec<&'static str>,
+) {
     if let Some(runtime) = patch.runtime.as_ref() {
         if let Some(kind) = runtime.kind.as_ref() {
             if kind.trim().to_ascii_lowercase() != cfg.runtime.kind {
@@ -576,6 +592,7 @@ pub fn restart_required_updates(
             }
         }
     }
+
     if let Some(identity) = patch.identity.as_ref() {
         if let Some(format) = identity.format.as_ref() {
             if format.trim().to_ascii_lowercase() != cfg.identity.format {
@@ -589,6 +606,13 @@ pub fn restart_required_updates(
             }
         }
     }
+}
+
+fn collect_scheduler_gateway_restart_fields(
+    cfg: &Config,
+    patch: &AdminConfigUpdateRequest,
+    fields: &mut Vec<&'static str>,
+) {
     if let Some(scheduler) = patch.scheduler.as_ref() {
         if let Some(enabled) = scheduler.enabled {
             if enabled != cfg.scheduler.enabled {
@@ -606,6 +630,7 @@ pub fn restart_required_updates(
             }
         }
     }
+
     if let Some(gateway) = patch.gateway.as_ref() {
         if let Some(port) = gateway.port {
             if port != cfg.gateway.port {
@@ -638,6 +663,13 @@ pub fn restart_required_updates(
             }
         }
     }
+}
+
+fn collect_webhook_restart_fields(
+    cfg: &Config,
+    patch: &AdminConfigUpdateRequest,
+    fields: &mut Vec<&'static str>,
+) {
     let channel_webhook = patch
         .channels
         .as_ref()
@@ -671,6 +703,20 @@ pub fn restart_required_updates(
             }
         }
     }
+}
+
+fn collect_secret_restart_fields(
+    cfg: &Config,
+    patch: &AdminConfigUpdateRequest,
+    fields: &mut Vec<&'static str>,
+) {
+    if let Some(provider) = patch.provider.as_ref() {
+        if let Some(api_key) = provider.api_key.as_ref() {
+            if secret_update_changes(cfg.api_key.as_deref(), api_key) {
+                fields.push("provider.api_key");
+            }
+        }
+    }
 
     if let Some(composio) = patch.composio.as_ref() {
         if let Some(api_key) = composio.api_key.as_ref() {
@@ -679,6 +725,7 @@ pub fn restart_required_updates(
             }
         }
     }
+
     if let Some(web_search) = patch.web_search.as_ref() {
         if let Some(api_key) = web_search.brave_api_key.as_ref() {
             if secret_update_changes(cfg.web_search.brave_api_key.as_deref(), api_key) {
@@ -686,6 +733,7 @@ pub fn restart_required_updates(
             }
         }
     }
+
     if let Some(browser) = patch.browser.as_ref() {
         if let Some(api_key) = browser.computer_use_api_key.as_ref() {
             if secret_update_changes(cfg.browser.computer_use.api_key.as_deref(), api_key) {
@@ -693,6 +741,7 @@ pub fn restart_required_updates(
             }
         }
     }
+
     if let Some(memory) = patch.memory.as_ref() {
         if let Some(surreal) = memory.surreal.as_ref() {
             if let Some(username) = surreal.username.as_ref() {
@@ -712,13 +761,23 @@ pub fn restart_required_updates(
             }
         }
     }
-
-    fields.sort_unstable();
-    fields.dedup();
-    fields
 }
 
 fn apply_patch(cfg: &mut Config, patch: &AdminConfigUpdateRequest) -> Result<(), AdminResponse> {
+    apply_core_patch(cfg, patch)?;
+    apply_runtime_identity_patch(cfg, patch)?;
+    apply_scheduler_gateway_patch(cfg, patch)?;
+    apply_channels_patch(cfg, patch)?;
+    apply_integrations_patch(cfg, patch)?;
+    apply_memory_patch(cfg, patch)?;
+
+    Ok(())
+}
+
+fn apply_core_patch(
+    cfg: &mut Config,
+    patch: &AdminConfigUpdateRequest,
+) -> Result<(), AdminResponse> {
     if let Some(provider) = patch.default_provider.as_ref() {
         cfg.default_provider = normalize_optional_string(provider);
     }
@@ -763,6 +822,13 @@ fn apply_patch(cfg: &mut Config, patch: &AdminConfigUpdateRequest) -> Result<(),
             cfg.observability.otel_service_name = normalize_optional_string(service_name);
         }
     }
+    Ok(())
+}
+
+fn apply_runtime_identity_patch(
+    cfg: &mut Config,
+    patch: &AdminConfigUpdateRequest,
+) -> Result<(), AdminResponse> {
     if let Some(runtime) = patch.runtime.as_ref() {
         if let Some(kind) = runtime.kind.as_ref() {
             let kind = kind.trim().to_ascii_lowercase();
@@ -772,6 +838,7 @@ fn apply_patch(cfg: &mut Config, patch: &AdminConfigUpdateRequest) -> Result<(),
             cfg.runtime.kind = kind;
         }
     }
+
     if let Some(autonomy) = patch.autonomy.as_ref() {
         if let Some(level) = autonomy.level {
             cfg.autonomy.level = level;
@@ -798,6 +865,7 @@ fn apply_patch(cfg: &mut Config, patch: &AdminConfigUpdateRequest) -> Result<(),
             cfg.autonomy.always_ask = always_ask.clone();
         }
     }
+
     if let Some(identity) = patch.identity.as_ref() {
         if let Some(format) = identity.format.as_ref() {
             let format = format.trim().to_ascii_lowercase();
@@ -812,6 +880,14 @@ fn apply_patch(cfg: &mut Config, patch: &AdminConfigUpdateRequest) -> Result<(),
             cfg.identity.aieos_path = normalize_optional_string(aieos_path);
         }
     }
+
+    Ok(())
+}
+
+fn apply_scheduler_gateway_patch(
+    cfg: &mut Config,
+    patch: &AdminConfigUpdateRequest,
+) -> Result<(), AdminResponse> {
     if let Some(scheduler) = patch.scheduler.as_ref() {
         if let Some(enabled) = scheduler.enabled {
             cfg.scheduler.enabled = enabled;
@@ -829,6 +905,7 @@ fn apply_patch(cfg: &mut Config, patch: &AdminConfigUpdateRequest) -> Result<(),
             cfg.scheduler.max_concurrent = max_concurrent;
         }
     }
+
     if let Some(gateway) = patch.gateway.as_ref() {
         if let Some(port) = gateway.port {
             if port == 0 {
@@ -888,6 +965,13 @@ fn apply_patch(cfg: &mut Config, patch: &AdminConfigUpdateRequest) -> Result<(),
         }
     }
 
+    Ok(())
+}
+
+fn apply_channels_patch(
+    cfg: &mut Config,
+    patch: &AdminConfigUpdateRequest,
+) -> Result<(), AdminResponse> {
     if let Some(channels) = patch.channels.as_ref() {
         if let Some(cli) = channels.cli {
             cfg.channels_config.cli = cli;
@@ -899,7 +983,13 @@ fn apply_patch(cfg: &mut Config, patch: &AdminConfigUpdateRequest) -> Result<(),
     if let Some(webhook) = patch.webhook.as_ref() {
         apply_webhook_patch(cfg, webhook)?;
     }
+    Ok(())
+}
 
+fn apply_integrations_patch(
+    cfg: &mut Config,
+    patch: &AdminConfigUpdateRequest,
+) -> Result<(), AdminResponse> {
     if let Some(composio) = patch.composio.as_ref() {
         if let Some(enabled) = composio.enabled {
             cfg.composio.enabled = enabled;
@@ -915,6 +1005,7 @@ fn apply_patch(cfg: &mut Config, patch: &AdminConfigUpdateRequest) -> Result<(),
             apply_secret_update(&mut cfg.composio.api_key, api_key, "composio.api_key")?;
         }
     }
+
     if let Some(web_search) = patch.web_search.as_ref() {
         if let Some(enabled) = web_search.enabled {
             cfg.web_search.enabled = enabled;
@@ -950,6 +1041,7 @@ fn apply_patch(cfg: &mut Config, patch: &AdminConfigUpdateRequest) -> Result<(),
             )?;
         }
     }
+
     if let Some(browser) = patch.browser.as_ref() {
         if let Some(computer_use_api_key) = browser.computer_use_api_key.as_ref() {
             apply_secret_update(
@@ -959,6 +1051,14 @@ fn apply_patch(cfg: &mut Config, patch: &AdminConfigUpdateRequest) -> Result<(),
             )?;
         }
     }
+
+    Ok(())
+}
+
+fn apply_memory_patch(
+    cfg: &mut Config,
+    patch: &AdminConfigUpdateRequest,
+) -> Result<(), AdminResponse> {
     if let Some(memory) = patch.memory.as_ref() {
         if let Some(backend) = memory.backend.as_ref() {
             let backend = backend.trim().to_ascii_lowercase();

--- a/clients/agent-runtime/src/gateway/mod.rs
+++ b/clients/agent-runtime/src/gateway/mod.rs
@@ -2586,7 +2586,12 @@ mod tests {
             .into_response();
         assert_eq!(pair_response.status(), StatusCode::OK);
 
-        let pair_body = pair_response.into_body().collect().await.unwrap().to_bytes();
+        let pair_body = pair_response
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
         let pair_json: serde_json::Value = serde_json::from_slice(&pair_body).unwrap();
         let issued_token = pair_json["token"]
             .as_str()


### PR DESCRIPTION
This pull request refactors and modularizes the logic for determining and applying configuration changes that require a restart in the `agent-runtime` gateway admin code. The main improvements are the extraction of logic into themed helper functions, which enhances maintainability and readability. Additionally, there are minor consistency updates to shell scripts and workflow files.

**Refactoring and modularization of configuration update logic:**

* The `restart_required_updates` function in `clients/agent-runtime/src/gateway/admin.rs` is refactored to delegate to new helper functions, each responsible for a specific configuration theme (core, runtime/identity, scheduler/gateway, webhook, secrets). This makes the code more organized and easier to extend. [[1]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR537-R552) [[2]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bL565-R595) [[3]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR609-R615) [[4]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR633) [[5]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR666-R672) [[6]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR706-R719) [[7]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR728-R744) [[8]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bL715-R780)
* The `apply_patch` function is similarly split into themed helper functions for applying patches to each configuration area, improving clarity and separation of concerns. [[1]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bL715-R780) [[2]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR825-R831) [[3]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR841) [[4]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR868) [[5]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR883-R890) [[6]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR908) [[7]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR968-R974) [[8]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR986-R992) [[9]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR1008) [[10]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR1044) [[11]](diffhunk://#diff-ce8d62aaa2dc6150d6e8868981d4518d531c7672112920e7bf1c3fea3f20183bR1054-R1061)

**Shell script consistency improvements:**

* All `if [ ... ]` conditional checks in `.agents/skills/android-expert/scripts/analyze-apk-size.sh` are updated to use the more modern and consistent `[[ ... ]]` syntax. This improves script robustness and readability. [[1]](diffhunk://#diff-62668887858d66c5ae185c81bc35807c543cb87abbad454419f1f11071ba49a8L24-R24) [[2]](diffhunk://#diff-62668887858d66c5ae185c81bc35807c543cb87abbad454419f1f11071ba49a8L61-R61) [[3]](diffhunk://#diff-62668887858d66c5ae185c81bc35807c543cb87abbad454419f1f11071ba49a8L77-R77) [[4]](diffhunk://#diff-62668887858d66c5ae185c81bc35807c543cb87abbad454419f1f11071ba49a8L88-R88) [[5]](diffhunk://#diff-62668887858d66c5ae185c81bc35807c543cb87abbad454419f1f11071ba49a8L102-R108) [[6]](diffhunk://#diff-62668887858d66c5ae185c81bc35807c543cb87abbad454419f1f11071ba49a8L126-R126) [[7]](diffhunk://#diff-62668887858d66c5ae185c81bc35807c543cb87abbad454419f1f11071ba49a8L140-R143) [[8]](diffhunk://#diff-62668887858d66c5ae185c81bc35807c543cb87abbad454419f1f11071ba49a8L153-R153) [[9]](diffhunk://#diff-62668887858d66c5ae185c81bc35807c543cb87abbad454419f1f11071ba49a8L195-R210)

* In `.agents/skills/web-quality-audit/scripts/analyze.sh`, the `usage` function now returns instead of exiting, and an explicit `exit 1` is added after its call, improving script flow and error handling.

**Workflow pinning for reproducibility:**

* The GitHub Actions workflow `.github/workflows/sonarqube-analysis.yml` now pins the Rust toolchain and `cargo-llvm-cov` install actions to specific commit SHAs, ensuring reproducible builds and improved security.