### PR TITLE
fix(security): prevent path validation bypass via command flags

### DIFF
--- a/.agents/journal/sentinnel-journal.md
+++ b/.agents/journal/sentinnel-journal.md
@@ -16,3 +16,8 @@
 2. ✅ Enforced exact command matching in `is_segment_valid` to block `./cmd` bypasses.
 3. ✅ Validated path-like command arguments against path traversal and forbidden path rules.
 4. ✅ Expanded `contains_blocked_operators` to include backslash; glob chars blocked in `is_segment_valid`.
+
+## 2025-05-20 - Flag-based Path Validation Hardening
+
+**Learning:** The `SecurityPolicy` was vulnerable to path validation bypass when absolute paths or traversal sequences were passed within command flags (e.g., `grep --file=/etc/passwd` or `git -C/etc status`). The argument validation loop was only checking standalone arguments and not extracting values from flag assignments.
+**Action:** Updated the argument validation loop in `is_segment_valid` to extract and validate potential paths from flags (`--key=value` and `-Cvalue`). This ensures that security checks (traversal, workspace bounds, forbidden paths) are applied consistently to all path-like inputs, even when embedded in flags.

--- a/clients/agent-runtime/src/security/policy.rs
+++ b/clients/agent-runtime/src/security/policy.rs
@@ -432,20 +432,33 @@ impl SecurityPolicy {
         // We only check arguments that look like paths to avoid false positives
         // on non-path tokens (e.g., git diff patterns, grep globs, brace literals).
         for (_raw_arg, arg) in raw_args.iter().zip(normalized_args.iter()) {
-            if !is_likely_path(arg) {
+            // Extract potential path from flags (e.g. --file=/path or -C/path)
+            let effective_arg = if arg.starts_with("--") {
+                arg.split_once('=').map(|(_, v)| v).unwrap_or(arg)
+            } else if arg.starts_with('-') && arg.len() > 2 {
+                arg.char_indices()
+                    .nth(2)
+                    .map(|(idx, _)| &arg[idx..])
+                    .unwrap_or("")
+            } else {
+                arg
+            };
+
+            if !is_likely_path(effective_arg) {
                 continue;
             }
 
-            if Path::new(arg)
+            if Path::new(effective_arg)
                 .components()
                 .any(|c| matches!(c, std::path::Component::ParentDir))
-                || (self.workspace_only && (arg.starts_with('/') || arg.starts_with('~')))
+                || (self.workspace_only
+                    && (effective_arg.starts_with('/') || effective_arg.starts_with('~')))
             {
                 return false;
             }
 
             // Check against forbidden paths (e.g. /etc, ~/.ssh)
-            if matches_any_forbidden_path(arg, &self.forbidden_paths) {
+            if matches_any_forbidden_path(effective_arg, &self.forbidden_paths) {
                 return false;
             }
         }
@@ -1913,4 +1926,22 @@ mod tests {
             "Read must always be allowed regardless of autonomy level"
         );
     }
+}
+
+#[test]
+fn is_command_allowed_blocks_path_in_flags() {
+    let mut p = SecurityPolicy::default();
+    p.workspace_only = true;
+    p.allowed_commands = vec!["grep".into()];
+    p.forbidden_paths = vec!["/etc".into()];
+
+    // Case 1: Standalone absolute path - Should be BLOCKED (currently passes test)
+    assert!(!p.is_command_allowed("grep pattern /etc/passwd"));
+
+    // Case 2: Path in flag - CURRENTLY BYPASSES (this test should fail if my hypothesis is correct)
+    assert!(!p.is_command_allowed("grep --file=/etc/passwd pattern"), "Should block absolute path in flag");
+
+    // Case 3: git -C/etc status - CURRENTLY BYPASSES
+    p.allowed_commands.push("git".into());
+    assert!(!p.is_command_allowed("git -C/etc status"), "Should block absolute path in short flag");
 }


### PR DESCRIPTION
This PR hardens the `SecurityPolicy` in the Rust agent runtime to prevent bypasses where absolute paths or traversal sequences are passed as values within command-line flags.

Previously, the argument validation loop only scrutinized standalone arguments, allowing payloads like `grep --file=/etc/passwd` or `git -C/etc status` to bypass workspace and forbidden path checks.

Changes:
- Updated `is_segment_valid` to extract potential path values from long flags (`--key=value`) and short flags (`-Xvalue`).
- Hardened string slicing for short flag extraction using `char_indices` to prevent panics on multi-byte UTF-8 characters.
- Added a regression test `is_command_allowed_blocks_path_in_flags` covering various bypass scenarios.
- Updated `.agents/journal/sentinnel-journal.md` with the discovery and mitigation.

Security Impact:
- Risk reduced: Unauthorized file access/read via flag-based path injection.
- Attack surface: Narrowed by consistently applying path validation to all command arguments.

Performance Impact:
- Negligible: Involves O(1) string slicing and a single-pass search for '=' per argument.

---
*PR created automatically by Jules for task [14289455833197750325](https://jules.google.com/task/14289455833197750325) started by @yacosta738*