### PR TITLE
ci: update dallay/common-actions to v1.2.0

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   cleanup:
-    uses: dallay/common-actions/.github/workflows/cleanup-cache.yml@e77aee209c07cd031e1fc6a3f275df774b4685a2 # v1.1.0
+    uses: dallay/common-actions/.github/workflows/cleanup-cache.yml@0f8de7c46309882e873a878e1fcc636bf56ad586 # v1.2.0
     secrets: inherit

--- a/.github/workflows/contributor-report.yml
+++ b/.github/workflows/contributor-report.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   report:
-    uses: dallay/common-actions/.github/workflows/contributor-report.yml@e77aee209c07cd031e1fc6a3f275df774b4685a2 # v1.1.0
+    uses: dallay/common-actions/.github/workflows/contributor-report.yml@0f8de7c46309882e873a878e1fcc636bf56ad586 # v1.2.0
     with:
       trusted-users: dependabot[bot],renovate[bot],github-copilot[bot],github-actions[bot],codecov[bot],sonarcloud[bot],dallay-bot[bot]
     secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -9,5 +9,5 @@ permissions:
 
 jobs:
   greet:
-    uses: dallay/common-actions/.github/workflows/greetings.yml@e77aee209c07cd031e1fc6a3f275df774b4685a2 # v1.1.0
+    uses: dallay/common-actions/.github/workflows/greetings.yml@0f8de7c46309882e873a878e1fcc636bf56ad586 # v1.2.0
     secrets: inherit

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   label:
-    uses: dallay/common-actions/.github/workflows/pr-size-labeler.yml@e77aee209c07cd031e1fc6a3f275df774b4685a2 # v1.1.0
+    uses: dallay/common-actions/.github/workflows/pr-size-labeler.yml@0f8de7c46309882e873a878e1fcc636bf56ad586 # v1.2.0
     secrets: inherit

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   lint:
-    uses: dallay/common-actions/.github/workflows/semantic-pr.yml@e77aee209c07cd031e1fc6a3f275df774b4685a2 # v1.1.0
+    uses: dallay/common-actions/.github/workflows/semantic-pr.yml@0f8de7c46309882e873a878e1fcc636bf56ad586 # v1.2.0
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   stale:
-    uses: dallay/common-actions/.github/workflows/stale.yml@e77aee209c07cd031e1fc6a3f275df774b4685a2 # v1.1.0
+    uses: dallay/common-actions/.github/workflows/stale.yml@0f8de7c46309882e873a878e1fcc636bf56ad586 # v1.2.0
     secrets: inherit


### PR DESCRIPTION
Update shared workflow references to v1.2.0 by pinning to the latest SHA. This fixes the 'failed to fetch workflow' error for pr-size-labeler.yml.

Modified workflows:
- cleanup-cache.yml
- contributor-report.yml
- greetings.yml
- pr-size-labeler.yml
- semantic-pull-request.yml
- stale.yml

---
*PR created automatically by Jules for task [14789540126710815356](https://jules.google.com/task/14789540126710815356) started by @yacosta738*