### PR TITLE
docs(runtime): add comprehensive tools reference (EN/ES)

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -13,3 +13,18 @@
 - Confirmed `gemini-cli` OAuth token support in `gemini.rs`.
 - Confirmed `ANTHROPIC_OAUTH_TOKEN` support in `mod.rs`.
 - Maintained strict bilingual parity between English and Spanish versions.
+
+## 2025-05-18 - Tools Reference Documentation - Completed
+
+**Verification:** Audited `clients/agent-runtime/src/tools/` to identify all built-in tools, their parameters, and security tiers. Verified the integration of `agent-browser` and MCP.
+**Changes:**
+- Created a comprehensive Tools Reference section in both English and Spanish (14 new files).
+- Categorized tools into: Core (shell, file_read/write), Web (browser, http_request, search), Memory (store/recall/forget), Automation (git, cron, schedule), Media (screenshot, image_info), and MCP.
+- Documented Security Operation Tiers (Safe/Read-Only vs. Risk/Action-Bearing).
+- Updated index pages in `docs/clients/agent-runtime/` and `docs/es/clients/agent-runtime/` to link to the new Tools Reference.
+**Validation:**
+- Ran `make docs-check` and `make docs-build`. 58 pages built successfully.
+- Visual verification performed via Playwright for both English and Spanish layouts.
+**Notes:**
+- Confirmed strict 1:1 parity between `en/` and `es/` directories.
+- Technical details like `mcp.<server>.<tool>` naming convention and `agent-browser` requirements are now documented.

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/index.mdx
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/index.mdx
@@ -15,6 +15,7 @@ Documentation for the Corvus Rust agent runtime.
 ## Contents
 
 - [Architecture](architecture.md) - System design and component overview
+- [Tools Reference](tools/index.mdx) - Built-in tools and MCP capabilities
 - [AI Providers](providers/index.mdx) - Supported AI providers and configuration
 - [PR Workflow](pr-workflow.md) - High-volume collaboration process
 - [CI Workflow Map](ci-map.md) - CI/CD pipeline reference

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/automation.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/automation.md
@@ -1,0 +1,61 @@
+---
+title: Automation & Utility Tools
+description: Reference for Git, Cron, Scheduling, and Notification tools in Corvus.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+These tools enable the agent to perform repository management, schedule future actions, and notify the user.
+
+## `git_operations`
+
+A structured interface for common Git tasks.
+
+- **Security Tier:** Mixed (Write operations like `commit` are Action-Bearing).
+- **Supported Operations:** `status`, `diff`, `log`, `branch`, `commit`, `add`, `checkout`, `stash`.
+- **Safety:** Automatically sanitizes arguments to prevent shell injection (blocks `--exec`, `-c`, etc.).
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `operation` | `string` | **Required.** One of the supported git commands. |
+| `message` | `string` | Commit message (for `commit`). |
+| `paths` | `string` | File paths to stage (for `add`). |
+
+---
+
+## `cron_add` / `schedule`
+
+Tools for managing autonomous, time-based execution.
+
+- **Security Tier:** Action-Bearing (Risk-bearing).
+- **Capability:** Allows the agent to schedule itself (Agent Job) or a shell script (Shell Job) to run in the future.
+- **Schedules:**
+  - `cron`: Recurring tasks (e.g., `0 9 * * *`).
+  - `at`: One-shot tasks at a specific RFC3339 timestamp.
+  - `every`: Fixed intervals in milliseconds.
+
+### `schedule` Actions
+`create`, `list`, `get`, `cancel`, `pause`, `resume`.
+
+---
+
+## `pushover`
+
+Sends a push notification to the user's mobile device.
+
+- **Security Tier:** Action-Bearing (Risk-bearing).
+- **Requirements:** Requires `PUSHOVER_TOKEN` and `PUSHOVER_USER_KEY` in the workspace `.env` file.
+- **Usage:** Ideal for notifying the user when a long-running mission is complete or requires manual intervention.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `message` | `string` | **Required.** The notification text. |
+| `priority` | `integer` | Priority from -2 (silent) to 2 (emergency). |
+| `sound` | `string` | Optional sound override (e.g., `bugle`, `bike`). |

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/core.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/core.md
@@ -1,0 +1,68 @@
+---
+title: Core Tools
+description: Reference for system command execution and filesystem tools in Corvus.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+Core tools provide the foundation for agent autonomy, allowing interaction with the host operating system and the local workspace.
+
+## `shell`
+
+Executes an arbitrary shell command within the workspace directory.
+
+- **Security Tier:** Action-Bearing (Risk-bearing).
+- **Execution:** Runs via the configured [Runtime](../../architecture.md#runtime) (Native or Docker).
+- **Constraints:**
+  - Blocked commands: Defined in `autonomy.forbidden_paths`.
+  - Allowed commands: Must be in `autonomy.allowed_commands` if configured.
+  - Environment: Only safe functional variables (`PATH`, `HOME`, `USER`, etc.) are passed. API keys and secrets are explicitly redacted/cleared.
+  - Timeout: Defaults to 60 seconds.
+  - Output limit: Truncated at 1 MB to prevent memory exhaustion.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `command` | `string` | **Required.** The shell command to execute. |
+| `approved` | `boolean` | Set `true` to explicitly approve medium/high-risk commands in supervised mode. |
+
+---
+
+## `file_read`
+
+Reads the contents of a file within the workspace.
+
+- **Security Tier:** Read-Only (Safe).
+- **Constraints:**
+  - Path traversal (e.g., `../../etc/passwd`) is strictly blocked.
+  - Symlinks that resolve outside the workspace boundary are rejected.
+  - Maximum file size: 10 MB.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `path` | `string` | **Required.** Relative path to the file within the workspace. |
+
+---
+
+## `file_write`
+
+Writes or overwrites a file within the workspace.
+
+- **Security Tier:** Action-Bearing (Risk-bearing).
+- **Constraints:**
+  - Creates parent directories automatically if they don't exist.
+  - Refuses to write through symlinks (TOCTOU protection).
+  - Subject to the same path-sandboxing rules as `file_read`.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `path` | `string` | **Required.** Relative path to the file within the workspace. |
+| `content` | `string` | **Required.** The content to write to the file. |

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/index.mdx
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/index.mdx
@@ -1,0 +1,51 @@
+---
+title: Tools Reference
+description: Overview of the Corvus Agent tool system, security model, and registration.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+# Tools Reference
+
+Corvus Agents interact with the world through **Tools**. Each tool is a specialized function that the agent can invoke with structured parameters to perform actions, retrieve data, or manage its internal state.
+
+The tool system is built on a "deny-by-default" security model, ensuring that every operation is subject to the configured [Security Policy](../../guides/configuration.md#autonomy--security).
+
+## Categories
+
+Built-in tools are organized into five primary categories:
+
+- [**Core Tools**](core.md) — System command execution (`shell`) and workspace filesystem access (`file_read`, `file_write`).
+- [**Web Tools**](web.md) — Web browsing (`browser`), search (`web_search_tool`), and structured API calls (`http_request`).
+- [**Memory Tools**](memory.md) — Long-term persistence and retrieval of facts and preferences (`memory_store`, `memory_recall`).
+- [**Automation Tools**](automation.md) — Git repository management, scheduled tasks (Cron/Schedule), and notifications (`pushover`).
+- [**Media Tools**](media.md) — Vision-related capabilities including screen capture and image metadata extraction.
+
+## Security Model
+
+Every tool execution passes through the `SecurityPolicy` layer. Tools are classified into two operational tiers:
+
+### Read-Only (Safe)
+These tools do not modify the system or external state. They are generally allowed even in low-autonomy modes.
+- *Examples:* `file_read`, `memory_recall`, `web_search_tool`, `image_info`.
+
+### Action-Bearing (Risk-bearing)
+These tools can modify files, execute code, or interact with external services. They may require explicit user approval in supervised modes.
+- *Examples:* `shell`, `file_write`, `git_operations`, `cron_add`, `pushover`.
+
+## MCP Integration
+
+In addition to built-in tools, Corvus supports the **Model Context Protocol (MCP)**. This allows you to extend the agent's capabilities by connecting to external MCP servers.
+
+MCP tools are automatically namespaced as `mcp.<server_name>.<tool_name>`. For detailed configuration, see the [MCP Guide](mcp.md).
+
+## Registration & Discovery
+
+Tools are registered during the runtime bootstrap process. The agent discovers available tools by inspecting the `ToolSpec` emitted by each implementation, which includes the tool's name, description, and JSON Schema for parameters.
+
+:::tip[Custom Tools]
+To add custom tools, you must implement the `Tool` trait in Rust and register it in the `all_tools` factory in `clients/agent-runtime/src/tools/mod.rs`.
+:::

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/mcp.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/mcp.md
@@ -1,0 +1,64 @@
+---
+title: Model Context Protocol (MCP)
+description: Guide for integrating and using MCP tools in the Corvus Agent Runtime.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+# Model Context Protocol (MCP)
+
+The Model Context Protocol (MCP) is an open standard that enables agents to connect to external tools, data sources, and services. Corvus provides a first-class MCP runtime that integrates these external capabilities directly into the agent's toolbelt.
+
+## Configuration
+
+MCP servers are configured in `config.toml` under the `[mcp]` section. Each server requires a unique name and a command to launch it.
+
+```toml
+[mcp]
+enabled = true
+
+[[mcp.servers]]
+name = "github"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_PERSONAL_ACCESS_TOKEN = "your_token_here" }
+
+[[mcp.servers]]
+name = "postgres"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost/mydb"]
+```
+
+## Namespacing
+
+To prevent name collisions with built-in tools, all MCP tools are automatically prefixed with the server name:
+
+`mcp.<server_name>.<tool_name>`
+
+*Example:* If the `github` server provides a `create_issue` tool, the agent will see it as `mcp.github.create_issue`.
+
+## Security & Approval
+
+MCP tools are treated as **Action-Bearing (Risk-bearing)** by default.
+
+- **Approval:** In Supervised mode, any call to an MCP tool will trigger an approval request.
+- **Timeouts:** Every MCP call has a default timeout (30s) to prevent hanging the agent loop.
+- **Output Limits:** Responses are capped (default 64 KB) to protect context window space.
+
+## Discovery
+
+Corvus discovers MCP tools at startup. If a server fails to start, the runtime will log the error but continue to operate with other healthy servers. You can verify discovered tools using:
+
+```bash
+corvus doctor
+```
+
+## Supported Capability Types
+
+The Corvus MCP implementation currently supports:
+- **Tools:** Executable functions (e.g., query database, send email).
+- **Resources:** (Planned) Read-only data sources.
+- **Prompts:** (Planned) Pre-defined prompt templates.

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
@@ -1,0 +1,46 @@
+---
+title: Media Tools
+description: Reference for vision and image-related tools in Corvus.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+Media tools provide the agent with visual capabilities, allowing it to "see" the host environment and process image files.
+
+## `screenshot`
+
+Captures a screenshot of the current screen or a specific region.
+
+- **Security Tier:** Action-Bearing (Risk-bearing) / Sensitive.
+- **Returns:** The file path of the saved PNG and a base64-encoded version of the image (if size permits).
+- **Platform Support:**
+  - **macOS:** Uses native `screencapture`.
+  - **Linux:** Requires `gnome-screenshot`, `scrot`, or `import` (ImageMagick).
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `filename` | `string` | Optional filename. Saved in the workspace. |
+| `region` | `string` | (macOS only) `selection` for interactive crop, `window` for front window. |
+
+---
+
+## `image_info`
+
+Extracts metadata from an image file and optionally returns it as base64 for processing by multimodal models.
+
+- **Security Tier:** Read-Only (Safe).
+- **Supported Formats:** PNG, JPEG, GIF, WEBP, BMP.
+- **Metadata Extracted:** Format, dimensions (width/height), and file size.
+- **Constraints:** Path-sandboxed to the workspace; maximum file size 5 MB.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `path` | `string` | **Required.** Path to the image file. |
+| `include_base64` | `boolean` | Include the full image data in the output. Default: `false`. |

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/memory.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/memory.md
@@ -1,0 +1,60 @@
+---
+title: Memory Tools
+description: Reference for long-term memory persistence and retrieval tools in Corvus.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+Memory tools allow the agent to persist information across conversations, effectively building a long-term "soul" or knowledge base.
+
+## `memory_store`
+
+Stores a fact, preference, or note in long-term memory.
+
+- **Security Tier:** Action-Bearing (Risk-bearing).
+- **Sensitive Data Filter:** Automatically rejects content that appears to contain passwords, API keys, or credentials.
+- **Categories:**
+  - `core`: Permanent facts (e.g., "The user lives in London").
+  - `daily`: Temporary notes for the current session.
+  - `conversation`: Chat-specific context.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `key` | `string` | **Required.** Unique identifier for the memory (e.g., `user_pref_theme`). |
+| `content` | `string` | **Required.** The information to remember. |
+| `category` | `string` | Optional category. Default: `core`. |
+
+---
+
+## `memory_recall`
+
+Searches the memory system for relevant information based on a semantic query.
+
+- **Security Tier:** Read-Only (Safe).
+- **Retrieval:** Uses hybrid search (Vector similarity + Keyword BM25) when supported by the backend.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `query` | `string` | **Required.** Keywords or phrase to search for. |
+| `limit` | `integer` | Maximum number of results to return. Default: `5`. |
+
+---
+
+## `memory_forget`
+
+Permanently removes a memory entry by its key.
+
+- **Security Tier:** Action-Bearing (Risk-bearing).
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `key` | `string` | **Required.** The key of the memory to delete. |

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/web.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/web.md
@@ -1,0 +1,83 @@
+---
+title: Web Tools
+description: Reference for web browsing, search, and HTTP request tools in Corvus.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+# Web Tools
+
+Web tools enable agents to retrieve information from the internet and interact with external APIs. All web tools enforce a strict **Domain Allowlist** policy.
+
+## `web_search_tool`
+
+Performs a web search to find current information, news, or research topics.
+
+- **Security Tier:** Read-Only (Safe).
+- **Providers:**
+  - `duckduckgo` (Default): Free, no API key required.
+  - `brave`: Requires `web_search.brave_api_key`.
+- **Results:** Returns ranked titles, URLs, and snippets.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `query` | `string` | **Required.** The search query. Be specific for better results. |
+
+---
+
+## `browser`
+
+Full browser automation for interacting with complex web applications. Supports multiple backends including Playwright-based `agent-browser` and OS-level `computer_use`.
+
+- **Security Tier:** Action-Bearing (Risk-bearing).
+- **Backends:**
+  - `agent_browser`: Uses the `agent-browser` CLI.
+  - `rust_native`: Built-in Rust driver (requires `browser-native` feature).
+  - `computer_use`: OS-level mouse/keyboard control via sidecar.
+- **Constraints:** Enforces `browser.allowed_domains`.
+
+### Common Actions
+
+| Action | Description |
+| :--- | :--- |
+| `open` | Navigate to a URL (HTTPS only). |
+| `snapshot` | Get an accessibility-tree snapshot with element refs (`@e1`, `@e2`). |
+| `click` | Click an element by ref (e.g., `@e5`) or selector. |
+| `fill` | Type text into an input field. |
+| `screenshot` | Capture a visual of the current page. |
+
+---
+
+## `browser_open`
+
+A lightweight alternative to `browser` that simply opens an approved HTTPS URL in the host's Brave Browser.
+
+- **Security Tier:** Action-Bearing (Risk-bearing).
+- **Note:** This tool does **not** allow the agent to scrape or see the page content; it is for opening pages for the user's benefit.
+
+---
+
+## `http_request`
+
+Performs structured HTTP requests (REST/JSON) to external APIs.
+
+- **Security Tier:** Action-Bearing (Risk-bearing).
+- **Constraints:**
+  - Only `http://` and `https://` schemes are allowed.
+  - Local/private hosts (SSRF protection) are strictly blocked.
+  - Sensitive headers (Authorization, API-Key) are redacted in logs.
+  - Redirects are disabled by default for security.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `url` | `string` | **Required.** The full URL to request. |
+| `method` | `string` | HTTP method (GET, POST, PUT, DELETE, etc.). Default: `GET`. |
+| `headers` | `object` | Optional key-value pairs for headers. |
+| `body` | `string` | Optional payload for POST/PUT requests. |

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/index.mdx
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/index.mdx
@@ -15,6 +15,7 @@ Documentación del runtime de agente Rust de Corvus.
 ## Contenidos
 
 - [Arquitectura](architecture.md) - Diseño del sistema y visión general de componentes
+- [Referencia de Herramientas](tools/index.mdx) - Herramientas integradas y capacidades MCP
 - [Providers de IA](providers/index.mdx) - Providers de IA soportados y su configuración
 - [PR Workflow](pr-workflow.md) - Proceso de colaboración de alto volumen
 - [CI Workflow Map](ci-map.md) - Referencia del pipeline de CI/CD

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/automation.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/automation.md
@@ -1,0 +1,61 @@
+---
+title: Herramientas de Automatización y Utilidades
+description: Referencia para las herramientas de Git, Cron, Programación y Notificaciones en Corvus.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+Estas herramientas permiten al agente realizar la gestión de repositorios, programar acciones futuras y notificar al usuario.
+
+## `git_operations`
+
+Una interfaz estructurada para tareas comunes de Git.
+
+- **Nivel de Seguridad:** Mixto (Las operaciones de escritura como `commit` son De Acción).
+- **Operaciones Soportadas:** `status`, `diff`, `log`, `branch`, `commit`, `add`, `checkout`, `stash`.
+- **Seguridad:** Desinfecta automáticamente los argumentos para evitar la inyección de shell (bloquea `--exec`, `-c`, etc.).
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `operation` | `string` | **Requerido.** Uno de los comandos de git soportados. |
+| `message` | `string` | Mensaje de commit (para `commit`). |
+| `paths` | `string` | Rutas de archivos para añadir al stage (para `add`). |
+
+---
+
+## `cron_add` / `schedule`
+
+Herramientas para gestionar la ejecución autónoma basada en el tiempo.
+
+- **Nivel de Seguridad:** De Acción (Con riesgo).
+- **Capacidad:** Permite al agente programarse a sí mismo (Agent Job) o un script de shell (Shell Job) para ejecutarse en el futuro.
+- **Programaciones:**
+  - `cron`: Tareas recurrentes (ej. `0 9 * * *`).
+  - `at`: Tareas únicas en un timestamp RFC3339 específico.
+  - `every`: Intervalos fijos en milisegundos.
+
+### Acciones de `schedule`
+`create`, `list`, `get`, `cancel`, `pause`, `resume`.
+
+---
+
+## `pushover`
+
+Envía una noticia push al dispositivo móvil del usuario.
+
+- **Nivel de Seguridad:** De Acción (Con riesgo).
+- **Requisitos:** Requiere `PUSHOVER_TOKEN` y `PUSHOVER_USER_KEY` en el archivo `.env` del workspace.
+- **Uso:** Ideal para notificar al usuario cuando una misión de larga duración se completa o requiere intervención manual.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `message` | `string` | **Requerido.** El texto de la notificación. |
+| `priority` | `integer` | Prioridad de -2 (silencioso) a 2 (emergencia). |
+| `sound` | `string` | Sobrescritura de sonido opcional (ej. `bugle`, `bike`). |

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/core.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/core.md
@@ -1,0 +1,70 @@
+---
+title: Herramientas Core
+description: Referencia para la ejecución de comandos del sistema y herramientas de archivos en Corvus.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+# Herramientas Core
+
+Las herramientas core proporcionan la base para la autonomía del agente, permitiendo la interacción con el sistema operativo host y el espacio de trabajo local.
+
+## `shell`
+
+Ejecuta un comando de shell arbitrario dentro del directorio del workspace.
+
+- **Nivel de Seguridad:** De Acción (Con riesgo).
+- **Ejecución:** Se ejecuta a través del [Runtime](../../architecture.md#runtime) configurado (Nativo o Docker).
+- **Restricciones:**
+  - Comandos bloqueados: Definidos en `autonomy.forbidden_paths`.
+  - Comandos permitidos: Deben estar en `autonomy.allowed_commands` si se configura.
+  - Entorno: Solo se pasan variables funcionales seguras (`PATH`, `HOME`, `USER`, etc.). Las claves de API y los secretos se redactan/limpian explícitamente.
+  - Tiempo de espera: Por defecto 60 segundos.
+  - Límite de salida: Truncado a 1 MB para evitar el agotamiento de la memoria.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `command` | `string` | **Requerido.** El comando de shell a ejecutar. |
+| `approved` | `boolean` | Establecer en `true` para aprobar explícitamente comandos de riesgo medio/alto en modo supervisado. |
+
+---
+
+## `file_read`
+
+Lee el contenido de un archivo dentro del workspace.
+
+- **Nivel de Seguridad:** Solo Lectura (Segura).
+- **Restricciones:**
+  - El salto de directorios (path traversal, ej. `../../etc/passwd`) está estrictamente bloqueado.
+  - Se rechazan los symlinks que resuelven fuera de los límites del workspace.
+  - Tamaño máximo de archivo: 10 MB.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `path` | `string` | **Requerido.** Ruta relativa al archivo dentro del workspace. |
+
+---
+
+## `file_write`
+
+Escribe o sobrescribe un archivo dentro del workspace.
+
+- **Nivel de Seguridad:** De Acción (Con riesgo).
+- **Restricciones:**
+  - Crea directorios padres automáticamente si no existen.
+  - Se niega a escribir a través de symlinks (protección TOCTOU).
+  - Sujeto a las mismas reglas de sandboxing de rutas que `file_read`.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `path` | `string` | **Requerido.** Ruta relativa al archivo dentro del workspace. |
+| `content` | `string` | **Requerido.** El contenido a escribir en el archivo. |

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/index.mdx
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/index.mdx
@@ -1,0 +1,51 @@
+---
+title: Referencia de Herramientas
+description: Descripción general del sistema de herramientas de Corvus Agent, modelo de seguridad y registro.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+# Referencia de Herramientas
+
+Los agentes de Corvus interactúan con el mundo a través de **Herramientas**. Cada herramienta es una función especializada que el agente puede invocar con parámetros estructurados para realizar acciones, recuperar datos o gestionar su estado interno.
+
+El sistema de herramientas se basa en un modelo de seguridad de "denegación por defecto", asegurando que cada operación esté sujeta a la [Política de Seguridad](../../guides/configuration.md#autonomía-y-seguridad) configurada.
+
+## Categorías
+
+Las herramientas integradas se organizan en cinco categorías principales:
+
+- [**Herramientas Core**](core.md) — Ejecución de comandos del sistema (`shell`) y acceso al sistema de archivos del workspace (`file_read`, `file_write`).
+- [**Herramientas Web**](web.md) — Navegación web (`browser`), búsqueda (`web_search_tool`) y llamadas estructuradas a APIs (`http_request`).
+- [**Herramientas de Memoria**](memory.md) — Persistencia a largo plazo y recuperación de hechos y preferencias (`memory_store`, `memory_recall`).
+- [**Herramientas de Automatización**](automation.md) — Gestión de repositorios Git, tareas programadas (Cron/Schedule) y notificaciones (`pushover`).
+- [**Herramientas Multimedia**](media.md) — Capacidades relacionadas con la visión, incluyendo captura de pantalla y extracción de metadatos de imágenes.
+
+## Modelo de Seguridad
+
+Cada ejecución de herramienta pasa por la capa de `SecurityPolicy`. Las herramientas se clasifican en dos niveles operativos:
+
+### Solo Lectura (Seguras)
+Estas herramientas no modifican el sistema ni el estado externo. Generalmente están permitidas incluso en modos de baja autonomía.
+- *Ejemplos:* `file_read`, `memory_recall`, `web_search_tool`, `image_info`.
+
+### De Acción (Con riesgo)
+Estas herramientas pueden modificar archivos, ejecutar código o interactuar con servicios externos. Pueden requerir aprobación explícita del usuario en modos supervisados.
+- *Ejemplos:* `shell`, `file_write`, `git_operations`, `cron_add`, `pushover`.
+
+## Integración MCP
+
+Además de las herramientas integradas, Corvus soporta el **Model Context Protocol (MCP)**. Esto permite extender las capacidades del agente conectándolo a servidores MCP externos.
+
+Las herramientas MCP reciben automáticamente un namespace como `mcp.<nombre_servidor>.<nombre_herramienta>`. Para una configuración detallada, consulta la [Guía de MCP](mcp.md).
+
+## Registro y Descubrimiento
+
+Las herramientas se registran durante el proceso de arranque (bootstrap) del runtime. El agente descubre las herramientas disponibles inspeccionando el `ToolSpec` emitido por cada implementación, que incluye el nombre de la herramienta, la descripción y el JSON Schema para los parámetros.
+
+:::tip[Herramientas Personalizadas]
+Para añadir herramientas personalizadas, debes implementar el trait `Tool` en Rust y registrarlo en el factory `all_tools` en `clients/agent-runtime/src/tools/mod.rs`.
+:::

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/mcp.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/mcp.md
@@ -1,0 +1,64 @@
+---
+title: Model Context Protocol (MCP)
+description: Guía para integrar y usar herramientas MCP en el Corvus Agent Runtime.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+# Model Context Protocol (MCP)
+
+El Model Context Protocol (MCP) es un estándar abierto que permite a los agentes conectarse con herramientas externas, fuentes de datos y servicios. Corvus proporciona un runtime de MCP de primer nivel que integra estas capacidades externas directamente en el cinturón de herramientas del agente.
+
+## Configuración
+
+Los servidores MCP se configuran en el `config.toml` bajo la sección `[mcp]`. Cada servidor requiere un nombre único y un comando para iniciarlo.
+
+```toml
+[mcp]
+enabled = true
+
+[[mcp.servers]]
+name = "github"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_PERSONAL_ACCESS_TOKEN = "tu_token_aqui" }
+
+[[mcp.servers]]
+name = "postgres"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost/mydb"]
+```
+
+## Namespacing
+
+Para evitar colisiones de nombres con las herramientas integradas, todas las herramientas MCP reciben automáticamente un prefijo con el nombre del servidor:
+
+`mcp.<nombre_servidor>.<nombre_herramienta>`
+
+*Ejemplo:* Si el servidor `github` proporciona una herramienta `create_issue`, el agente la verá como `mcp.github.create_issue`.
+
+## Seguridad y Aprobación
+
+Las herramientas MCP se tratan como **De Acción (Con riesgo)** por defecto.
+
+- **Aprobación:** En modo Supervisado, cualquier llamada a una herramienta MCP activará una solicitud de aprobación.
+- **Tiempos de espera:** Cada llamada MCP tiene un tiempo de espera por defecto (30s) para evitar que el bucle del agente se bloquee.
+- **Límites de salida:** Las respuestas están limitadas (por defecto 64 KB) para proteger el espacio de la ventana de contexto.
+
+## Descubrimiento
+
+Corvus descubre las herramientas MCP al iniciar. Si un servidor no logra iniciarse, el runtime registrará el error pero continuará operando con otros servidores sanos. Puedes verificar las herramientas descubiertas usando:
+
+```bash
+corvus doctor
+```
+
+## Tipos de Capacidades Soportadas
+
+La implementación de Corvus MCP soporta actualmente:
+- **Herramientas (Tools):** Funciones ejecutables (ej. consultar base de datos, enviar email).
+- **Recursos (Resources):** (Planificado) Fuentes de datos de solo lectura.
+- **Prompts:** (Planificado) Plantillas de prompts predefinidas.

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
@@ -1,0 +1,46 @@
+---
+title: Herramientas Multimedia
+description: Referencia para herramientas de visión e imágenes en Corvus.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+Las herramientas multimedia proporcionan al agente capacidades visuales, permitiéndole "ver" el entorno del host y procesar archivos de imagen.
+
+## `screenshot`
+
+Captura una imagen de la pantalla actual o de una región específica.
+
+- **Nivel de Seguridad:** De Acción (Con riesgo) / Sensible.
+- **Devuelve:** La ruta del archivo PNG guardado y una versión de la imagen codificada en base64 (si el tamaño lo permite).
+- **Soporte de Plataformas:**
+  - **macOS:** Utiliza `screencapture` nativo.
+  - **Linux:** Requiere `gnome-screenshot`, `scrot` o `import` (ImageMagick).
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `filename` | `string` | Nombre de archivo opcional. Guardado en el workspace. |
+| `region` | `string` | (Solo macOS) `selection` para recorte interactivo, `window` para la ventana frontal. |
+
+---
+
+## `image_info`
+
+Extrae metadatos de un archivo de imagen y, opcionalmente, lo devuelve como base64 para su procesamiento por modelos multimodales.
+
+- **Nivel de Seguridad:** Solo Lectura (Segura).
+- **Formatos Soportados:** PNG, JPEG, GIF, WEBP, BMP.
+- **Metadatos Extraídos:** Formato, dimensiones (ancho/alto) y tamaño del archivo.
+- **Restricciones:** Sandboxing de ruta al workspace; tamaño máximo de archivo 5 MB.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `path` | `string` | **Requerido.** Ruta al archivo de imagen. |
+| `include_base64` | `boolean` | Incluir los datos completos de la imagen en la salida. Por defecto: `false`. |

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/memory.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/memory.md
@@ -1,0 +1,60 @@
+---
+title: Herramientas de Memoria
+description: Referencia para herramientas de persistencia y recuperación de memoria a largo plazo en Corvus.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+Las herramientas de memoria permiten al agente persistir información a través de las conversaciones, construyendo efectivamente un "alma" o base de conocimientos a largo plazo.
+
+## `memory_store`
+
+Almacena un hecho, preferencia o nota en la memoria a largo plazo.
+
+- **Nivel de Seguridad:** De Acción (Con riesgo).
+- **Filtro de Datos Sensibles:** Rechaza automáticamente el contenido que parezca contener contraseñas, claves de API o credenciales.
+- **Categorías:**
+  - `core`: Hechos permanentes (ej. "El usuario vive en Madrid").
+  - `daily`: Notas temporales para la sesión actual.
+  - `conversation`: Contexto específico del chat.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `key` | `string` | **Requerido.** Identificador único para la memoria (ej. `user_pref_theme`). |
+| `content` | `string` | **Requerido.** La información a recordar. |
+| `category` | `string` | Categoría opcional. Por defecto: `core`. |
+
+---
+
+## `memory_recall`
+
+Busca en el sistema de memoria información relevante basada en una consulta semántica.
+
+- **Nivel de Seguridad:** Solo Lectura (Segura).
+- **Recuperación:** Utiliza búsqueda híbrida (similitud vectorial + BM25 por palabras clave) cuando el backend lo soporta.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `query` | `string` | **Requerido.** Palabras clave o frase a buscar. |
+| `limit` | `integer` | Número máximo de resultados a devolver. Por defecto: `5`. |
+
+---
+
+## `memory_forget`
+
+Elimina permanentemente una entrada de memoria mediante su clave.
+
+- **Nivel de Seguridad:** De Acción (Con riesgo).
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `key` | `string` | **Requerido.** La clave de la memoria a eliminar. |

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/web.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/web.md
@@ -1,0 +1,83 @@
+---
+title: Herramientas Web
+description: Referencia para herramientas de navegación web, búsqueda y peticiones HTTP en Corvus.
+owner: team-runtime
+status: canonical
+lastReviewed: 2026-03-26
+appliesTo: main
+docType: reference
+---
+
+# Herramientas Web
+
+Las herramientas web permiten a los agentes recuperar información de Internet e interactuar con APIs externas. Todas las herramientas web imponen una política estricta de **Lista de Dominios Permitidos**.
+
+## `web_search_tool`
+
+Realiza una búsqueda web para encontrar información actual, noticias o temas de investigación.
+
+- **Nivel de Seguridad:** Solo Lectura (Segura).
+- **Proveedores:**
+  - `duckduckgo` (Por defecto): Gratuito, no requiere clave de API.
+  - `brave`: Requiere `web_search.brave_api_key`.
+- **Resultados:** Devuelve títulos, URLs y fragmentos (snippets) clasificados.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `query` | `string` | **Requerido.** La consulta de búsqueda. Sé específico para obtener mejores resultados. |
+
+---
+
+## `browser`
+
+Automatización completa del navegador para interactuar con aplicaciones web complejas. Soporta múltiples backends, incluyendo `agent-browser` basado en Playwright y `computer_use` a nivel de sistema operativo.
+
+- **Nivel de Seguridad:** De Acción (Con riesgo).
+- **Backends:**
+  - `agent_browser`: Utiliza la CLI de `agent-browser`.
+  - `rust_native`: Driver de Rust integrado (requiere la feature `browser-native`).
+  - `computer_use`: Control de ratón/teclado a nivel de SO vía sidecar.
+- **Restricciones:** Aplica `browser.allowed_domains`.
+
+### Acciones Comunes
+
+| Acción | Descripción |
+| :--- | :--- |
+| `open` | Navegar a una URL (solo HTTPS). |
+| `snapshot` | Obtener una captura del árbol de accesibilidad con referencias de elementos (`@e1`, `@e2`). |
+| `click` | Hacer clic en un elemento por referencia (ej. `@e5`) o selector. |
+| `fill` | Escribir texto en un campo de entrada. |
+| `screenshot` | Capturar una imagen visual de la página actual. |
+
+---
+
+## `browser_open`
+
+Una alternativa ligera a `browser` que simplemente abre una URL HTTPS aprobada en el navegador Brave del host.
+
+- **Nivel de Seguridad:** De Acción (Con riesgo).
+- **Nota:** Esta herramienta **no** permite al agente extraer datos o ver el contenido de la página; es para abrir páginas en beneficio del usuario.
+
+---
+
+## `http_request`
+
+Realiza peticiones HTTP estructuradas (REST/JSON) a APIs externas.
+
+- **Nivel de Seguridad:** De Acción (Con riesgo).
+- **Restricciones:**
+  - Solo se permiten esquemas `http://` y `https://`.
+  - Los hosts locales/privados (protección SSRF) están estrictamente bloqueados.
+  - Los encabezados sensibles (Authorization, API-Key) se redactan en los registros.
+  - Las redirecciones están desactivadas por defecto por seguridad.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `url` | `string` | **Requerido.** La URL completa de la petición. |
+| `method` | `string` | Método HTTP (GET, POST, PUT, DELETE, etc.). Por defecto: `GET`. |
+| `headers` | `object` | Pares clave-valor opcionales para los encabezados. |
+| `body` | `string` | Payload opcional para peticiones POST/PUT. |


### PR DESCRIPTION
This PR introduces a comprehensive Tools Reference section to the Corvus documentation, specifically for the Agent Runtime. In accordance with the "Scribe" agent mission, all documentation has been verified against the actual Rust implementation and maintains strict bilingual parity between English and Spanish.

Key additions:
- **Core Tools**: `shell`, `file_read`, `file_write`.
- **Web Tools**: `browser`, `http_request`, `web_search_tool`.
- **Memory Tools**: `memory_store`, `memory_recall`, `memory_forget`.
- **Automation Tools**: `git_operations`, `cron_add`, `schedule`, `pushover`.
- **Media Tools**: `screenshot`, `image_info`.
- **MCP**: Guide for Model Context Protocol integration.
- **Security**: Documentation of Safe vs. Risk operation tiers.

All changes were validated using the documentation build pipeline (`make docs-build` and `make docs-check`) and visually verified across both languages.

---
*PR created automatically by Jules for task [7245530421772779966](https://jules.google.com/task/7245530421772779966) started by @yacosta738*