### PR TITLE
refactor(agent-runtime): extract multimedia contracts to corvus-traits

### DIFF
--- a/clients/agent-runtime/crates/corvus-traits/src/lib.rs
+++ b/clients/agent-runtime/crates/corvus-traits/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod channels;
 pub mod memory;
+pub mod multimedia;
 pub mod security;
 mod testing;
 pub mod tools;

--- a/clients/agent-runtime/crates/corvus-traits/src/multimedia.rs
+++ b/clients/agent-runtime/crates/corvus-traits/src/multimedia.rs
@@ -1,0 +1,192 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Allowed image MIME types for ingress.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AllowedImageMime {
+    Jpeg,
+    Png,
+    Webp,
+}
+
+impl AllowedImageMime {
+    /// Parse from a MIME string (e.g. `"image/jpeg"`).
+    pub fn from_mime_str(s: &str) -> Option<Self> {
+        match s {
+            "image/jpeg" => Some(Self::Jpeg),
+            "image/png" => Some(Self::Png),
+            "image/webp" => Some(Self::Webp),
+            _ => None,
+        }
+    }
+
+    /// Return the canonical MIME string.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Jpeg => "image/jpeg",
+            Self::Png => "image/png",
+            Self::Webp => "image/webp",
+        }
+    }
+}
+
+/// Transport encoding for the image payload sent to the provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImageTransportForm {
+    /// Raw bytes inlined in the provider request (MVP).
+    InlineBytes,
+}
+
+/// A validated, staged image ready for provider dispatch.
+#[derive(Debug, Clone)]
+pub struct StagedImage {
+    pub sha256: String,
+    pub mime_type: AllowedImageMime,
+    pub byte_len: u64,
+    pub temp_path: PathBuf,
+    pub transport_form: ImageTransportForm,
+    pub channel_origin: String,
+}
+
+/// Compact metadata for an image that appeared in a prior conversation turn.
+/// Stored in history instead of raw bytes to bound memory usage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImageHistoryMeta {
+    /// MIME type string (e.g. "image/jpeg").
+    pub mime: String,
+    /// SHA-256 hex digest of the original image bytes.
+    pub sha256: String,
+    /// Original image size in bytes.
+    pub byte_len: u64,
+    /// Channel that originated the image.
+    pub channel_origin: String,
+    /// User-provided caption, if any.
+    pub caption: Option<String>,
+    /// Model-generated description of image content (populated post-response).
+    pub description: Option<String>,
+}
+
+impl ImageHistoryMeta {
+    /// Build from a `StagedImage` at ingestion time (description populated later).
+    pub fn from_staged(staged: &StagedImage, caption: Option<String>) -> Self {
+        Self {
+            mime: staged.mime_type.as_str().to_string(),
+            sha256: staged.sha256.clone(),
+            byte_len: staged.byte_len,
+            channel_origin: staged.channel_origin.clone(),
+            caption,
+            description: None,
+        }
+    }
+
+    /// Render as a synthetic context string for history injection.
+    pub fn to_context_string(&self) -> String {
+        let prefix_len = 16.min(self.sha256.len());
+        let mut s = format!(
+            "[Prior image: {}, {} bytes, sha256:{}",
+            self.mime,
+            self.byte_len,
+            &self.sha256[..prefix_len]
+        );
+        if let Some(desc) = &self.description {
+            use std::fmt::Write;
+            let sanitized = sanitize_history_text(desc);
+            if !sanitized.is_empty() {
+                let _ = write!(s, ". Description: {sanitized}");
+            }
+        }
+        if let Some(cap) = &self.caption {
+            use std::fmt::Write;
+            let sanitized = sanitize_history_text(cap);
+            if !sanitized.is_empty() {
+                let _ = write!(s, ". Caption: {sanitized}");
+            }
+        }
+        s.push(']');
+        s
+    }
+}
+
+/// Compact metadata for an audio turn stored in conversation history.
+///
+/// Stored in history instead of raw audio bytes to bound memory usage.
+/// The transcription is stored at ingestion time (unlike images where
+/// the description is populated post-response).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AudioHistoryMeta {
+    /// MIME type string (e.g. "audio/ogg").
+    pub mime: String,
+    /// SHA-256 hex digest of the original audio bytes.
+    pub sha256: String,
+    /// Original audio size in bytes.
+    pub byte_len: u64,
+    /// Audio duration in seconds, if known.
+    pub duration_secs: Option<f64>,
+    /// Channel that originated the audio.
+    pub channel_origin: String,
+    /// The transcribed text from this audio.
+    pub transcription: String,
+    /// User-provided caption, if any.
+    pub caption: Option<String>,
+}
+
+impl AudioHistoryMeta {
+    /// Build directly from shared contract fields.
+    pub fn new(
+        mime: impl Into<String>,
+        sha256: impl Into<String>,
+        byte_len: u64,
+        duration_secs: Option<f64>,
+        channel_origin: impl Into<String>,
+        transcription: impl Into<String>,
+        caption: Option<String>,
+    ) -> Self {
+        Self {
+            mime: mime.into(),
+            sha256: sha256.into(),
+            byte_len,
+            duration_secs,
+            channel_origin: channel_origin.into(),
+            transcription: transcription.into(),
+            caption,
+        }
+    }
+
+    /// Render as a synthetic context string for history injection.
+    ///
+    /// Only includes modality, duration, transcription, and caption.
+    /// Internal metadata (sha256, byte_len) is kept in the struct but not
+    /// injected into model-facing history to reduce token consumption.
+    ///
+    /// Example: `"[Prior audio: audio/ogg, 45s. Transcription: Hola...]"`
+    pub fn to_context_string(&self) -> String {
+        let mut s = format!("[Prior audio: {}", self.mime);
+        if let Some(dur) = self.duration_secs {
+            use std::fmt::Write;
+            let _ = write!(s, ", {dur:.0}s");
+        }
+        let sanitized = sanitize_history_text(&self.transcription);
+        if !sanitized.is_empty() {
+            use std::fmt::Write;
+            let _ = write!(s, ". Transcription: {sanitized}");
+        }
+        if let Some(cap) = &self.caption {
+            use std::fmt::Write;
+            let sanitized_cap = sanitize_history_text(cap);
+            if !sanitized_cap.is_empty() {
+                let _ = write!(s, ". Caption: {sanitized_cap}");
+            }
+        }
+        s.push(']');
+        s
+    }
+}
+
+fn sanitize_history_text(value: &str) -> String {
+    value
+        .chars()
+        .filter(|c| *c != '\n' && *c != '\r')
+        .take(200)
+        .collect()
+}

--- a/clients/agent-runtime/src/channels/audio_media.rs
+++ b/clients/agent-runtime/src/channels/audio_media.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
+pub use corvus_traits::multimedia::AudioHistoryMeta;
 
 /// Maximum audio payload size (25 MiB).
 pub const MAX_AUDIO_BYTES: u64 = 25 * 1024 * 1024;
@@ -206,81 +206,21 @@ impl StagedAudio {
 
 // ── AudioHistoryMeta ──────────────────────────────────────────
 
-/// Compact metadata for an audio turn stored in conversation history.
-///
-/// Stored in history instead of raw audio bytes to bound memory usage.
-/// The transcription is stored at ingestion time (unlike images where
-/// the description is populated post-response).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AudioHistoryMeta {
-    /// MIME type string (e.g. "audio/ogg").
-    pub mime: String,
-    /// SHA-256 hex digest of the original audio bytes.
-    pub sha256: String,
-    /// Original audio size in bytes.
-    pub byte_len: u64,
-    /// Audio duration in seconds, if known.
-    pub duration_secs: Option<f64>,
-    /// Channel that originated the audio.
-    pub channel_origin: String,
-    /// The transcribed text from this audio.
-    pub transcription: String,
-    /// User-provided caption, if any.
-    pub caption: Option<String>,
-}
-
-impl AudioHistoryMeta {
-    /// Build from a `StagedAudio` after transcription completes.
-    pub fn from_staged(staged: &StagedAudio, transcription: &str, caption: Option<&str>) -> Self {
-        Self {
-            mime: staged.mime_type.as_str().to_string(),
-            sha256: staged.sha256.clone(),
-            byte_len: staged.byte_len,
-            duration_secs: staged.duration_secs,
-            channel_origin: staged.channel_origin.clone(),
-            transcription: transcription.to_string(),
-            caption: caption.map(String::from),
-        }
-    }
-
-    /// Render as a synthetic context string for history injection.
-    ///
-    /// Only includes modality, duration, transcription, and caption.
-    /// Internal metadata (sha256, byte_len) is kept in the struct but not
-    /// injected into model-facing history to reduce token consumption.
-    ///
-    /// Example: `"[Prior audio: audio/ogg, 45s. Transcription: Hola...]"`
-    pub fn to_context_string(&self) -> String {
-        let mut s = format!("[Prior audio: {}", self.mime);
-        if let Some(dur) = self.duration_secs {
-            use std::fmt::Write;
-            let _ = write!(s, ", {dur:.0}s");
-        }
-        // Truncate transcription to 200 chars for history compactness
-        let sanitized: String = self
-            .transcription
-            .chars()
-            .filter(|c| *c != '\n' && *c != '\r')
-            .take(200)
-            .collect();
-        if !sanitized.is_empty() {
-            use std::fmt::Write;
-            let _ = write!(s, ". Transcription: {sanitized}");
-        }
-        if let Some(cap) = &self.caption {
-            use std::fmt::Write;
-            let sanitized_cap: String = cap
-                .chars()
-                .filter(|c| *c != '\n' && *c != '\r')
-                .take(200)
-                .collect();
-            if !sanitized_cap.is_empty() {
-                let _ = write!(s, ". Caption: {sanitized_cap}");
-            }
-        }
-        s.push(']');
-        s
-    }
+/// Build audio history metadata from the runtime-only staged audio type.
+pub fn build_audio_history_meta_from_staged(
+    staged: &StagedAudio,
+    transcription: &str,
+    caption: Option<&str>,
+) -> AudioHistoryMeta {
+    AudioHistoryMeta::new(
+        staged.mime_type.as_str(),
+        staged.sha256.clone(),
+        staged.byte_len,
+        staged.duration_secs,
+        staged.channel_origin.clone(),
+        transcription,
+        caption.map(String::from),
+    )
 }
 
 // ── stage_audio_from_bytes ────────────────────────────────────
@@ -731,7 +671,7 @@ mod tests {
             channel_origin: "telegram".into(),
         };
 
-        let meta = AudioHistoryMeta::from_staged(&staged, "Hola mundo", Some("caption"));
+        let meta = build_audio_history_meta_from_staged(&staged, "Hola mundo", Some("caption"));
 
         assert_eq!(meta.mime, "audio/ogg");
         assert_eq!(meta.sha256, "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6");
@@ -753,7 +693,7 @@ mod tests {
             channel_origin: "telegram".into(),
         };
 
-        let meta = AudioHistoryMeta::from_staged(&staged, "Hello world", None);
+        let meta = build_audio_history_meta_from_staged(&staged, "Hello world", None);
 
         assert_eq!(meta.caption, None);
         assert_eq!(meta.transcription, "Hello world");

--- a/clients/agent-runtime/src/channels/discord.rs
+++ b/clients/agent-runtime/src/channels/discord.rs
@@ -1050,7 +1050,7 @@ mod tests {
         );
 
         let temp_path = staged.temp_path.clone();
-        staged.cleanup();
+        media::cleanup_staged_image(&staged);
         assert!(
             !temp_path.exists(),
             "staged.cleanup() should remove {}",

--- a/clients/agent-runtime/src/channels/media.rs
+++ b/clients/agent-runtime/src/channels/media.rs
@@ -1,8 +1,9 @@
-use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
+pub use corvus_traits::multimedia::{
+    AllowedImageMime, ImageHistoryMeta, ImageTransportForm, StagedImage,
+};
 use futures_util::StreamExt;
-use serde::{Deserialize, Serialize};
 
 /// Maximum image payload size (10 MiB).
 pub const MAX_IMAGE_BYTES: u64 = 10 * 1024 * 1024;
@@ -165,35 +166,6 @@ fn is_lower_hex(value: &str, len: usize) -> bool {
             .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
 }
 
-/// Allowed image MIME types for ingress.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AllowedImageMime {
-    Jpeg,
-    Png,
-    Webp,
-}
-
-impl AllowedImageMime {
-    /// Parse from a MIME string (e.g. `"image/jpeg"`).
-    pub fn from_mime_str(s: &str) -> Option<Self> {
-        match s {
-            "image/jpeg" => Some(Self::Jpeg),
-            "image/png" => Some(Self::Png),
-            "image/webp" => Some(Self::Webp),
-            _ => None,
-        }
-    }
-
-    /// Return the canonical MIME string.
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Jpeg => "image/jpeg",
-            Self::Png => "image/png",
-            Self::Webp => "image/webp",
-        }
-    }
-}
-
 /// Reason an image turn was rejected.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ImageRejectionReason {
@@ -219,103 +191,15 @@ pub enum ImageRejectionReason {
     ChannelNotSupported,
 }
 
-/// Transport encoding for the image payload sent to the provider.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ImageTransportForm {
-    /// Raw bytes inlined in the provider request (MVP).
-    InlineBytes,
-}
-
-/// A validated, staged image ready for provider dispatch.
-#[derive(Debug, Clone)]
-pub struct StagedImage {
-    pub sha256: String,
-    pub mime_type: AllowedImageMime,
-    pub byte_len: u64,
-    pub temp_path: PathBuf,
-    pub transport_form: ImageTransportForm,
-    pub channel_origin: String,
-}
-
-impl StagedImage {
-    /// Best-effort cleanup of the staged temp file.
-    pub fn cleanup(&self) {
-        if self.temp_path.exists() {
-            if let Err(e) = std::fs::remove_file(&self.temp_path) {
-                tracing::warn!(
-                    "Failed to remove staged image {}: {e}",
-                    self.temp_path.display()
-                );
-            }
+/// Best-effort cleanup of the staged temp file.
+pub fn cleanup_staged_image(staged: &StagedImage) {
+    if staged.temp_path.exists() {
+        if let Err(e) = std::fs::remove_file(&staged.temp_path) {
+            tracing::warn!(
+                "Failed to remove staged image {}: {e}",
+                staged.temp_path.display()
+            );
         }
-    }
-}
-
-/// Compact metadata for an image that appeared in a prior conversation turn.
-/// Stored in history instead of raw bytes to bound memory usage.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ImageHistoryMeta {
-    /// MIME type string (e.g. "image/jpeg").
-    pub mime: String,
-    /// SHA-256 hex digest of the original image bytes.
-    pub sha256: String,
-    /// Original image size in bytes.
-    pub byte_len: u64,
-    /// Channel that originated the image.
-    pub channel_origin: String,
-    /// User-provided caption, if any.
-    pub caption: Option<String>,
-    /// Model-generated description of image content (populated post-response).
-    pub description: Option<String>,
-}
-
-impl ImageHistoryMeta {
-    /// Build from a `StagedImage` at ingestion time (description populated later).
-    pub fn from_staged(staged: &StagedImage, caption: Option<String>) -> Self {
-        Self {
-            mime: staged.mime_type.as_str().to_string(),
-            sha256: staged.sha256.clone(),
-            byte_len: staged.byte_len,
-            channel_origin: staged.channel_origin.clone(),
-            caption,
-            description: None,
-        }
-    }
-
-    /// Render as a synthetic context string for history injection.
-    pub fn to_context_string(&self) -> String {
-        let prefix_len = 16.min(self.sha256.len());
-        let mut s = format!(
-            "[Prior image: {}, {} bytes, sha256:{}",
-            self.mime,
-            self.byte_len,
-            &self.sha256[..prefix_len]
-        );
-        if let Some(desc) = &self.description {
-            use std::fmt::Write;
-            let sanitized: String = desc
-                .chars()
-                .filter(|c| *c != '\n' && *c != '\r')
-                .take(200)
-                .collect();
-            if !sanitized.is_empty() {
-                let _ = write!(s, ". Description: {sanitized}");
-            }
-        }
-        if let Some(cap) = &self.caption {
-            use std::fmt::Write;
-            // Sanitize: strip newlines, limit to 200 chars
-            let sanitized: String = cap
-                .chars()
-                .filter(|c| *c != '\n' && *c != '\r')
-                .take(200)
-                .collect();
-            if !sanitized.is_empty() {
-                let _ = write!(s, ". Caption: {sanitized}");
-            }
-        }
-        s.push(']');
-        s
     }
 }
 
@@ -657,7 +541,7 @@ mod tests {
         };
 
         assert!(tmp.exists());
-        staged.cleanup();
+        cleanup_staged_image(&staged);
         assert!(!tmp.exists());
     }
 
@@ -667,12 +551,12 @@ mod tests {
             sha256: "abc".into(),
             mime_type: AllowedImageMime::Png,
             byte_len: 0,
-            temp_path: PathBuf::from("/tmp/nonexistent_corvus_test_file"),
+            temp_path: std::path::PathBuf::from("/tmp/nonexistent_corvus_test_file"),
             transport_form: ImageTransportForm::InlineBytes,
             channel_origin: "test".into(),
         };
         // Should not panic
-        staged.cleanup();
+        cleanup_staged_image(&staged);
     }
 
     // ── Constants ─────────────────────────────────────────────
@@ -731,7 +615,7 @@ mod tests {
         // Verify SHA-256 is a 64-char hex string
         assert_eq!(staged.sha256.len(), 64);
         assert!(staged.sha256.chars().all(|c| c.is_ascii_hexdigit()));
-        staged.cleanup();
+        cleanup_staged_image(&staged);
     }
 
     #[tokio::test]
@@ -748,7 +632,7 @@ mod tests {
         assert_eq!(staged.mime_type, AllowedImageMime::Png);
         assert_eq!(staged.channel_origin, "ch");
         assert!(staged.temp_path.extension().unwrap().to_str().unwrap() == "png");
-        staged.cleanup();
+        cleanup_staged_image(&staged);
     }
 
     #[tokio::test]
@@ -815,7 +699,7 @@ mod tests {
             fname.starts_with("corvus-wa-img-"),
             "filename should contain channel prefix: {fname}"
         );
-        staged.cleanup();
+        cleanup_staged_image(&staged);
     }
 
     #[test]
@@ -946,7 +830,7 @@ mod tests {
             sha256: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2".into(),
             mime_type: AllowedImageMime::Jpeg,
             byte_len: 245_760,
-            temp_path: PathBuf::from("/tmp/test.jpg"),
+            temp_path: std::path::PathBuf::from("/tmp/test.jpg"),
             transport_form: ImageTransportForm::InlineBytes,
             channel_origin: "telegram".into(),
         }
@@ -1022,7 +906,7 @@ mod tests {
             sha256: "abcd1234".into(),
             mime_type: AllowedImageMime::Png,
             byte_len: 100,
-            temp_path: PathBuf::from("/tmp/test.png"),
+            temp_path: std::path::PathBuf::from("/tmp/test.png"),
             transport_form: ImageTransportForm::InlineBytes,
             channel_origin: "test".into(),
         };
@@ -1063,7 +947,7 @@ mod tests {
 
         let staged = result.expect("should succeed with custom higher limit");
         assert_eq!(staged.byte_len, body.len() as u64);
-        staged.cleanup();
+        cleanup_staged_image(&staged);
     }
 
     #[tokio::test]

--- a/clients/agent-runtime/src/channels/mod.rs
+++ b/clients/agent-runtime/src/channels/mod.rs
@@ -132,7 +132,7 @@ struct StagedImageGuard(Vec<media::StagedImage>);
 impl Drop for StagedImageGuard {
     fn drop(&mut self) {
         for img in &self.0 {
-            img.cleanup();
+            media::cleanup_staged_image(img);
         }
     }
 }
@@ -1568,7 +1568,7 @@ fn inject_transcription(
                     let audio = &staged[tx_idx];
                     let trimmed = transcription.text.trim().to_string();
 
-                    let meta = audio_media::AudioHistoryMeta::from_staged(
+                    let meta = audio_media::build_audio_history_meta_from_staged(
                         audio,
                         &trimmed,
                         caption_text.as_deref(),
@@ -1722,7 +1722,7 @@ async fn stage_channel_images(
             Ok(image) => staged.push(image),
             Err(reason) => {
                 for image in &staged {
-                    image.cleanup();
+                    media::cleanup_staged_image(image);
                 }
                 return Err(reason);
             }
@@ -5062,7 +5062,7 @@ mod tests {
                 .await
                 .unwrap();
         let first_path = first_staged.temp_path.clone();
-        first_staged.cleanup();
+        media::cleanup_staged_image(&first_staged);
 
         let message = traits::ChannelMessage {
             id: "img-partial-cleanup".into(),

--- a/clients/agent-runtime/src/channels/slack.rs
+++ b/clients/agent-runtime/src/channels/slack.rs
@@ -910,7 +910,7 @@ mod tests {
             .is_some_and(|name| name.starts_with("corvus-sl-img-")));
 
         let temp_path = staged.temp_path.clone();
-        staged.cleanup();
+        media::cleanup_staged_image(&staged);
         assert!(
             !temp_path.exists(),
             "cleanup should remove {}",

--- a/clients/agent-runtime/tests/traits_api_compat.rs
+++ b/clients/agent-runtime/tests/traits_api_compat.rs
@@ -1,15 +1,22 @@
 use std::any::TypeId;
 
 use async_trait::async_trait;
-use corvus::channels::{self, Channel as RuntimeChannel, SendMessage};
+use corvus::channels::audio_media::AudioHistoryMeta as RuntimeAudioHistoryMeta;
+use corvus::channels::media::{
+    AllowedImageMime as RuntimeAllowedImageMime, ImageHistoryMeta as RuntimeImageHistoryMeta,
+    ImageTransportForm as RuntimeImageTransportForm, StagedImage as RuntimeStagedImage,
+};
+use corvus::channels::{self, audio_media, media, Channel as RuntimeChannel, SendMessage};
 use corvus::memory::{self, Memory as RuntimeMemory, MemoryCategory};
 use corvus::security::{self, Sandbox as RuntimeSandbox};
-use corvus::tools::{self, Tool as RuntimeTool, ToolResult as RuntimeToolResult, ToolSpec as RuntimeToolSpec};
 use corvus::tools::traits::{
     ToolDescriptorHint as RuntimeToolDescriptorHint,
     ToolDescriptorMcpHint as RuntimeToolDescriptorMcpHint,
     ToolDescriptorMcpPromptArgumentHint as RuntimeToolDescriptorMcpPromptArgumentHint,
     ToolSourceMetadata as RuntimeToolSourceMetadata,
+};
+use corvus::tools::{
+    self, Tool as RuntimeTool, ToolResult as RuntimeToolResult, ToolSpec as RuntimeToolSpec,
 };
 
 struct DummySandbox;
@@ -199,6 +206,35 @@ fn legacy_paths_match_extracted_trait_identities() {
     assert_eq!(
         TypeId::of::<RuntimeToolDescriptorMcpPromptArgumentHint>(),
         TypeId::of::<corvus_traits::tools::ToolDescriptorMcpPromptArgumentHint>()
+    );
+
+    assert_eq!(
+        TypeId::of::<RuntimeAllowedImageMime>(),
+        TypeId::of::<corvus_traits::multimedia::AllowedImageMime>()
+    );
+    assert_eq!(
+        TypeId::of::<media::AllowedImageMime>(),
+        TypeId::of::<corvus_traits::multimedia::AllowedImageMime>()
+    );
+    assert_eq!(
+        TypeId::of::<RuntimeImageTransportForm>(),
+        TypeId::of::<corvus_traits::multimedia::ImageTransportForm>()
+    );
+    assert_eq!(
+        TypeId::of::<RuntimeStagedImage>(),
+        TypeId::of::<corvus_traits::multimedia::StagedImage>()
+    );
+    assert_eq!(
+        TypeId::of::<RuntimeImageHistoryMeta>(),
+        TypeId::of::<corvus_traits::multimedia::ImageHistoryMeta>()
+    );
+    assert_eq!(
+        TypeId::of::<RuntimeAudioHistoryMeta>(),
+        TypeId::of::<corvus_traits::multimedia::AudioHistoryMeta>()
+    );
+    assert_eq!(
+        TypeId::of::<audio_media::AudioHistoryMeta>(),
+        TypeId::of::<corvus_traits::multimedia::AudioHistoryMeta>()
     );
 }
 


### PR DESCRIPTION
## Related Issues

closes #431

---

## Summary

- extract the shared multimedia contract/data types into `clients/agent-runtime/crates/corvus-traits/src/multimedia.rs`
- preserve existing runtime import paths by re-exporting the moved types from `src/channels/media.rs` and `src/channels/audio_media.rs`
- keep runtime-only validation, staging, cleanup, rejection enums, limits, and channel-coupled helpers in the runtime modules

---

## Tested Information

- `cargo check --manifest-path clients/agent-runtime/Cargo.toml -p corvus-traits`
- `cargo test --manifest-path clients/agent-runtime/Cargo.toml --test traits_api_compat`
- `cargo test --manifest-path clients/agent-runtime/Cargo.toml channels::media::tests::staged_image_cleanup_removes_temp_file --lib`
- `cargo test --manifest-path clients/agent-runtime/Cargo.toml channels::media::tests::image_history_meta_serde_roundtrip --lib`
- `cargo test --manifest-path clients/agent-runtime/Cargo.toml channels::audio_media::tests::audio_history_meta_from_staged --lib`
- `cargo test --manifest-path clients/agent-runtime/Cargo.toml channels::audio_media::tests::staged_audio_cleanup_removes_temp_file --lib`
- pre-push hook: full `clients/agent-runtime` Rust test suite (`3507 passed` on retry)

---

## Documentation Impact

- Docs updated in:
- No docs update required because this PR only extracts shared Rust contracts and preserves runtime compatibility without changing end-user setup, UX, or operations.
- [x] I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
