### PR TITLE
feat(agent-runtime): Phase 5A — trait compliance macros and differential tests

### DIFF
--- a/clients/agent-runtime/crates/corvus-composer/src/lib.rs
+++ b/clients/agent-runtime/crates/corvus-composer/src/lib.rs
@@ -785,4 +785,122 @@ tools = []
             "minimal template should have no tools"
         );
     }
+
+    // -------------------------------------------------------------------------
+    // Differential: AgentComposer capability report matches manifest declarations
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn differential_required_capabilities_match_provider_section() {
+        let toml = r#"
+version = "1.0"
+name = "diff-test-agent"
+[providers]
+providers = ["anthropic", "openai"]
+default = "anthropic"
+[channels]
+channels = ["telegram"]
+[tools]
+tools = ["shell"]
+"#;
+        let composer = AgentComposer::from_toml(toml).unwrap();
+        let caps = composer.required_capabilities();
+        assert!(caps.providers.contains(&"anthropic".to_string()));
+        assert!(caps.providers.contains(&"openai".to_string()));
+    }
+
+    #[test]
+    fn differential_required_capabilities_match_channel_section() {
+        let toml = r#"
+version = "1.0"
+name = "diff-channels-agent"
+[providers]
+providers = ["gemini"]
+default = "gemini"
+[channels]
+channels = ["discord", "slack"]
+[tools]
+tools = []
+"#;
+        let composer = AgentComposer::from_toml(toml).unwrap();
+        let caps = composer.required_capabilities();
+        assert!(caps.channels.contains(&"discord".to_string()));
+        assert!(caps.channels.contains(&"slack".to_string()));
+    }
+
+    #[test]
+    fn differential_required_capabilities_match_tools_section() {
+        let toml = r#"
+version = "1.0"
+name = "diff-tools-agent"
+[providers]
+providers = ["anthropic"]
+default = "anthropic"
+[channels]
+channels = ["telegram"]
+[tools]
+tools = ["shell", "file_read", "browser"]
+"#;
+        let composer = AgentComposer::from_toml(toml).unwrap();
+        let caps = composer.required_capabilities();
+        assert!(caps.tools.contains(&"shell".to_string()));
+        assert!(caps.tools.contains(&"file_read".to_string()));
+        assert!(caps.tools.contains(&"browser".to_string()));
+    }
+
+    #[test]
+    fn differential_empty_tools_produces_no_tool_capabilities() {
+        let toml = r#"
+version = "1.0"
+name = "minimal-diff-agent"
+[providers]
+providers = ["anthropic"]
+default = "anthropic"
+[channels]
+channels = ["telegram"]
+[tools]
+tools = []
+"#;
+        let composer = AgentComposer::from_toml(toml).unwrap();
+        let caps = composer.required_capabilities();
+        assert!(caps.tools.is_empty());
+    }
+
+    #[test]
+    fn differential_memory_capability_present_when_configured() {
+        let toml = r#"
+version = "1.0"
+name = "memory-diff-agent"
+[providers]
+providers = ["anthropic"]
+default = "anthropic"
+[channels]
+channels = ["telegram"]
+[tools]
+tools = []
+[memory]
+backend = "sqlite"
+"#;
+        let composer = AgentComposer::from_toml(toml).unwrap();
+        let caps = composer.required_capabilities();
+        assert!(caps.memory_backend.is_some());
+    }
+
+    #[test]
+    fn differential_no_memory_capability_when_not_configured() {
+        let toml = r#"
+version = "1.0"
+name = "no-memory-diff-agent"
+[providers]
+providers = ["anthropic"]
+default = "anthropic"
+[channels]
+channels = ["telegram"]
+[tools]
+tools = []
+"#;
+        let composer = AgentComposer::from_toml(toml).unwrap();
+        let caps = composer.required_capabilities();
+        assert!(caps.memory_backend.is_none());
+    }
 }

--- a/clients/agent-runtime/crates/corvus-traits/src/lib.rs
+++ b/clients/agent-runtime/crates/corvus-traits/src/lib.rs
@@ -3,5 +3,5 @@ pub mod memory;
 pub mod multimedia;
 pub mod providers;
 pub mod security;
-mod testing;
+pub mod testing;
 pub mod tools;

--- a/clients/agent-runtime/crates/corvus-traits/src/testing.rs
+++ b/clients/agent-runtime/crates/corvus-traits/src/testing.rs
@@ -1,6 +1,356 @@
-//! Scaffolding for future shared contract-compliance tests.
+/// Generates a set of contract-compliance `#[tokio::test]` functions for a [`Provider`]
+/// implementation.
+///
+/// Each generated test calls a factory expression (`$factory`) to produce an instance,
+/// then exercises a required contract method to verify the implementation compiles and
+/// returns the expected type.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// provider_compliance_tests!(MyProvider::new());
+/// ```
+#[macro_export]
+macro_rules! provider_compliance_tests {
+    ($factory:expr) => {
+        #[tokio::test]
+        async fn complies_with_capabilities_contract() {
+            let instance = $factory;
+            let caps = instance.capabilities();
+            let _native: bool = caps.native_tool_calling;
+            let _image: bool = caps.image_input;
+        }
 
-/// Placeholder harness type for follow-up compliance testing work.
-#[allow(dead_code)]
-#[derive(Debug, Default, Clone, Copy)]
-pub(crate) struct TraitHarness;
+        #[tokio::test]
+        async fn complies_with_chat_contract() {
+            let instance = $factory;
+            let result = instance
+                .chat_with_system(None, "ping", "test-model", 0.0)
+                .await;
+            assert!(
+                result.is_ok(),
+                "chat_with_system must return Ok: {:?}",
+                result
+            );
+        }
+
+        #[tokio::test]
+        async fn complies_with_streaming_contract() {
+            let instance = $factory;
+            let _supports: bool = instance.supports_streaming();
+        }
+
+        #[tokio::test]
+        async fn complies_with_tool_conversion_contract() {
+            let instance = $factory;
+            let payload = instance.convert_tools(&[]);
+            match payload {
+                $crate::providers::ToolsPayload::Gemini { .. }
+                | $crate::providers::ToolsPayload::Anthropic { .. }
+                | $crate::providers::ToolsPayload::OpenAI { .. }
+                | $crate::providers::ToolsPayload::PromptGuided { .. } => {}
+            }
+        }
+    };
+}
+
+/// Generates contract-compliance `#[tokio::test]` functions for a [`Tool`] implementation.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// tool_compliance_tests!(MyTool::new());
+/// ```
+#[macro_export]
+macro_rules! tool_compliance_tests {
+    ($factory:expr) => {
+        #[tokio::test]
+        async fn complies_with_name_contract() {
+            let instance = $factory;
+            assert!(!instance.name().is_empty(), "name() must be non-empty");
+        }
+
+        #[tokio::test]
+        async fn complies_with_description_contract() {
+            let instance = $factory;
+            assert!(
+                !instance.description().is_empty(),
+                "description() must be non-empty"
+            );
+        }
+
+        #[tokio::test]
+        async fn complies_with_execute_contract() {
+            let instance = $factory;
+            let result = instance.execute(serde_json::json!({})).await;
+            assert!(result.is_ok(), "execute must return Ok: {:?}", result);
+        }
+    };
+}
+
+/// Generates contract-compliance `#[tokio::test]` functions for a [`Memory`] implementation.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// memory_compliance_tests!(MyMemory::new());
+/// ```
+#[macro_export]
+macro_rules! memory_compliance_tests {
+    ($factory:expr) => {
+        #[tokio::test]
+        async fn complies_with_name_contract() {
+            let instance = $factory;
+            assert!(!instance.name().is_empty(), "name() must be non-empty");
+        }
+
+        #[tokio::test]
+        async fn complies_with_health_check_contract() {
+            let instance = $factory;
+            let _healthy: bool = instance.health_check().await;
+        }
+
+        #[tokio::test]
+        async fn complies_with_count_contract() {
+            let instance = $factory;
+            let result = instance.count().await;
+            assert!(result.is_ok(), "count() must return Ok: {:?}", result);
+        }
+    };
+}
+
+/// Generates contract-compliance `#[tokio::test]` functions for a [`Channel`] implementation.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// channel_compliance_tests!(MyChannel::new());
+/// ```
+#[macro_export]
+macro_rules! channel_compliance_tests {
+    ($factory:expr) => {
+        #[tokio::test]
+        async fn complies_with_name_contract() {
+            let instance = $factory;
+            assert!(!instance.name().is_empty(), "name() must be non-empty");
+        }
+
+        #[tokio::test]
+        async fn complies_with_health_check_contract() {
+            let instance = $factory;
+            let _healthy: bool = instance.health_check().await;
+        }
+    };
+}
+
+/// Generates contract-compliance `#[test]` functions for a [`Sandbox`] implementation.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// sandbox_compliance_tests!(MySandbox::new());
+/// ```
+#[macro_export]
+macro_rules! sandbox_compliance_tests {
+    ($factory:expr) => {
+        #[test]
+        fn complies_with_name_contract() {
+            let instance = $factory;
+            assert!(!instance.name().is_empty(), "name() must be non-empty");
+        }
+
+        #[test]
+        fn complies_with_availability_contract() {
+            let instance = $factory;
+            let _available: bool = instance.is_available();
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::channels::{Channel, ChannelMessage, SendMessage};
+    use super::super::memory::{Memory, MemoryCategory, MemoryEntry};
+    use super::super::providers::{Provider, ProviderCapabilities};
+    use super::super::security::Sandbox;
+    use super::super::tools::{Tool, ToolResult};
+    use async_trait::async_trait;
+
+    // -------------------------------------------------------------------------
+    // Stub implementations
+    // -------------------------------------------------------------------------
+
+    struct StubProvider;
+
+    #[async_trait]
+    impl Provider for StubProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            Ok("stub".into())
+        }
+    }
+
+    struct StubTool;
+
+    #[async_trait]
+    impl Tool for StubTool {
+        fn name(&self) -> &str {
+            "stub"
+        }
+
+        fn description(&self) -> &str {
+            "stub tool"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}})
+        }
+
+        async fn execute(&self, _args: serde_json::Value) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                success: true,
+                output: "stub".into(),
+                error: None,
+                structured: None,
+            })
+        }
+    }
+
+    struct StubMemory;
+
+    #[async_trait]
+    impl Memory for StubMemory {
+        fn name(&self) -> &str {
+            "stub"
+        }
+
+        async fn store(
+            &self,
+            _key: &str,
+            _content: &str,
+            _category: MemoryCategory,
+            _session_id: Option<&str>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn recall(
+            &self,
+            _query: &str,
+            _limit: usize,
+            _session_id: Option<&str>,
+        ) -> anyhow::Result<Vec<MemoryEntry>> {
+            Ok(vec![])
+        }
+
+        async fn get(&self, _key: &str) -> anyhow::Result<Option<MemoryEntry>> {
+            Ok(None)
+        }
+
+        async fn list(
+            &self,
+            _category: Option<&MemoryCategory>,
+            _session_id: Option<&str>,
+        ) -> anyhow::Result<Vec<MemoryEntry>> {
+            Ok(vec![])
+        }
+
+        async fn forget(&self, _key: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+
+        async fn count(&self) -> anyhow::Result<usize> {
+            Ok(0)
+        }
+
+        async fn health_check(&self) -> bool {
+            true
+        }
+    }
+
+    struct StubChannel;
+
+    #[async_trait]
+    impl Channel for StubChannel {
+        fn name(&self) -> &str {
+            "stub"
+        }
+
+        async fn send(&self, _message: &SendMessage) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn listen(
+            &self,
+            _tx: tokio::sync::mpsc::Sender<ChannelMessage>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct StubSandbox;
+
+    impl Sandbox for StubSandbox {
+        fn wrap_command(&self, _cmd: &mut std::process::Command) -> std::io::Result<()> {
+            Ok(())
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        fn name(&self) -> &str {
+            "stub"
+        }
+
+        fn description(&self) -> &str {
+            "stub sandbox"
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Macro invocations — each macro generates its compliance test functions.
+    // Name collisions are avoided by invoking each macro in its own submodule.
+    // -------------------------------------------------------------------------
+
+    mod provider_compliance {
+        use super::*;
+        provider_compliance_tests!(StubProvider);
+    }
+
+    mod tool_compliance {
+        use super::*;
+        tool_compliance_tests!(StubTool);
+    }
+
+    mod memory_compliance {
+        use super::*;
+        memory_compliance_tests!(StubMemory);
+    }
+
+    mod channel_compliance {
+        use super::*;
+        channel_compliance_tests!(StubChannel);
+    }
+
+    mod sandbox_compliance {
+        use super::*;
+        sandbox_compliance_tests!(StubSandbox);
+    }
+
+    // -------------------------------------------------------------------------
+    // Sanity check: ProviderCapabilities fields are accessible
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn provider_capabilities_has_expected_fields() {
+        let caps = ProviderCapabilities::default();
+        let _native: bool = caps.native_tool_calling;
+        let _image: bool = caps.image_input;
+    }
+}


### PR DESCRIPTION
## Related Issues

Closes DALLAY-264

---

## Summary

Phase 5A introduces the trait compliance test harness for the capability-based architecture. This PR delivers:

1. **Five `#[macro_export]` compliance macros** in `crates/corvus-traits/src/testing.rs`, replacing the 6-line `TraitHarness` placeholder:
   - `provider_compliance_tests!` — validates `capabilities()`, `chat_with_system()`, `supports_streaming()`, `convert_tools()`
   - `tool_compliance_tests!` — validates `name()`, `description()`, `execute()`
   - `memory_compliance_tests!` — validates `name()`, `health_check()`, `count()`
   - `channel_compliance_tests!` — validates `name()`, `health_check()`
   - `sandbox_compliance_tests!` — validates `name()`, `is_available()`

   Each macro takes a factory expression and generates standard test functions. Self-validation tests using stub implementations are included in `#[cfg(test)]`.

2. **`pub mod testing`** — the `testing` module is now public so capability crates (`corvus-providers`, `corvus-channels`, etc.) can import and use the macros.

3. **Six differential tests** in `crates/corvus-composer/src/lib.rs` that validate `AgentComposer::required_capabilities()` is consistent with each manifest section (providers, channels, tools, memory presence/absence).

---

## Tested Information

```
cargo fmt --manifest-path clients/agent-runtime/Cargo.toml --all
cargo clippy --manifest-path clients/agent-runtime/Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path clients/agent-runtime/Cargo.toml --lib
```

Results:
- `corvus-traits`: 22 → 37 tests (15 new: 5 macros × 3 self-tests each)
- `corvus-composer`: 8 → 14 tests (6 new differential tests)
- Main runtime: 3493 tests — all passing, no regressions

---

## Documentation Impact

- No docs update required because this is a test harness — the macros are developer tooling for future capability crate authors. The `docs/composing-agents.md` added in Phase 5B covers the user-facing documentation.
- I verified the documentation matches the current behavior.

---

## Breaking Changes

None. The `testing` module visibility change (`mod` → `pub mod`) is additive — no existing code referenced the private module.

---

## Checklist

- [x] I have checked that there isn't already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
