### PR TITLE
fix(docs): update architecture diagram links and overview references

### DIFF
--- a/clients/web/apps/docs/src/content/docs/en/guides/architecture.md
+++ b/clients/web/apps/docs/src/content/docs/en/guides/architecture.md
@@ -117,9 +117,9 @@ For a more detailed view of the architecture, see the following C4 diagrams:
 
 | Level           | Diagram                                                                    | Description                                       | Diagram ID                        |
 |-----------------|----------------------------------------------------------------------------|---------------------------------------------------|-----------------------------------|
-| C1 - Context    | [System Context](./architecture/diagrams/context/system-context.mmd)       | High-level view of the runtime and external actors | `context/system-context.mmd`     |
-| C2 - Containers | [Runtime Containers](./architecture/diagrams/container/runtime-containers.mmd) | Runtime services and operator surfaces         | `container/runtime-containers.mmd` |
-| C3 - Components | [Runtime Core](./architecture/diagrams/component/runtime-core.mmd)         | Internal components of the runtime core           | `component/runtime-core.mmd`      |
-| -               | [Cargo Dependencies](./architecture/diagrams/cargo-dependencies.mmd)       | Cargo workspace and runtime dependency flow       | `cargo-dependencies.mmd`          |
+| C1 - Context    | [System Context](./diagrams/context/system-context.mmd)       | High-level view of the runtime and external actors | `context/system-context.mmd`     |
+| C2 - Containers | [Runtime Containers](./diagrams/container/runtime-containers.mmd) | Runtime services and operator surfaces         | `container/runtime-containers.mmd` |
+| C3 - Components | [Runtime Core](./diagrams/component/runtime-core.mmd)         | Internal components of the runtime core           | `component/runtime-core.mmd`      |
+| -               | [Cargo Dependencies](./diagrams/cargo-dependencies.mmd)       | Cargo workspace and runtime dependency flow       | `cargo-dependencies.mmd`          |
 
-See [Architecture Index](./architecture/overview.md) for more details on how to visualize them.
+See [Architecture Index](./overview) for more details on how to visualize them.

--- a/clients/web/apps/docs/src/content/docs/es/guides/architecture.md
+++ b/clients/web/apps/docs/src/content/docs/es/guides/architecture.md
@@ -118,10 +118,10 @@ Para una vista más detallada de la arquitectura, consulta los siguientes diagra
 
 | Nivel             | Diagrama                                                                            | Descripción                                        | ID del Diagrama                   |
 |-------------------|-------------------------------------------------------------------------------------|----------------------------------------------------|-----------------------------------|
-| C1 - Contexto     | [Sistema Completo](./architecture/diagrams/context/system-context.mmd)                 | Vista de alto nivel del runtime y actores externos | `context/system-context.mmd`      |
-| C2 - Contenedores | [Contenedores del Runtime](./architecture/diagrams/container/runtime-containers.mmd) | Servicios del runtime y superficies operativas     | `container/runtime-containers.mmd` |
-| C3 - Componentes  | [Núcleo del Runtime](./architecture/diagrams/component/runtime-core.mmd)             | Componentes internos del núcleo del runtime        | `component/runtime-core.mmd`      |
-| -                 | [Dependencias de Cargo](./architecture/diagrams/cargo-dependencies.mmd)              | Flujo de dependencias del workspace Rust/Cargo     | `cargo-dependencies.mmd`          |
+| C1 - Contexto     | [Sistema Completo](./diagrams/context/system-context.mmd)                 | Vista de alto nivel del runtime y actores externos | `context/system-context.mmd`      |
+| C2 - Contenedores | [Contenedores del Runtime](./diagrams/container/runtime-containers.mmd) | Servicios del runtime y superficies operativas     | `container/runtime-containers.mmd` |
+| C3 - Componentes  | [Núcleo del Runtime](./diagrams/component/runtime-core.mmd)             | Componentes internos del núcleo del runtime        | `component/runtime-core.mmd`      |
+| -                 | [Dependencias de Cargo](./diagrams/cargo-dependencies.mmd)              | Flujo de dependencias del workspace Rust/Cargo     | `cargo-dependencies.mmd`          |
 
-Ver [Visión General de la Arquitectura](./architecture/overview.md) para más detalles sobre cómo
+Ver [Visión General de la Arquitectura](./overview) para más detalles sobre cómo
 visualizarlos.


### PR DESCRIPTION
This pull request updates the architecture documentation in both English and Spanish to fix and simplify the links to diagram files and overview pages. The main goal is to ensure that all diagram and overview references point to the correct locations, improving navigation and consistency across the documentation.

**Documentation link updates:**

* Updated all architecture diagram links in both `architecture.md` files to remove the `architecture/diagrams/` prefix, so they now point to the correct relative `./diagrams/` directory. [[1]](diffhunk://#diff-50c98b5c5be145000e2fa180a5a12afeae4d36968e7d7c70d6ce3d5ac3eeee0bL120-R125) [[2]](diffhunk://#diff-43111c544c791c4031dcece613947186c207d71888873d828e3015aea9d10cb9L121-R126)
* Changed the "Architecture Index"/"Visión General de la Arquitectura" overview links to point to `./overview` instead of `./architecture/overview.md` for consistency and to avoid broken links. [[1]](diffhunk://#diff-50c98b5c5be145000e2fa180a5a12afeae4d36968e7d7c70d6ce3d5ac3eeee0bL120-R125) [[2]](diffhunk://#diff-43111c544c791c4031dcece613947186c207d71888873d828e3015aea9d10cb9L121-R126)