### PR TITLE
test: add unit tests for config payload and webhook handling

### DIFF
--- a/clients/agent-runtime/src/hardware/introspect.rs
+++ b/clients/agent-runtime/src/hardware/introspect.rs
@@ -122,3 +122,33 @@ fn probe_memory_map(chip: &str) -> anyhow::Result<String> {
     }
     Ok(out)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "hardware")]
+    #[test]
+    fn memory_map_for_board_uses_static_probe_guidance_without_probe_feature() {
+        let note = memory_map_for_board(Some("nucleo-f401re"));
+        assert!(note.contains("Build with --features probe"));
+
+        let unknown = memory_map_for_board(Some("custom-board"));
+        assert!(unknown.contains("Build with --features probe"));
+    }
+
+    #[test]
+    fn introspect_result_keeps_supplied_path() {
+        let result = IntrospectResult {
+            path: "/dev/ttyACM0".to_string(),
+            vid: Some(0x0483),
+            pid: Some(0x5740),
+            board_name: Some("nucleo-f401re".to_string()),
+            architecture: Some("arm".to_string()),
+            memory_map_note: "note".to_string(),
+        };
+
+        assert_eq!(result.path, "/dev/ttyACM0");
+        assert_eq!(result.board_name.as_deref(), Some("nucleo-f401re"));
+    }
+}

--- a/clients/agent-runtime/src/peripherals/mod.rs
+++ b/clients/agent-runtime/src/peripherals/mod.rs
@@ -322,3 +322,89 @@ async fn connect_serial_board(
 pub async fn create_peripheral_tools(_config: &PeripheralsConfig) -> Result<Vec<Box<dyn Tool>>> {
     Ok(Vec::new())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn board(board: &str, transport: &str, path: Option<&str>) -> PeripheralBoardConfig {
+        PeripheralBoardConfig {
+            board: board.to_string(),
+            transport: transport.to_string(),
+            path: path.map(str::to_string),
+            baud: 115_200,
+        }
+    }
+
+    #[test]
+    fn list_configured_boards_returns_empty_when_disabled() {
+        let config = PeripheralsConfig {
+            enabled: false,
+            boards: vec![board("nucleo-f401re", "serial", Some("/dev/ttyACM0"))],
+            datasheet_dir: None,
+        };
+
+        assert!(list_configured_boards(&config).is_empty());
+    }
+
+    #[test]
+    fn list_configured_boards_returns_all_boards_when_enabled() {
+        let config = PeripheralsConfig {
+            enabled: true,
+            boards: vec![
+                board("nucleo-f401re", "serial", Some("/dev/ttyACM0")),
+                board("arduino-uno-q", "bridge", None),
+            ],
+            datasheet_dir: None,
+        };
+
+        let boards = list_configured_boards(&config);
+        assert_eq!(boards.len(), 2);
+        assert_eq!(boards[0].board, "nucleo-f401re");
+        assert_eq!(boards[1].transport, "bridge");
+    }
+
+    #[test]
+    fn validate_board_config_rejects_invalid_entries() {
+        assert_eq!(
+            validate_board_config(&board("", "serial", Some("/dev/ttyACM0"))).unwrap_err(),
+            "board name is empty"
+        );
+        assert_eq!(
+            validate_board_config(&board("uno", "serial", Some("   "))).unwrap_err(),
+            "serial transport requires a path"
+        );
+        assert_eq!(
+            validate_board_config(&board("uno", "bluetooth", None)).unwrap_err(),
+            "unsupported transport 'bluetooth' (use: serial, native, bridge)"
+        );
+    }
+
+    #[test]
+    fn validate_board_config_accepts_supported_transports() {
+        assert!(validate_board_config(&board("uno", "native", None)).is_ok());
+        assert!(validate_board_config(&board("uno", "bridge", None)).is_ok());
+        assert!(validate_board_config(&board("uno", "serial", Some("/dev/ttyUSB0"))).is_ok());
+    }
+
+    #[cfg(feature = "hardware")]
+    #[test]
+    fn try_add_uno_q_bridge_tools_only_for_bridge_transport() {
+        let mut tools: Vec<Box<dyn Tool>> = Vec::new();
+
+        assert!(try_add_uno_q_bridge_tools(
+            &board("arduino-uno-q", "bridge", None),
+            &mut tools,
+        ));
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].name(), "gpio_read");
+        assert_eq!(tools[1].name(), "gpio_write");
+
+        let mut tools: Vec<Box<dyn Tool>> = Vec::new();
+        assert!(!try_add_uno_q_bridge_tools(
+            &board("arduino-uno-q", "serial", Some("/dev/ttyACM0")),
+            &mut tools,
+        ));
+        assert!(tools.is_empty());
+    }
+}

--- a/clients/agent-runtime/src/peripherals/uno_q_bridge.rs
+++ b/clients/agent-runtime/src/peripherals/uno_q_bridge.rs
@@ -155,3 +155,49 @@ impl Tool for UnoQGpioWriteTool {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::traits::Tool;
+
+    #[test]
+    fn read_tool_exposes_expected_schema() {
+        let tool = UnoQGpioReadTool;
+
+        assert_eq!(tool.name(), "gpio_read");
+        assert!(tool.description().contains("Arduino Uno Q"));
+        assert_eq!(tool.parameters_schema()["required"], json!(["pin"]));
+    }
+
+    #[tokio::test]
+    async fn read_tool_requires_pin_parameter() {
+        let tool = UnoQGpioReadTool;
+        let error = tool.execute(json!({})).await.unwrap_err();
+
+        assert_eq!(error.to_string(), "Missing 'pin' parameter");
+    }
+
+    #[test]
+    fn write_tool_exposes_expected_schema() {
+        let tool = UnoQGpioWriteTool;
+
+        assert_eq!(tool.name(), "gpio_write");
+        assert!(tool.description().contains("Set GPIO pin"));
+        assert_eq!(
+            tool.parameters_schema()["required"],
+            json!(["pin", "value"])
+        );
+    }
+
+    #[tokio::test]
+    async fn write_tool_requires_both_parameters() {
+        let tool = UnoQGpioWriteTool;
+
+        let missing_pin = tool.execute(json!({ "value": 1 })).await.unwrap_err();
+        assert_eq!(missing_pin.to_string(), "Missing 'pin' parameter");
+
+        let missing_value = tool.execute(json!({ "pin": 13 })).await.unwrap_err();
+        assert_eq!(missing_value.to_string(), "Missing 'value' parameter");
+    }
+}

--- a/clients/agent-runtime/src/peripherals/uno_q_setup.rs
+++ b/clients/agent-runtime/src/peripherals/uno_q_setup.rs
@@ -141,3 +141,46 @@ fn copy_dir(src: &std::path::Path, dst: &std::path::Path) -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_embedded_bridge_creates_expected_layout() {
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        write_embedded_bridge(temp_dir.path()).unwrap();
+
+        assert!(temp_dir.path().join("app.yaml").exists());
+        assert!(temp_dir.path().join("sketch").join("sketch.ino").exists());
+        assert!(temp_dir.path().join("sketch").join("sketch.yaml").exists());
+        assert!(temp_dir.path().join("python").join("main.py").exists());
+        assert!(temp_dir
+            .path()
+            .join("python")
+            .join("requirements.txt")
+            .exists());
+    }
+
+    #[test]
+    fn copy_dir_recursively_copies_files() {
+        let src = tempfile::tempdir().unwrap();
+        let dst = tempfile::tempdir().unwrap();
+
+        std::fs::create_dir_all(src.path().join("nested")).unwrap();
+        std::fs::write(src.path().join("app.yaml"), "name: bridge\n").unwrap();
+        std::fs::write(src.path().join("nested").join("main.py"), "print('ok')\n").unwrap();
+
+        copy_dir(src.path(), dst.path()).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(dst.path().join("app.yaml")).unwrap(),
+            "name: bridge\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dst.path().join("nested").join("main.py")).unwrap(),
+            "print('ok')\n"
+        );
+    }
+}

--- a/clients/web/apps/chat/src/App.spec.ts
+++ b/clients/web/apps/chat/src/App.spec.ts
@@ -151,4 +151,76 @@ describe("App", () => {
       "Bearer zc_test_token"
     );
   });
+
+  it("bloquea guardar secretos cuando el gateway no es seguro", async () => {
+    const wrapper = mountApp();
+
+    await wrapper.get('[data-testid="toggle-config"]').trigger("click");
+    await wrapper
+      .get(`input[placeholder="${translatedPlaceholder("form.baseUrlPlaceholder")}"]`)
+      .setValue("http://example.com");
+    await wrapper
+      .get(`input[placeholder="${translatedPlaceholder("form.pairingCodePlaceholder")}"]`)
+      .setValue("123456");
+    await wrapper.get("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain(translatedPlaceholder("errors.insecureUrlError"));
+  });
+
+  it("incluye webhook secret al enviar mensajes despues de guardar configuracion local", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ response: "ok" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const wrapper = mountApp();
+
+    await wrapper.get('[data-testid="toggle-config"]').trigger("click");
+    await wrapper
+      .get(`input[placeholder="${translatedPlaceholder("form.baseUrlPlaceholder")}"]`)
+      .setValue("https://example.com");
+    await wrapper
+      .get(`input[placeholder="${translatedPlaceholder("form.webhookSecretPlaceholder")}"]`)
+      .setValue("shared-secret");
+    await wrapper.get("form").trigger("submit.prevent");
+    await flushPromises();
+
+    await wrapper.get('[data-testid="toggle-config"]').trigger("click");
+    const input = wrapper.get(
+      `input[placeholder="${translatedPlaceholder("chat.inputPlaceholder")}"]`
+    );
+    await input.setValue("hola webhook");
+    await wrapper.get("form").trigger("submit.prevent");
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [webhookUrl, webhookInit] = fetchMock.mock.calls[0] ?? [];
+    expect(String(webhookUrl)).toBe("https://example.com/webhook");
+    expect((webhookInit?.headers as Record<string, string>)["X-Webhook-Secret"]).toBe(
+      "shared-secret"
+    );
+  });
+
+  it("muestra error de timeout cuando el webhook expira", async () => {
+    const abortError = new Error("timeout");
+    abortError.name = "AbortError";
+    fetchMock.mockRejectedValueOnce(abortError);
+
+    const wrapper = mountApp();
+    const input = wrapper.get(
+      `input[placeholder="${translatedPlaceholder("chat.inputPlaceholder")}"]`
+    );
+    await input.setValue("hola timeout");
+    await wrapper.get("form").trigger("submit.prevent");
+    await flushPromises();
+
+    const chatMessages = wrapper.findAll('[data-testid="chat-message"]');
+    expect(chatMessages[chatMessages.length - 1]?.text()).toContain(
+      translatedPlaceholder("chat.timeoutError")
+    );
+  });
 });

--- a/clients/web/apps/dashboard/src/composables/configPayload.spec.ts
+++ b/clients/web/apps/dashboard/src/composables/configPayload.spec.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPayloadForSection } from "@/composables/configPayload";
+import type { AdminConfigForm, AdminConfigSnapshot } from "@/types/admin-config";
+
+function createSnapshot(): AdminConfigSnapshot {
+  return {
+    default_provider: "openai",
+    default_model: "gpt-4.1",
+    api_url: "http://localhost:3000/api",
+    default_temperature: 0.7,
+    memory_backend: "sqlite",
+    observability_backend: "none",
+    otel_endpoint: "",
+    otel_service_name: "",
+    runtime_kind: "native",
+    autonomy_level: "supervised",
+    autonomy_workspace_only: true,
+    autonomy_max_actions_per_hour: 20,
+    autonomy_max_cost_per_day_cents: 500,
+    identity_format: "openclaw",
+    identity_aieos_path: "",
+    scheduler_enabled: true,
+    scheduler_max_tasks: 64,
+    scheduler_max_concurrent: 4,
+    gateway_port: 3000,
+    gateway_host: "127.0.0.1",
+    gateway_require_pairing: true,
+    gateway_allow_public_bind: false,
+    gateway_pair_rate_limit_per_minute: 10,
+    gateway_webhook_rate_limit_per_minute: 60,
+    webhook_enabled: false,
+    webhook_port: 3001,
+    webhook_secret_exists: false,
+  };
+}
+
+function createForm(overrides: Partial<AdminConfigForm> = {}): AdminConfigForm {
+  const snapshot = createSnapshot();
+  return {
+    default_provider: snapshot.default_provider,
+    default_model: snapshot.default_model,
+    api_url: snapshot.api_url,
+    default_temperature: `${snapshot.default_temperature}`,
+    memory_backend: snapshot.memory_backend,
+    observability_backend: snapshot.observability_backend,
+    otel_endpoint: snapshot.otel_endpoint,
+    otel_service_name: snapshot.otel_service_name,
+    runtime_kind: snapshot.runtime_kind,
+    autonomy_level: snapshot.autonomy_level,
+    autonomy_workspace_only: snapshot.autonomy_workspace_only,
+    autonomy_max_actions_per_hour: `${snapshot.autonomy_max_actions_per_hour}`,
+    autonomy_max_cost_per_day_cents: `${snapshot.autonomy_max_cost_per_day_cents}`,
+    identity_format: snapshot.identity_format,
+    identity_aieos_path: snapshot.identity_aieos_path,
+    scheduler_enabled: snapshot.scheduler_enabled,
+    scheduler_max_tasks: `${snapshot.scheduler_max_tasks}`,
+    scheduler_max_concurrent: `${snapshot.scheduler_max_concurrent}`,
+    gateway_port: `${snapshot.gateway_port}`,
+    gateway_host: snapshot.gateway_host,
+    gateway_require_pairing: snapshot.gateway_require_pairing,
+    gateway_allow_public_bind: snapshot.gateway_allow_public_bind,
+    gateway_pair_rate_limit_per_minute: `${snapshot.gateway_pair_rate_limit_per_minute}`,
+    gateway_webhook_rate_limit_per_minute: `${snapshot.gateway_webhook_rate_limit_per_minute}`,
+    webhook_enabled: snapshot.webhook_enabled,
+    webhook_port: `${snapshot.webhook_port}`,
+    webhook_secret_mode: "unchanged",
+    webhook_secret_value: "",
+    webhook_secret_exists: snapshot.webhook_secret_exists,
+    ...overrides,
+  };
+}
+
+describe("buildPayloadForSection", () => {
+  it("builds diff-only payloads for general settings", () => {
+    const snapshot = createSnapshot();
+    const payload = buildPayloadForSection(
+      "general",
+      createForm({
+        default_provider: "anthropic",
+        default_temperature: "not-a-number",
+        memory_backend: "surreal",
+      }),
+      snapshot
+    );
+
+    expect(payload).toEqual({
+      default_provider: "anthropic",
+      memory_backend: "surreal",
+    });
+  });
+
+  it("nests changed security fields and ignores unchanged values", () => {
+    const snapshot = createSnapshot();
+    const payload = buildPayloadForSection(
+      "security",
+      createForm({
+        autonomy_level: "full",
+        autonomy_workspace_only: false,
+        autonomy_max_actions_per_hour: "30",
+        autonomy_max_cost_per_day_cents: "",
+        identity_aieos_path: "/tmp/identity.json",
+      }),
+      snapshot
+    );
+
+    expect(payload).toEqual({
+      autonomy: {
+        level: "full",
+        workspace_only: false,
+        max_actions_per_hour: 30,
+      },
+      identity: {
+        aieos_path: "/tmp/identity.json",
+      },
+    });
+  });
+
+  it("builds observability, runtime, scheduler, and gateway sections only when changed", () => {
+    const snapshot = createSnapshot();
+
+    expect(
+      buildPayloadForSection(
+        "observability",
+        createForm({
+          observability_backend: "otel",
+          otel_endpoint: "http://localhost:4318",
+          otel_service_name: "dashboard",
+        }),
+        snapshot
+      )
+    ).toEqual({
+      observability: {
+        backend: "otel",
+        otel_endpoint: "http://localhost:4318",
+        otel_service_name: "dashboard",
+      },
+    });
+
+    expect(buildPayloadForSection("runtime", createForm(), snapshot)).toEqual({});
+    expect(
+      buildPayloadForSection("runtime", createForm({ runtime_kind: "docker" }), snapshot)
+    ).toEqual({ runtime: { kind: "docker" } });
+
+    expect(
+      buildPayloadForSection(
+        "scheduler",
+        createForm({ scheduler_enabled: false, scheduler_max_tasks: "96" }),
+        snapshot
+      )
+    ).toEqual({
+      scheduler: {
+        enabled: false,
+        max_tasks: 96,
+      },
+    });
+
+    expect(
+      buildPayloadForSection(
+        "gateway",
+        createForm({
+          gateway_port: "4000",
+          gateway_allow_public_bind: true,
+          gateway_pair_rate_limit_per_minute: "",
+        }),
+        snapshot
+      )
+    ).toEqual({
+      gateway: {
+        port: 4000,
+        allow_public_bind: true,
+      },
+    });
+  });
+
+  it("supports webhook secret clear and replace flows", () => {
+    const snapshot = createSnapshot();
+
+    expect(
+      buildPayloadForSection(
+        "webhook",
+        createForm({ webhook_enabled: true, webhook_secret_mode: "clear" }),
+        snapshot
+      )
+    ).toEqual({
+      channels: {
+        webhook: {
+          enabled: true,
+          secret: { mode: "clear" },
+        },
+      },
+    });
+
+    expect(
+      buildPayloadForSection(
+        "webhook",
+        createForm({
+          webhook_secret_mode: "replace",
+          webhook_secret_value: "  top-secret  ",
+        }),
+        snapshot
+      )
+    ).toEqual({
+      channels: {
+        webhook: {
+          secret: { mode: "replace", value: "top-secret" },
+        },
+      },
+    });
+  });
+
+  it("throws when replacing webhook secret with an empty value", () => {
+    expect(() =>
+      buildPayloadForSection(
+        "webhook",
+        createForm({ webhook_secret_mode: "replace", webhook_secret_value: "   " }),
+        createSnapshot()
+      )
+    ).toThrowError("empty_webhook_secret");
+  });
+});

--- a/clients/web/apps/dashboard/src/composables/useConfig.spec.ts
+++ b/clients/web/apps/dashboard/src/composables/useConfig.spec.ts
@@ -204,6 +204,107 @@ describe("useConfig", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("allows read-only public config fetches when no bearer token is present", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ observability_backends: ["none", "otel"] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ config: { channels: { webhook: {} } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+
+    const config = useConfig((key: string) => key);
+    config.baseUrl.value = "https://example.com/api";
+
+    await config.connectGateway();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toEqual({
+      "Content-Type": "application/json",
+    });
+    expect(config.observabilityBackendOptions.value).toEqual(["none", "otel"]);
+    expect(config.statusMessage.value).toBe("auth.connected");
+  });
+
+  it("supports pairing without auto-connect when requested", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ token: "token-123" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const config = useConfig((key: string) => key);
+    config.pairingCode.value = "857258";
+
+    const paired = await config.pairGateway({ autoConnect: false });
+
+    expect(paired).toBe(true);
+    expect(config.bearerToken.value).toBe("token-123");
+    expect(config.statusMessage.value).toBe("auth.pairSuccess");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports restart-required conflicts when saving config sections", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ config: { default_model: "a", channels: { webhook: {} } } }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ fields: ["runtime.kind"] }), {
+          status: 409,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+
+    const config = useConfig((key: string, params?: Record<string, unknown>) =>
+      params?.fields ? `${key}:${String(params.fields)}` : key
+    );
+    config.bearerToken.value = "token";
+    await config.connectGateway();
+    config.form.default_model = "b";
+
+    await config.saveSection("general");
+
+    expect(config.errorMessage.value).toBe("form.restartRequired:runtime.kind");
+  });
+
+  it("skips save requests when the selected section has no changes", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ config: { default_model: "a", channels: { webhook: {} } } }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      );
+
+    const config = useConfig((key: string) => key);
+    config.bearerToken.value = "token";
+    await config.connectGateway();
+
+    await config.saveSection("general");
+
+    expect(config.statusMessage.value).toBe("form.noChanges");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   describe("Quick Pair (Magic Link)", () => {
     let originalLocation: Location;
     let originalHistory: History;


### PR DESCRIPTION
This pull request adds extensive test coverage across several Rust and TypeScript modules, focusing on hardware introspection, peripheral management, and web client configuration logic. The main goal is to improve reliability and ensure correct behavior for configuration flows, board validation, and hardware tool interfaces.

**New and enhanced test coverage:**

*Hardware and Peripheral Modules:*
- Added tests for `probe_memory_map`, `memory_map_for_board`, and `IntrospectResult` to verify correct handling of probe guidance and field retention.
- Introduced comprehensive tests for board configuration logic, including validation, listing, and tool assignment for different transport types in `peripherals/mod.rs`.
- Added tests for GPIO tool schemas and parameter validation in `uno_q_bridge.rs`, ensuring correct error handling and schema exposure.
- Implemented tests for embedded bridge setup and directory copying logic in `uno_q_setup.rs`, verifying file structure creation and recursive copying.

*Web Client Configuration and Payload Logic:*
- Added tests for configuration payload building in the Dashboard app, verifying diff-based payloads, section nesting, webhook secret flows, and error handling for empty secrets.
- Expanded tests for the Dashboard's `useConfig` composable, covering read-only config fetches, pairing behavior, restart-required conflicts, and save optimizations.
- Improved Chat app tests to cover secure/insecure gateway handling, webhook secret usage, and timeout error reporting.

Closes: #253