### PR TITLE
chore: fix for Empty except

### DIFF
--- a/clients/agent-runtime/firmware/corvus-uno-q-bridge/python/main.py
+++ b/clients/agent-runtime/firmware/corvus-uno-q-bridge/python/main.py
@@ -8,6 +8,18 @@ from arduino.app_utils import App, Bridge
 corvus_PORT = 9999
 
 def handle_client(conn):
+    """
+    Handle a single client connection, processing a simple GPIO text command and replying with the result.
+    
+    Reads a single whitespace-separated command from the connection and responds on the same socket. Supported commands:
+    - "gpio_write <pin> <value>": calls Bridge.call("digitalWrite", [pin, value]) and sends "ok\n".
+    - "gpio_read <pin>": calls Bridge.call("digitalRead", [pin]) and sends "<value>\n".
+    
+    If the command is malformed, sends "error: invalid command\n". If the command is unrecognized, sends "error: unknown command\n". If an exception occurs while processing, attempts to send "error: {e}\n". The connection is closed before returning.
+    
+    Parameters:
+        conn: A socket-like object representing the client connection; must support recv, sendall, and close.
+    """
     try:
         data = conn.recv(256).decode().strip()
         if not data:


### PR DESCRIPTION
General fix: avoid empty `except` blocks. Either handle the exception in a meaningful way (logging, cleanup, re-raising) or, if it is genuinely safe to ignore, add a clear explanatory comment so the intent is explicit.

Best fix here: keep the current behavior of ignoring failures in the secondary `sendall` (to avoid changing functionality), but document it with a comment. We only need to modify `handle_client` in `clients/agent-runtime/firmware/corvus-uno-q-bridge/python/main.py`: on line 36, inside `except Exception:`, add an explanatory comment above `pass`, such as `# Ignore secondary errors while attempting to report the original error`.

No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._