### PR TITLE
docs: fix 429 errors from surrealdb.com in link checker

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -28,7 +28,7 @@ exclude = [
     # Common placeholders
     'mailto:.*@example\.com',
     # SurrealDB returns 429 Too Many Requests to bots
-    '^https://surrealdb\.com/.*',
+    '^https://surrealdb\.com(/.*)?$',
     # Internal docs links resolved by Astro/Starlight at build time
     # These are links to other pages within the documentation that Astro resolves at build time
     # Root-relative links: /en/guides/pagename or /es/guides/pagename


### PR DESCRIPTION
The SurrealDB website (surrealdb.com) returns 429 Too Many Requests status codes to the Lychee link checker in CI, causing workflow failures. This change adds an exclusion pattern to lychee.toml to skip checking these links while maintaining overall documentation integrity. Verified with make docs-build and make docs-check.

Fixes #312

---
*PR created automatically by Jules for task [11470418155735804544](https://jules.google.com/task/11470418155735804544) started by @yacosta738*