### PR TITLE
docs: update CLI reference for new agent-runtime commands and flags

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -90,3 +90,15 @@ All three identified issues have been fixed:
 ### Notes
 - Glossary: "Firejail" = Linux user-space sandbox (confirmed implemented). "Landlock" = Linux kernel-level sandbox (confirmed). "Cerebro" = standalone MCP memory service in `modules/cerebro/` (confirmed).
 - Remaining gap: `cost` command subcommands (`summary`, `history`, `reset`) exist in code but are not yet in the CLI reference doc. Low priority.
+
+## 2026-04-15 - CLI Reference Update - Complete
+
+**Verification:** Verified `clients/agent-runtime/src/main.rs` for `code` and `cost` command implementations.
+**Changes:**
+- Updated `guides/cli-reference.md` and `es/guides/cli-reference.md`.
+- Added `code` command documentation.
+- Added `cost` command documentation with `summary`, `history`, and `reset` subcommands.
+- Updated `agent` command with new flags (`--override-budget`, `--plan`) and subcommands (`build`, `run`, `new`).
+- Removed deprecated `surreal-graphs` and `surreal` memory backends from `onboard` command.
+**Validation:** Results of `make docs-check` and `make docs-build` passed (80 pages built).
+**Notes:** Bilingual parity maintained for all changes.

--- a/clients/web/apps/docs/src/content/docs/es/guides/cli-reference.md
+++ b/clients/web/apps/docs/src/content/docs/es/guides/cli-reference.md
@@ -21,7 +21,7 @@ Inicializa tu espacio de trabajo y configuración.
 - `--channels-only`: Reconfigura solo los canales.
 - `--api-key <KEY>`: Clave de API para configuración rápida.
 - `--provider <NAME>`: Nombre del proveedor (por defecto: openrouter).
-- `--memory <TYPE>`: Backend de memoria (sqlite, lucid, surreal-graphs, surreal, markdown, none).
+- `--memory <TYPE>`: Backend de memoria (sqlite, lucid, markdown, none).
 
 **Ejemplo:**
 
@@ -31,18 +31,45 @@ corvus onboard --interactive
 
 ### `agent`
 
-Inicia el bucle del agente de IA.
+Inicia el bucle del agente de IA (o compone desde el manifiesto).
 
-- `-m, --message <TEXT>`: Modo de mensaje único.
-- `-p, --provider <NAME>`: Proveedor a utilizar.
+- `-m, --message <TEXT>`: Modo de mensaje único (no entra en modo interactivo).
+- `-p, --provider <NAME>`: Proveedor a utilizar (openrouter, anthropic, openai, openai-codex).
 - `--model <MODEL>`: Modelo específico a utilizar.
-- `-t, --temperature <VALUE>`: Temperatura (0.0 - 2.0).
+- `-t, --temperature <VALUE>`: Temperatura (0.0 - 2.0, por defecto: 0.7).
 - `--peripheral <BOARD:PATH>`: Conecta un periférico (ej., `nucleo-f401re:/dev/ttyACM0`).
+- `--override-budget`: Permite exactamente una solicitud por encima del presupuesto para esta sesión de la CLI.
+- `--plan`: Ejecuta el turno en modo de plan (ejecución de herramientas solo para análisis).
+
+**Subcomandos:**
+
+- `build --manifest <PATH>`: Construye un agente desde un archivo de manifiesto TOML.
+  - `--output <DIR>`: Directorio de salida para el agente compilado.
+- `run --manifest <PATH>`: Ejecuta un agente directamente desde un manifiesto (composición en tiempo de arranque).
+- `new --template <NAME> --name <NAME>`: Crea un nuevo agente desde una plantilla.
+  - `--output <DIR>`: Directorio de salida (opcional).
 
 **Ejemplo:**
 
 ```bash
 corvus agent -m "Hola, ¿cómo puedes ayudarme hoy?"
+```
+
+### `code`
+
+Ejecuta una sesión de especialista en código (inspeccionar, planificar, editar, verificar, informar).
+
+- `-m, --message <TEXT>`: Descripción de la tarea o instrucción para la sesión de código.
+- `-p, --provider <NAME>`: Proveedor a utilizar (openrouter, anthropic, openai).
+- `--model <MODEL>`: Modelo específico a utilizar.
+- `-t, --temperature <VALUE>`: Temperatura (0.0 - 2.0, por defecto: 0.7).
+- `--override-budget`: Permite exactamente una solicitud por encima del presupuesto para esta sesión de la CLI.
+- `--plan`: Ejecuta la sesión en modo de plan (ejecución de herramientas solo para análisis).
+
+**Ejemplo:**
+
+```bash
+corvus code -m "Corrige el error en el módulo de autenticación"
 ```
 
 ### `daemon`
@@ -328,4 +355,22 @@ Administrar actualizaciones del runtime.
 
 ```bash
 corvus update check
+```
+
+### `cost`
+
+Inspecciona y gestiona el estado de costos del runtime.
+
+- `summary`: Muestra el resumen de costos actual (sesión, diario, mensual).
+- `history`: Muestra el historial de costos agregados.
+  - `--period <PERIOD>`: Período de agregación (session, day, month).
+  - `--window <SIZE>`: Número de bloques a incluir (por defecto: 30).
+- `reset`: Restablece los costos rastreados para un alcance específico.
+  - `--scope <SCOPE>`: Alcance del restablecimiento (session, day, month).
+  - `--reason <TEXT>`: Motivo opcional registrado en el historial de auditoría de costos.
+
+**Ejemplo:**
+
+```bash
+corvus cost summary
 ```

--- a/clients/web/apps/docs/src/content/docs/guides/cli-reference.md
+++ b/clients/web/apps/docs/src/content/docs/guides/cli-reference.md
@@ -20,7 +20,7 @@ Initialize your workspace and configuration.
 - `--channels-only`: Reconfigure channels only.
 - `--api-key <KEY>`: API key for quick setup.
 - `--provider <NAME>`: Provider name (default: openrouter).
-- `--memory <TYPE>`: Memory backend (sqlite, lucid, surreal-graphs, surreal, markdown, none).
+- `--memory <TYPE>`: Memory backend (sqlite, lucid, markdown, none).
 
 When using `--interactive`, the wizard now ends with an optional dashboard step:
 
@@ -37,18 +37,45 @@ corvus onboard --interactive
 
 ### `agent`
 
-Start the AI agent loop.
+Start the AI agent loop (or compose from manifest).
 
-- `-m, --message <TEXT>`: Single message mode.
-- `-p, --provider <NAME>`: Provider to use.
+- `-m, --message <TEXT>`: Single message mode (don't enter interactive mode).
+- `-p, --provider <NAME>`: Provider to use (openrouter, anthropic, openai, openai-codex).
 - `--model <MODEL>`: Specific model to use.
-- `-t, --temperature <VALUE>`: Temperature (0.0 - 2.0).
+- `-t, --temperature <VALUE>`: Temperature (0.0 - 2.0, default: 0.7).
 - `--peripheral <BOARD:PATH>`: Attach a peripheral (e.g., `nucleo-f401re:/dev/ttyACM0`).
+- `--override-budget`: Allow exactly one over-budget request for this CLI session.
+- `--plan`: Run the turn in plan mode (analysis-only tool execution).
+
+**Subcommands:**
+
+- `build --manifest <PATH>`: Build an agent from a manifest TOML file.
+  - `--output <DIR>`: Output directory for compiled agent.
+- `run --manifest <PATH>`: Run an agent directly from a manifest (boot-time composition).
+- `new --template <NAME> --name <NAME>`: Create a new agent from a template.
+  - `--output <DIR>`: Output directory (optional).
 
 **Example:**
 
 ```bash
 corvus agent -m "Hello, how can you help me today?"
+```
+
+### `code`
+
+Run a code-specialist session (inspect, plan, edit, verify, report).
+
+- `-m, --message <TEXT>`: Task description or instruction for the code session.
+- `-p, --provider <NAME>`: Provider to use (openrouter, anthropic, openai).
+- `--model <MODEL>`: Specific model to use.
+- `-t, --temperature <VALUE>`: Temperature (0.0 - 2.0, default: 0.7).
+- `--override-budget`: Allow exactly one over-budget request for this CLI session.
+- `--plan`: Run the session in plan mode (analysis-only tool execution).
+
+**Example:**
+
+```bash
+corvus code -m "Fix the bug in the authentication module"
 ```
 
 ### `daemon`
@@ -350,4 +377,22 @@ Manage runtime updates.
 
 ```bash
 corvus update check
+```
+
+### `cost`
+
+Inspect and manage runtime cost state.
+
+- `summary`: Show the current cost summary (session, daily, monthly).
+- `history`: Show aggregated cost history.
+  - `--period <PERIOD>`: Aggregation period (session, day, month).
+  - `--window <SIZE>`: Number of buckets to include (default: 30).
+- `reset`: Reset tracked costs for a specific scope.
+  - `--scope <SCOPE>`: Reset scope (session, day, month).
+  - `--reason <TEXT>`: Optional reason recorded in cost audit history.
+
+**Example:**
+
+```bash
+corvus cost summary
 ```


### PR DESCRIPTION
Synchronized the CLI reference documentation with the current state of the agent-runtime. Added documentation for 'code' and 'cost' commands, updated 'agent' command with new flags and subcommands, and removed obsolete 'surreal' memory backend references. Maintained 1:1 bilingual parity between English and Spanish versions.

---
*PR created automatically by Jules for task [17053585770502547444](https://jules.google.com/task/17053585770502547444) started by @yacosta738*