### PR TITLE
feat(agent-runtime): unify slash command transport handling (#541)

### DIFF
--- a/clients/agent-runtime/src/channels/mod.rs
+++ b/clients/agent-runtime/src/channels/mod.rs
@@ -1878,7 +1878,7 @@ async fn handle_ingress_outcome(
     );
 
     match crate::pre_execution::adapt_handled_ingress(
-        crate::pre_execution::evaluate_ingress(memory, ingress_context, content).await,
+        crate::pre_execution::evaluate_ingress(memory, ingress_context, content, true).await,
     ) {
         crate::pre_execution::HandledIngress::Handled(
             crate::pre_execution::HandledIngressOutcome::SessionCommandSuccess(success),

--- a/clients/agent-runtime/src/channels/mod.rs
+++ b/clients/agent-runtime/src/channels/mod.rs
@@ -1877,18 +1877,35 @@ async fn handle_ingress_outcome(
         caller_scope,
     );
 
-    match crate::pre_execution::evaluate_ingress(memory, ingress_context, content).await {
-        crate::pre_execution::IngressDecision::SessionCommand { outcome } => {
-            let message = match outcome {
-                crate::session_commands::SessionCommandOutcome::Success(success) => success.message,
-                crate::session_commands::SessionCommandOutcome::Failure(failure) => failure.message,
-            };
+    match crate::pre_execution::adapt_handled_ingress(
+        crate::pre_execution::evaluate_ingress(memory, ingress_context, content).await,
+    ) {
+        crate::pre_execution::HandledIngress::Handled(
+            crate::pre_execution::HandledIngressOutcome::SessionCommandSuccess(success),
+        ) => {
             if let Some(ch) = channel {
-                let _ = ch.send(&SendMessage::new(message, reply_target)).await;
+                let _ = ch
+                    .send(&SendMessage::new(success.message, reply_target))
+                    .await;
             }
             Some(())
         }
-        crate::pre_execution::IngressDecision::Blocking(blocking) => {
+        crate::pre_execution::HandledIngress::Handled(
+            crate::pre_execution::HandledIngressOutcome::SessionCommandFailure {
+                class: _,
+                failure,
+            },
+        ) => {
+            if let Some(ch) = channel {
+                let _ = ch
+                    .send(&SendMessage::new(failure.message, reply_target))
+                    .await;
+            }
+            Some(())
+        }
+        crate::pre_execution::HandledIngress::Handled(
+            crate::pre_execution::HandledIngressOutcome::Blocking(blocking),
+        ) => {
             if let Some(ch) = channel {
                 let text = match blocking {
                     crate::pre_execution::BlockingOutcome::ApprovalRequired { tool, .. } => {
@@ -1907,7 +1924,7 @@ async fn handle_ingress_outcome(
             }
             Some(())
         }
-        crate::pre_execution::IngressDecision::Continue => None,
+        crate::pre_execution::HandledIngress::NotHandled => None,
     }
 }
 
@@ -3231,6 +3248,47 @@ mod tests {
         }
     }
 
+    fn channel_caller_scope(channel_name: &str, sender: &str) -> String {
+        use sha2::{Digest, Sha256};
+
+        let mut hasher = Sha256::new();
+        hasher.update(channel_name.as_bytes());
+        hasher.update(b":");
+        hasher.update(sender.as_bytes());
+        hex::encode(hasher.finalize())
+    }
+
+    async fn seed_resumable_session(memory: &SqliteMemory, session_id: &str, token_hash: &str) {
+        memory
+            .upsert_session(session_id, Some(token_hash))
+            .await
+            .unwrap();
+        let snapshot = memory
+            .create_session_snapshot(
+                session_id,
+                crate::memory::SessionSnapshotKind::Compact,
+                serde_json::json!({
+                    "preview": "resume me",
+                    "summary": "resume me",
+                    "resume_context": "resume me",
+                }),
+                true,
+            )
+            .await
+            .unwrap();
+        memory
+            .apply_session_state_patch(crate::memory::SessionStatePatch {
+                session_id: session_id.to_string(),
+                lifecycle: Some(crate::memory::SlashSessionLifecycle::Suspended),
+                latest_tldr_snapshot_id: crate::memory::SessionFieldPatch::Keep,
+                latest_compact_snapshot_id: crate::memory::SessionFieldPatch::Set(snapshot.id),
+                pending_hydration_snapshot_id: crate::memory::SessionFieldPatch::Clear,
+                suspended_at: crate::memory::SessionFieldPatch::Set("now".to_string()),
+            })
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn ingress_outcome_handles_slash_session_commands_before_memory_enrichment() {
         let channel = Arc::new(RecordingChannel::default());
@@ -3310,6 +3368,63 @@ mod tests {
         assert_eq!(sent.len(), 1);
         // Should still handle in Plan mode
         assert!(sent[0].contains("require sqlite"));
+    }
+
+    #[tokio::test]
+    async fn ingress_outcome_preserves_resume_success_for_authorized_scope() {
+        let channel = Arc::new(RecordingChannel::default());
+        let channel_dyn: Arc<dyn Channel> = channel.clone();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let memory = SqliteMemory::new(tmp.path()).unwrap();
+        let scope = channel_caller_scope(channel_dyn.name(), "tester");
+        seed_resumable_session(&memory, "session-target", &scope).await;
+
+        let handled = handle_ingress_outcome(
+            Some(&channel_dyn),
+            &memory,
+            "session-control",
+            "tester",
+            "reply-target",
+            "/resume session-target",
+            ExecutionMode::Standard,
+        )
+        .await;
+
+        assert_eq!(handled, Some(()));
+        let sent = channel.sent_messages.lock().await.clone();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(
+            sent[0],
+            "reply-target:[session:session-target] resumed from persisted compact snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn ingress_outcome_preserves_permission_denied_for_resume_target() {
+        let channel = Arc::new(RecordingChannel::default());
+        let channel_dyn: Arc<dyn Channel> = channel.clone();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let memory = SqliteMemory::new(tmp.path()).unwrap();
+        seed_resumable_session(&memory, "session-target", "other-scope").await;
+
+        let handled = handle_ingress_outcome(
+            Some(&channel_dyn),
+            &memory,
+            "session-control",
+            "tester",
+            "reply-target",
+            "/resume session-target",
+            ExecutionMode::Standard,
+        )
+        .await;
+
+        assert_eq!(handled, Some(()));
+        let sent = channel.sent_messages.lock().await.clone();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(
+            sent[0],
+            "reply-target:[session:session-target] permission denied"
+        );
     }
 
     /// Instrumented memory wrapper that counts recall/store invocations for testing.

--- a/clients/agent-runtime/src/gateway/mod.rs
+++ b/clients/agent-runtime/src/gateway/mod.rs
@@ -1775,23 +1775,25 @@ async fn canonical_outcome_early_response(
         caller_token_hash.map(str::to_string),
     );
 
-    match crate::pre_execution::evaluate_ingress(state.mem.as_ref(), context, scrubbed_message)
-        .await
-    {
-        crate::pre_execution::IngressDecision::SessionCommand { outcome } => {
-            if let crate::session_commands::SessionCommandOutcome::Success(success) = outcome {
-                let body = serde_json::json!({
-                    "response": success.message,
-                    "model": state.model,
-                    "session_id": session_id,
-                });
-                return Some(((StatusCode::OK, Json(body)), true));
-            }
-
-            let failure = match outcome {
-                crate::session_commands::SessionCommandOutcome::Failure(failure) => failure,
-                crate::session_commands::SessionCommandOutcome::Success(_) => unreachable!(),
-            };
+    match crate::pre_execution::adapt_handled_ingress(
+        crate::pre_execution::evaluate_ingress(state.mem.as_ref(), context, scrubbed_message).await,
+    ) {
+        crate::pre_execution::HandledIngress::Handled(
+            crate::pre_execution::HandledIngressOutcome::SessionCommandSuccess(success),
+        ) => {
+            let body = serde_json::json!({
+                "response": success.message,
+                "model": state.model,
+                "session_id": session_id,
+            });
+            return Some(((StatusCode::OK, Json(body)), true));
+        }
+        crate::pre_execution::HandledIngress::Handled(
+            crate::pre_execution::HandledIngressOutcome::SessionCommandFailure {
+                class: _,
+                failure,
+            },
+        ) => {
             let error_body = serde_json::json!({
                 "error": {
                     "code": "session_command_failed",
@@ -1801,7 +1803,9 @@ async fn canonical_outcome_early_response(
             });
             return Some(((StatusCode::UNPROCESSABLE_ENTITY, Json(error_body)), false));
         }
-        crate::pre_execution::IngressDecision::Blocking(blocking) => match blocking {
+        crate::pre_execution::HandledIngress::Handled(
+            crate::pre_execution::HandledIngressOutcome::Blocking(blocking),
+        ) => match blocking {
             crate::pre_execution::BlockingOutcome::ApprovalRequired { tool, reason } => {
                 let denial = crate::approval::structured_denial_payload(&tool, &reason);
                 let err = serde_json::json!({
@@ -1830,7 +1834,7 @@ async fn canonical_outcome_early_response(
                 return Some(((StatusCode::OK, Json(body)), true));
             }
         },
-        crate::pre_execution::IngressDecision::Continue => {}
+        crate::pre_execution::HandledIngress::NotHandled => {}
     }
 
     None
@@ -2227,14 +2231,16 @@ async fn handle_chat_stream(
         server_execution_mode,
         token_hash.clone(),
     );
-    let ingress_decision = crate::pre_execution::evaluate_ingress(
-        state.mem.as_ref(),
-        ingress_context,
-        &scrubbed_message,
-    )
-    .await;
+    let handled_ingress = crate::pre_execution::adapt_handled_ingress(
+        crate::pre_execution::evaluate_ingress(
+            state.mem.as_ref(),
+            ingress_context,
+            &scrubbed_message,
+        )
+        .await,
+    );
 
-    if let crate::pre_execution::IngressDecision::SessionCommand { outcome } = &ingress_decision {
+    if let crate::pre_execution::HandledIngress::Handled(handled) = &handled_ingress {
         // Update session activity before returning early
         if let Err(e) = state
             .mem
@@ -2245,44 +2251,100 @@ async fn handle_chat_stream(
         }
 
         let sid = session_id.clone();
-        let events: Vec<Result<Event, std::convert::Infallible>> =
-            if let crate::session_commands::SessionCommandOutcome::Success(success) = outcome {
-                let message_id = Uuid::new_v4().to_string();
-                vec![
-                    Ok(Event::default()
-                        .event("chunk")
-                        .data(success.message.clone())),
-                    Ok(Event::default()
-                        .event("done")
-                        .json_data(serde_json::json!({
-                            "message_id": message_id,
-                            "session_id": sid,
-                            "tools_called": [],
-                        }))
-                        .expect("serializable done event")),
-                ]
-            } else {
-                let failure = match outcome {
-                    crate::session_commands::SessionCommandOutcome::Failure(failure) => failure,
-                    crate::session_commands::SessionCommandOutcome::Success(_) => unreachable!(),
-                };
-                vec![Ok(Event::default()
-                    .event("error")
-                    .json_data(serde_json::json!({
-                        "code": "session_command_failed",
-                        "message": failure.message,
-                    }))
-                    .expect("serializable error event"))]
+        let (events, status) =
+            match handled {
+                crate::pre_execution::HandledIngressOutcome::SessionCommandSuccess(success) => {
+                    let message_id = Uuid::new_v4().to_string();
+                    (
+                        vec![
+                            Ok::<Event, std::convert::Infallible>(
+                                Event::default()
+                                    .event("chunk")
+                                    .data(success.message.clone()),
+                            ),
+                            Ok::<Event, std::convert::Infallible>(
+                                Event::default()
+                                    .event("done")
+                                    .json_data(serde_json::json!({
+                                        "message_id": message_id,
+                                        "session_id": sid,
+                                        "tools_called": [],
+                                    }))
+                                    .expect("serializable done event"),
+                            ),
+                        ],
+                        StatusCode::OK,
+                    )
+                }
+                crate::pre_execution::HandledIngressOutcome::SessionCommandFailure {
+                    class: _,
+                    failure,
+                } => (
+                    vec![Ok::<Event, std::convert::Infallible>(
+                        Event::default()
+                            .event("error")
+                            .json_data(serde_json::json!({
+                                "code": "session_command_failed",
+                                "message": failure.message,
+                            }))
+                            .expect("serializable error event"),
+                    )],
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                ),
+                crate::pre_execution::HandledIngressOutcome::Blocking(blocking) => match blocking {
+                    crate::pre_execution::BlockingOutcome::ApprovalRequired { tool, reason } => (
+                        vec![Ok::<Event, std::convert::Infallible>(Event::default()
+                            .event("error")
+                            .json_data(serde_json::json!({
+                                "code": "approval_required",
+                                "tool": tool,
+                                "reason": reason,
+                                "message": format!("Approval required for tool `{tool}`: {reason}"),
+                            }))
+                            .expect("serializable error event"))],
+                        StatusCode::FORBIDDEN,
+                    ),
+                    crate::pre_execution::BlockingOutcome::TimeoutAborted => (
+                        vec![Ok::<Event, std::convert::Infallible>(
+                            Event::default()
+                                .event("error")
+                                .json_data(serde_json::json!({
+                                    "code": "timeout",
+                                    "message": "Request timed out",
+                                }))
+                                .expect("serializable error event"),
+                        )],
+                        StatusCode::REQUEST_TIMEOUT,
+                    ),
+                    crate::pre_execution::BlockingOutcome::Fallback { response } => {
+                        let message_id = Uuid::new_v4().to_string();
+                        (
+                            vec![
+                                Ok::<Event, std::convert::Infallible>(
+                                    Event::default()
+                                        .event("chunk")
+                                        .data(scrub_sensitive_boundary_text(response)),
+                                ),
+                                Ok::<Event, std::convert::Infallible>(
+                                    Event::default()
+                                        .event("done")
+                                        .json_data(serde_json::json!({
+                                            "message_id": message_id,
+                                            "session_id": sid,
+                                            "tools_called": [],
+                                        }))
+                                        .expect("serializable done event"),
+                                ),
+                            ],
+                            StatusCode::OK,
+                        )
+                    }
+                },
             };
         let mut response = Sse::new(futures::stream::iter(events))
             .keep_alive(KeepAlive::default())
             .into_response();
-        if matches!(
-            outcome,
-            crate::session_commands::SessionCommandOutcome::Failure(_)
-        ) {
-            *response.status_mut() = StatusCode::UNPROCESSABLE_ENTITY;
-        }
+        *response.status_mut() = status;
         return Ok(response);
     }
 
@@ -2402,7 +2464,10 @@ async fn handle_chat_stream(
                 "code": "cost_governance_requires_dispatcher",
                 "message": "Cost governance requires the webhook dispatcher path when cost.enabled=true",
             }))
-        } else if let crate::pre_execution::IngressDecision::Blocking(blocking) = ingress_decision {
+        } else if let crate::pre_execution::HandledIngress::Handled(
+            crate::pre_execution::HandledIngressOutcome::Blocking(blocking),
+        ) = &handled_ingress
+        {
             let payload = match blocking {
                 crate::pre_execution::BlockingOutcome::ApprovalRequired { tool, reason } => {
                     serde_json::json!({
@@ -2430,7 +2495,7 @@ async fn handle_chat_stream(
                         Ok::<Event, std::convert::Infallible>(
                             Event::default()
                                 .event("chunk")
-                                .data(scrub_sensitive_boundary_text(&response)),
+                                .data(scrub_sensitive_boundary_text(response)),
                         ),
                         Ok::<Event, std::convert::Infallible>(
                             Event::default()
@@ -3986,6 +4051,41 @@ mod tests {
         }
     }
 
+    async fn seed_resumable_session(
+        memory: &crate::memory::SqliteMemory,
+        session_id: &str,
+        token_hash: &str,
+    ) {
+        memory
+            .upsert_session(session_id, Some(token_hash))
+            .await
+            .unwrap();
+        let snapshot = memory
+            .create_session_snapshot(
+                session_id,
+                crate::memory::SessionSnapshotKind::Compact,
+                serde_json::json!({
+                    "preview": "resume me",
+                    "summary": "resume me",
+                    "resume_context": "resume me",
+                }),
+                true,
+            )
+            .await
+            .unwrap();
+        memory
+            .apply_session_state_patch(crate::memory::SessionStatePatch {
+                session_id: session_id.to_string(),
+                lifecycle: Some(crate::memory::SlashSessionLifecycle::Suspended),
+                latest_tldr_snapshot_id: crate::memory::SessionFieldPatch::Keep,
+                latest_compact_snapshot_id: crate::memory::SessionFieldPatch::Set(snapshot.id),
+                pending_hydration_snapshot_id: crate::memory::SessionFieldPatch::Clear,
+                suspended_at: crate::memory::SessionFieldPatch::Set("now".to_string()),
+            })
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn canonical_outcome_early_response_intercepts_slash_session_commands() {
         // Use SqliteMemory to test real slash-session behavior with actual storage
@@ -4062,6 +4162,101 @@ mod tests {
         .await;
 
         assert!(response.is_none());
+    }
+
+    #[tokio::test]
+    async fn canonical_outcome_early_response_preserves_resume_success_for_authorized_scope() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mem = Arc::new(crate::memory::SqliteMemory::new(tmp.path()).unwrap());
+        seed_resumable_session(mem.as_ref(), "session-target", "caller-hash").await;
+
+        let state = AppState {
+            config: Arc::new(Mutex::new(Config::default())),
+            cost_tracker: None,
+            provider: Arc::new(MockProvider::default()),
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: mem.clone() as Arc<dyn crate::memory::Memory>,
+            auto_save: true,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            channel_runtime_handle: None,
+            observer: Arc::new(crate::observability::NoopObserver),
+            transcriber: None,
+            audio_config: crate::config::AudioConfig::default(),
+        };
+
+        let response = canonical_outcome_early_response(
+            &state,
+            "session-control",
+            crate::session_commands::CommandSessionSource::Explicit,
+            "/resume session-target",
+            Some("caller-hash"),
+        )
+        .await
+        .expect("authorized resume should short-circuit");
+        let ((status, Json(body)), persist) = response;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(persist);
+        assert_eq!(body["session_id"], "session-control");
+        assert_eq!(
+            body["response"],
+            "[session:session-target] resumed from persisted compact snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn canonical_outcome_early_response_preserves_permission_denied_for_resume_target() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mem = Arc::new(crate::memory::SqliteMemory::new(tmp.path()).unwrap());
+        seed_resumable_session(mem.as_ref(), "session-target", "owner-hash").await;
+
+        let state = AppState {
+            config: Arc::new(Mutex::new(Config::default())),
+            cost_tracker: None,
+            provider: Arc::new(MockProvider::default()),
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: mem.clone() as Arc<dyn crate::memory::Memory>,
+            auto_save: true,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            channel_runtime_handle: None,
+            observer: Arc::new(crate::observability::NoopObserver),
+            transcriber: None,
+            audio_config: crate::config::AudioConfig::default(),
+        };
+
+        let response = canonical_outcome_early_response(
+            &state,
+            "session-control",
+            crate::session_commands::CommandSessionSource::Explicit,
+            "/resume session-target",
+            Some("other-hash"),
+        )
+        .await
+        .expect("denied resume should short-circuit");
+        let ((status, Json(body)), persist) = response;
+
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(!persist);
+        assert_eq!(body["session_id"], "session-control");
+        assert_eq!(body["error"]["code"], "session_command_failed");
+        assert_eq!(
+            body["error"]["message"],
+            "[session:session-target] permission denied"
+        );
     }
 
     #[derive(Default)]
@@ -6209,6 +6404,112 @@ always_ask = []
         assert!(body_str.contains("event: done"));
         assert_eq!(provider_impl.chat_calls.load(Ordering::SeqCst), 0);
         assert_eq!(provider_impl.simple_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn web_chat_stream_returns_slash_session_error_sse_without_provider_execution() {
+        let provider_impl = Arc::new(SequencedChatProvider::new(vec![ChatResponse {
+            text: Some("should not run".into()),
+            tool_calls: Vec::new(),
+        }]));
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+
+        let mut config = temp_config();
+        config.memory.backend = "none".into();
+        let state = AppState {
+            config: Arc::new(Mutex::new(config)),
+            provider,
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: Arc::new(MockMemory),
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            channel_runtime_handle: None,
+            observer: Arc::new(crate::observability::NoopObserver),
+            cost_tracker: None,
+            transcriber: None,
+            audio_config: crate::config::AudioConfig::default(),
+        };
+
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("/web/chat/stream")
+            .header("content-type", "application/json")
+            .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 9999))))
+            .body(axum::body::Body::from(r#"{"message":"/tldr"}"#))
+            .unwrap();
+
+        let resp = build_stream_router(state).oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let collected = resp.into_body().collect().await.unwrap();
+        let body_str = std::str::from_utf8(&collected.to_bytes())
+            .unwrap()
+            .to_owned();
+
+        assert!(body_str.contains("event: error"));
+        assert!(body_str.contains("session_command_failed"));
+        assert!(body_str.contains("require sqlite"));
+        assert_eq!(provider_impl.chat_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(provider_impl.simple_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn web_chat_stream_unknown_slash_like_input_falls_through_to_provider_execution() {
+        let _dispatcher = GatewayWebhookDispatcherEnvGuard::set("0").await;
+        let provider_impl = Arc::new(SequencedChatProvider::new(vec![ChatResponse {
+            text: Some("provider ran".into()),
+            tool_calls: Vec::new(),
+        }]));
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+
+        let state = AppState {
+            config: Arc::new(Mutex::new(temp_config())),
+            provider,
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: Arc::new(MockMemory),
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            channel_runtime_handle: None,
+            observer: Arc::new(crate::observability::NoopObserver),
+            cost_tracker: None,
+            transcriber: None,
+            audio_config: crate::config::AudioConfig::default(),
+        };
+
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("/web/chat/stream")
+            .header("content-type", "application/json")
+            .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 9999))))
+            .body(axum::body::Body::from(r#"{"message":"/resume-later"}"#))
+            .unwrap();
+
+        let resp = build_stream_router(state).oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let collected = resp.into_body().collect().await.unwrap();
+        let body_str = std::str::from_utf8(&collected.to_bytes())
+            .unwrap()
+            .to_owned();
+
+        assert!(body_str.contains("event: chunk"));
+        assert!(body_str.contains("legacy"));
+        assert!(body_str.contains("event: done"));
+        assert!(!body_str.contains("session_command_failed"));
+        assert_eq!(provider_impl.chat_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(provider_impl.simple_calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/clients/agent-runtime/src/gateway/mod.rs
+++ b/clients/agent-runtime/src/gateway/mod.rs
@@ -4875,7 +4875,7 @@ mod tests {
         let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(payload["session_id"], "preview-slash");
-        assert_eq!(payload["error"]["code"], "unsupported_backend");
+        assert_eq!(payload["error"]["code"], "unknown_session");
         assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 0);
     }
 

--- a/clients/agent-runtime/src/gateway/mod.rs
+++ b/clients/agent-runtime/src/gateway/mod.rs
@@ -2302,7 +2302,7 @@ async fn handle_chat_stream(
                                 "message": format!("Approval required for tool `{tool}`: {reason}"),
                             }))
                             .expect("serializable error event"))],
-                        StatusCode::FORBIDDEN,
+                        StatusCode::OK,
                     ),
                     crate::pre_execution::BlockingOutcome::TimeoutAborted => (
                         vec![Ok::<Event, std::convert::Infallible>(
@@ -2314,7 +2314,7 @@ async fn handle_chat_stream(
                                 }))
                                 .expect("serializable error event"),
                         )],
-                        StatusCode::REQUEST_TIMEOUT,
+                        StatusCode::OK,
                     ),
                     crate::pre_execution::BlockingOutcome::Fallback { response } => {
                         let message_id = Uuid::new_v4().to_string();
@@ -6348,6 +6348,118 @@ always_ask = []
         assert!(body_str.contains(r#""execution_mode":"plan""#));
         assert!(body_str.contains("Plan Mode allows analysis-only capabilities"));
         assert_eq!(provider_impl.chat_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(provider_impl.simple_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn web_chat_stream_preserves_sse_contract_for_approval_required_blocking() {
+        let _dispatcher = GatewayWebhookDispatcherEnvGuard::set("1").await;
+
+        let provider_impl = Arc::new(SequencedChatProvider::new(vec![ChatResponse {
+            text: Some("should not run".into()),
+            tool_calls: Vec::new(),
+        }]));
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+
+        let mut config = temp_config();
+        config.gateway.webhook_dispatcher_enabled = true;
+
+        let state = AppState {
+            config: Arc::new(Mutex::new(config)),
+            provider,
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: Arc::new(MockMemory),
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            channel_runtime_handle: None,
+            observer: Arc::new(crate::observability::NoopObserver),
+            cost_tracker: None,
+            transcriber: None,
+            audio_config: crate::config::AudioConfig::default(),
+        };
+
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("/web/chat/stream")
+            .header("content-type", "application/json")
+            .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 9999))))
+            .body(axum::body::Body::from(r#"{"message":"needs-approval"}"#))
+            .unwrap();
+
+        let resp = build_stream_router(state).oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let collected = resp.into_body().collect().await.unwrap();
+        let body_str = std::str::from_utf8(&collected.to_bytes())
+            .unwrap()
+            .to_owned();
+
+        assert!(body_str.contains("event: error"));
+        assert!(body_str.contains(r#""code":"approval_required""#));
+        assert!(body_str.contains(r#""tool":"tool-1""#));
+        assert_eq!(provider_impl.chat_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(provider_impl.simple_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn web_chat_stream_preserves_sse_contract_for_timeout_blocking() {
+        let _dispatcher = GatewayWebhookDispatcherEnvGuard::set("1").await;
+
+        let provider_impl = Arc::new(SequencedChatProvider::new(vec![ChatResponse {
+            text: Some("should not run".into()),
+            tool_calls: Vec::new(),
+        }]));
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+
+        let mut config = temp_config();
+        config.gateway.webhook_dispatcher_enabled = true;
+
+        let state = AppState {
+            config: Arc::new(Mutex::new(config)),
+            provider,
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: Arc::new(MockMemory),
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            channel_runtime_handle: None,
+            observer: Arc::new(crate::observability::NoopObserver),
+            cost_tracker: None,
+            transcriber: None,
+            audio_config: crate::config::AudioConfig::default(),
+        };
+
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("/web/chat/stream")
+            .header("content-type", "application/json")
+            .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 9999))))
+            .body(axum::body::Body::from(r#"{"message":"timeout"}"#))
+            .unwrap();
+
+        let resp = build_stream_router(state).oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let collected = resp.into_body().collect().await.unwrap();
+        let body_str = std::str::from_utf8(&collected.to_bytes())
+            .unwrap()
+            .to_owned();
+
+        assert!(body_str.contains("event: error"));
+        assert!(body_str.contains(r#""code":"timeout""#));
+        assert!(body_str.contains("Request timed out"));
+        assert_eq!(provider_impl.chat_calls.load(Ordering::SeqCst), 0);
         assert_eq!(provider_impl.simple_calls.load(Ordering::SeqCst), 0);
     }
 

--- a/clients/agent-runtime/src/gateway/mod.rs
+++ b/clients/agent-runtime/src/gateway/mod.rs
@@ -1776,7 +1776,8 @@ async fn canonical_outcome_early_response(
     );
 
     match crate::pre_execution::adapt_handled_ingress(
-        crate::pre_execution::evaluate_ingress(state.mem.as_ref(), context, scrubbed_message).await,
+        crate::pre_execution::evaluate_ingress(state.mem.as_ref(), context, scrubbed_message, true)
+            .await,
     ) {
         crate::pre_execution::HandledIngress::Handled(
             crate::pre_execution::HandledIngressOutcome::SessionCommandSuccess(success),
@@ -1796,7 +1797,7 @@ async fn canonical_outcome_early_response(
         ) => {
             let error_body = serde_json::json!({
                 "error": {
-                    "code": "session_command_failed",
+                    "code": map_session_command_failure_code(&failure.kind),
                     "message": failure.message,
                 },
                 "session_id": session_id,
@@ -1838,6 +1839,28 @@ async fn canonical_outcome_early_response(
     }
 
     None
+}
+
+fn map_session_command_failure_code(
+    kind: &crate::session_commands::SessionCommandFailureKind,
+) -> &'static str {
+    match kind {
+        crate::session_commands::SessionCommandFailureKind::UnsupportedBackend => {
+            "unsupported_backend"
+        }
+        crate::session_commands::SessionCommandFailureKind::UnknownSession => "unknown_session",
+        crate::session_commands::SessionCommandFailureKind::InvalidState => "invalid_state",
+        crate::session_commands::SessionCommandFailureKind::MissingSnapshot => "missing_snapshot",
+        crate::session_commands::SessionCommandFailureKind::InvalidResumeTarget => {
+            "invalid_resume_target"
+        }
+        crate::session_commands::SessionCommandFailureKind::InvalidArguments => "invalid_arguments",
+        crate::session_commands::SessionCommandFailureKind::MissingCallerScope => {
+            "missing_caller_scope"
+        }
+        crate::session_commands::SessionCommandFailureKind::PermissionDenied => "permission_denied",
+        crate::session_commands::SessionCommandFailureKind::StorageFailure => "storage_failure",
+    }
 }
 
 fn webhook_response_from_dispatch_result(
@@ -2236,6 +2259,7 @@ async fn handle_chat_stream(
             state.mem.as_ref(),
             ingress_context,
             &scrubbed_message,
+            true,
         )
         .await,
     );
@@ -2284,12 +2308,12 @@ async fn handle_chat_stream(
                         Event::default()
                             .event("error")
                             .json_data(serde_json::json!({
-                                "code": "session_command_failed",
+                                "code": map_session_command_failure_code(&failure.kind),
                                 "message": failure.message,
                             }))
                             .expect("serializable error event"),
                     )],
-                    StatusCode::UNPROCESSABLE_ENTITY,
+                    StatusCode::OK,
                 ),
                 crate::pre_execution::HandledIngressOutcome::Blocking(blocking) => match blocking {
                     crate::pre_execution::BlockingOutcome::ApprovalRequired { tool, reason } => (
@@ -4123,10 +4147,10 @@ mod tests {
         .expect("slash session command should short-circuit");
         let ((status, Json(body)), _persist) = response;
 
-        // SqliteMemory returns 422 with session_command_failed when no session exists
+        // Slash-session lookup failures still return 422 with a stable error code.
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
         assert_eq!(body["session_id"], "session-1");
-        assert_eq!(body["error"]["code"], "session_command_failed");
+        assert_eq!(body["error"]["code"], "unknown_session");
     }
 
     #[tokio::test]
@@ -4252,7 +4276,7 @@ mod tests {
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
         assert!(!persist);
         assert_eq!(body["session_id"], "session-control");
-        assert_eq!(body["error"]["code"], "session_command_failed");
+        assert_eq!(body["error"]["code"], "permission_denied");
         assert_eq!(
             body["error"]["message"],
             "[session:session-target] permission denied"
@@ -4851,7 +4875,7 @@ mod tests {
         let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(payload["session_id"], "preview-slash");
-        assert_eq!(payload["error"]["code"], "session_command_failed");
+        assert_eq!(payload["error"]["code"], "unsupported_backend");
         assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 0);
     }
 
@@ -6558,14 +6582,14 @@ always_ask = []
             .unwrap();
 
         let resp = build_stream_router(state).oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(resp.status(), StatusCode::OK);
         let collected = resp.into_body().collect().await.unwrap();
         let body_str = std::str::from_utf8(&collected.to_bytes())
             .unwrap()
             .to_owned();
 
         assert!(body_str.contains("event: error"));
-        assert!(body_str.contains("session_command_failed"));
+        assert!(body_str.contains("unsupported_backend"));
         assert!(body_str.contains("require sqlite"));
         assert_eq!(provider_impl.chat_calls.load(Ordering::SeqCst), 0);
         assert_eq!(provider_impl.simple_calls.load(Ordering::SeqCst), 0);

--- a/clients/agent-runtime/src/gateway/webhook_dispatch.rs
+++ b/clients/agent-runtime/src/gateway/webhook_dispatch.rs
@@ -412,8 +412,13 @@ pub(crate) async fn execute(
     );
 
     match crate::pre_execution::adapt_handled_ingress(
-        crate::pre_execution::evaluate_ingress(memory.as_ref(), ingress_context, &request.message)
-            .await,
+        crate::pre_execution::evaluate_ingress(
+            memory.as_ref(),
+            ingress_context,
+            &request.message,
+            true,
+        )
+        .await,
     ) {
         HandledIngress::Handled(HandledIngressOutcome::SessionCommandSuccess(success)) => {
             return WebhookTurnResult {
@@ -1006,7 +1011,9 @@ mod tests {
                 latest_tldr_snapshot_id: crate::memory::SessionFieldPatch::Keep,
                 latest_compact_snapshot_id: crate::memory::SessionFieldPatch::Set(snapshot.id),
                 pending_hydration_snapshot_id: crate::memory::SessionFieldPatch::Clear,
-                suspended_at: crate::memory::SessionFieldPatch::Set("now".to_string()),
+                suspended_at: crate::memory::SessionFieldPatch::Set(
+                    "2026-04-17T00:00:00Z".to_string(),
+                ),
             })
             .await
             .unwrap();

--- a/clients/agent-runtime/src/gateway/webhook_dispatch.rs
+++ b/clients/agent-runtime/src/gateway/webhook_dispatch.rs
@@ -7,7 +7,7 @@ use crate::cost::UsagePeriod;
 use crate::gateway::resolve_webhook_execution_mode;
 use crate::memory::Memory;
 use crate::observability::Observer;
-use crate::pre_execution::{BlockingOutcome, IngressDecision};
+use crate::pre_execution::{BlockingOutcome, HandledIngress, HandledIngressOutcome};
 use crate::providers::traits::{
     ProviderCapabilities, StreamChunk, StreamOptions, StreamResult, ToolsPayload,
 };
@@ -411,30 +411,34 @@ pub(crate) async fn execute(
         request.caller_token_hash.clone(),
     );
 
-    match crate::pre_execution::evaluate_ingress(memory.as_ref(), ingress_context, &request.message)
-        .await
-    {
-        IngressDecision::SessionCommand { outcome } => {
-            // SessionCommand is a metadata-only operation — frames intentionally omitted.
-            // No agent execution occurs, so there are no tool calls or events to report.
-            let (terminal_outcome, response_text) = match outcome {
-                crate::session_commands::SessionCommandOutcome::Success(success) => {
-                    (WebhookTerminalOutcome::Completed, success.message)
-                }
-                crate::session_commands::SessionCommandOutcome::Failure(failure) => {
-                    (WebhookTerminalOutcome::Failed, failure.message)
-                }
-            };
+    match crate::pre_execution::adapt_handled_ingress(
+        crate::pre_execution::evaluate_ingress(memory.as_ref(), ingress_context, &request.message)
+            .await,
+    ) {
+        HandledIngress::Handled(HandledIngressOutcome::SessionCommandSuccess(success)) => {
             return WebhookTurnResult {
                 session_id: request.session_id.clone(),
                 model: model.to_string(),
-                outcome: terminal_outcome,
-                response_text: Some(response_text),
+                outcome: WebhookTerminalOutcome::Completed,
+                response_text: Some(success.message),
                 event_frames: Vec::new(),
                 tools_called: Vec::new(),
             };
         }
-        IngressDecision::Blocking(blocking) => match blocking {
+        HandledIngress::Handled(HandledIngressOutcome::SessionCommandFailure {
+            class: _,
+            failure,
+        }) => {
+            return WebhookTurnResult {
+                session_id: request.session_id.clone(),
+                model: model.to_string(),
+                outcome: WebhookTerminalOutcome::Failed,
+                response_text: Some(failure.message),
+                event_frames: Vec::new(),
+                tools_called: Vec::new(),
+            };
+        }
+        HandledIngress::Handled(HandledIngressOutcome::Blocking(blocking)) => match blocking {
             BlockingOutcome::ApprovalRequired { tool, reason } => {
                 return map_canonical_result(
                     &request,
@@ -453,7 +457,7 @@ pub(crate) async fn execute(
                 );
             }
         },
-        IngressDecision::Continue => {}
+        HandledIngress::NotHandled => {}
     }
 
     let mut effective_config = config.clone();
@@ -973,6 +977,41 @@ mod tests {
         (temp, config)
     }
 
+    async fn seed_resumable_session(
+        memory: &crate::memory::SqliteMemory,
+        session_id: &str,
+        token_hash: &str,
+    ) {
+        memory
+            .upsert_session(session_id, Some(token_hash))
+            .await
+            .unwrap();
+        let snapshot = memory
+            .create_session_snapshot(
+                session_id,
+                crate::memory::SessionSnapshotKind::Compact,
+                serde_json::json!({
+                    "preview": "resume me",
+                    "summary": "resume me",
+                    "resume_context": "resume me",
+                }),
+                true,
+            )
+            .await
+            .unwrap();
+        memory
+            .apply_session_state_patch(crate::memory::SessionStatePatch {
+                session_id: session_id.to_string(),
+                lifecycle: Some(crate::memory::SlashSessionLifecycle::Suspended),
+                latest_tldr_snapshot_id: crate::memory::SessionFieldPatch::Keep,
+                latest_compact_snapshot_id: crate::memory::SessionFieldPatch::Set(snapshot.id),
+                pending_hydration_snapshot_id: crate::memory::SessionFieldPatch::Clear,
+                suspended_at: crate::memory::SessionFieldPatch::Set("now".to_string()),
+            })
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn execute_maps_blocked_shell_tool_to_approval_required() {
         let (_temp, config) = test_config();
@@ -1129,5 +1168,83 @@ mod tests {
 
         assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 1);
         assert_eq!(result.outcome, WebhookTerminalOutcome::Completed);
+    }
+
+    #[tokio::test]
+    async fn execute_intercepts_authorized_resume_success_before_provider_execution() {
+        let (_temp, config) = test_config();
+        let temp = tempfile::tempdir().unwrap();
+        let memory = Arc::new(crate::memory::SqliteMemory::new(temp.path()).unwrap());
+        seed_resumable_session(memory.as_ref(), "session-target", "caller-hash").await;
+
+        let provider_impl = Arc::new(ScriptedProvider::new(vec![ChatResponse {
+            text: Some("should not be called".into()),
+            tool_calls: Vec::new(),
+        }]));
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+
+        let result = execute(
+            &config,
+            provider,
+            memory,
+            Arc::new(NoopObserver) as Arc<dyn Observer>,
+            None,
+            "test-model",
+            WebhookTurnRequest {
+                session_id: "session-control".into(),
+                session_source: WebhookSessionSource::Explicit,
+                caller_token_hash: Some("caller-hash".into()),
+                message: "/resume session-target".into(),
+                execution_mode: ExecutionMode::Standard,
+                include_sse_frames: false,
+            },
+        )
+        .await;
+
+        assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(result.outcome, WebhookTerminalOutcome::Completed);
+        assert_eq!(
+            result.response_text.as_deref(),
+            Some("[session:session-target] resumed from persisted compact snapshot")
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_preserves_permission_denied_for_resume_target() {
+        let (_temp, config) = test_config();
+        let temp = tempfile::tempdir().unwrap();
+        let memory = Arc::new(crate::memory::SqliteMemory::new(temp.path()).unwrap());
+        seed_resumable_session(memory.as_ref(), "session-target", "owner-hash").await;
+
+        let provider_impl = Arc::new(ScriptedProvider::new(vec![ChatResponse {
+            text: Some("should not be called".into()),
+            tool_calls: Vec::new(),
+        }]));
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+
+        let result = execute(
+            &config,
+            provider,
+            memory,
+            Arc::new(NoopObserver) as Arc<dyn Observer>,
+            None,
+            "test-model",
+            WebhookTurnRequest {
+                session_id: "session-control".into(),
+                session_source: WebhookSessionSource::Explicit,
+                caller_token_hash: Some("caller-hash".into()),
+                message: "/resume session-target".into(),
+                execution_mode: ExecutionMode::Standard,
+                include_sse_frames: false,
+            },
+        )
+        .await;
+
+        assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(result.outcome, WebhookTerminalOutcome::Failed);
+        assert_eq!(
+            result.response_text.as_deref(),
+            Some("[session:session-target] permission denied")
+        );
     }
 }

--- a/clients/agent-runtime/src/main.rs
+++ b/clients/agent-runtime/src/main.rs
@@ -1531,10 +1531,6 @@ async fn maybe_handle_cli_session_command(
     config: &Config,
     message: &str,
 ) -> Result<Option<String>> {
-    if !crate::session_commands::default_registry().recognizes(message) {
-        return Ok(None);
-    }
-
     let (memory, _observer) = crate::bootstrap::create_memory_and_observer(config)?;
     let session_id_env = std::env::var("CORVUS_SESSION_ID").ok();
     let session_source = if session_id_env.is_some() {
@@ -1550,17 +1546,19 @@ async fn maybe_handle_cli_session_command(
         None,
     );
 
-    match crate::pre_execution::evaluate_ingress(memory.as_ref(), context, message).await {
-        crate::pre_execution::IngressDecision::SessionCommand { outcome } => match outcome {
-            crate::session_commands::SessionCommandOutcome::Success(success) => {
-                Ok(Some(success.message))
-            }
-            crate::session_commands::SessionCommandOutcome::Failure(failure) => {
-                Err(anyhow::anyhow!("{}", failure.message))
-            }
-        },
-        crate::pre_execution::IngressDecision::Blocking(_)
-        | crate::pre_execution::IngressDecision::Continue => Ok(None),
+    match crate::pre_execution::adapt_handled_ingress(
+        crate::pre_execution::evaluate_ingress(memory.as_ref(), context, message).await,
+    ) {
+        crate::pre_execution::HandledIngress::Handled(
+            crate::pre_execution::HandledIngressOutcome::SessionCommandSuccess(success),
+        ) => Ok(Some(success.message)),
+        crate::pre_execution::HandledIngress::Handled(
+            crate::pre_execution::HandledIngressOutcome::SessionCommandFailure { failure, .. },
+        ) => Err(anyhow::anyhow!("{}", failure.message)),
+        crate::pre_execution::HandledIngress::Handled(
+            crate::pre_execution::HandledIngressOutcome::Blocking(_),
+        )
+        | crate::pre_execution::HandledIngress::NotHandled => Ok(None),
     }
 }
 

--- a/clients/agent-runtime/src/main.rs
+++ b/clients/agent-runtime/src/main.rs
@@ -1547,14 +1547,21 @@ async fn maybe_handle_cli_session_command(
     );
 
     match crate::pre_execution::adapt_handled_ingress(
-        crate::pre_execution::evaluate_ingress(memory.as_ref(), context, message).await,
+        crate::pre_execution::evaluate_ingress(memory.as_ref(), context, message, false).await,
     ) {
         crate::pre_execution::HandledIngress::Handled(
             crate::pre_execution::HandledIngressOutcome::SessionCommandSuccess(success),
         ) => Ok(Some(success.message)),
         crate::pre_execution::HandledIngress::Handled(
-            crate::pre_execution::HandledIngressOutcome::SessionCommandFailure { failure, .. },
-        ) => Err(anyhow::anyhow!("{}", failure.message)),
+            crate::pre_execution::HandledIngressOutcome::SessionCommandFailure { class, failure },
+        ) => match class {
+            crate::pre_execution::SessionCommandFailureClass::PermissionDenied => {
+                Err(anyhow::anyhow!("permission denied: {}", failure.message))
+            }
+            crate::pre_execution::SessionCommandFailureClass::Failed => {
+                Err(anyhow::anyhow!("{}", failure.message))
+            }
+        },
         crate::pre_execution::HandledIngress::Handled(
             crate::pre_execution::HandledIngressOutcome::Blocking(_),
         )
@@ -2438,6 +2445,7 @@ fn handle_status(auth_service: &auth::AuthService) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::memory::Memory;
     use crate::test_support::tracing_capture::capture_tracing_events;
     use async_trait::async_trait;
     use clap::CommandFactory;
@@ -3429,6 +3437,26 @@ mod tests {
             .unwrap_err();
 
         assert!(error.to_string().contains("require sqlite"));
+    }
+
+    #[tokio::test]
+    async fn cli_session_command_success_returns_message() {
+        let tmp = TempDir::new().unwrap();
+        let config = crate::test_support::test_config(&tmp);
+        let memory = crate::memory::SqliteMemory::new(&config.workspace_dir).unwrap();
+        memory
+            .upsert_session("interactive-session", None::<&str>)
+            .await
+            .unwrap();
+
+        let handled = maybe_handle_cli_session_command(&config, "/tldr")
+            .await
+            .unwrap();
+
+        assert!(handled.is_some());
+        assert!(handled
+            .unwrap()
+            .contains("No persisted session transcript is available yet."));
     }
 
     #[tokio::test]

--- a/clients/agent-runtime/src/pre_execution/mod.rs
+++ b/clients/agent-runtime/src/pre_execution/mod.rs
@@ -6,7 +6,6 @@ use crate::session_commands::{
 
 mod session_command_adapter;
 
-#[allow(unused_imports)]
 pub use session_command_adapter::{
     adapt_handled_ingress, HandledIngress, HandledIngressOutcome, SessionCommandFailureClass,
 };
@@ -49,11 +48,16 @@ pub async fn evaluate_ingress(
     memory: &dyn Memory,
     context: CommandContext,
     prompt: &str,
+    include_blocking_fallback: bool,
 ) -> IngressDecision {
     let service = SessionCommandService::new(memory);
     let session_id = context.session.session_id.clone();
     if let Some(outcome) = default_registry().dispatch(&service, context, prompt).await {
         return IngressDecision::SessionCommand { outcome };
+    }
+
+    if !include_blocking_fallback {
+        return IngressDecision::Continue;
     }
 
     let canonical = evaluate(session_id.to_string(), prompt).await;
@@ -248,6 +252,7 @@ mod tests {
                 None,
             ),
             "/tldr",
+            true,
         )
         .await;
 
@@ -280,6 +285,7 @@ mod tests {
                 None,
             ),
             "/resume-later",
+            true,
         )
         .await;
 
@@ -297,6 +303,7 @@ mod tests {
                 None,
             ),
             "/tldr extra args",
+            true,
         )
         .await;
 

--- a/clients/agent-runtime/src/pre_execution/mod.rs
+++ b/clients/agent-runtime/src/pre_execution/mod.rs
@@ -4,6 +4,13 @@ use crate::session_commands::{
     default_registry, CommandContext, SessionCommandOutcome, SessionCommandService,
 };
 
+mod session_command_adapter;
+
+#[allow(unused_imports)]
+pub use session_command_adapter::{
+    adapt_handled_ingress, HandledIngress, HandledIngressOutcome, SessionCommandFailureClass,
+};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BlockingOutcome {
     ApprovalRequired { tool: String, reason: String },
@@ -85,8 +92,9 @@ mod tests {
     use crate::config::ExecutionMode;
     use crate::memory::{Memory, MemoryCategory, MemoryEntry};
     use crate::session_commands::{
-        CommandCaller, CommandIngressSource, CommandSessionSource, SessionCommandFailureKind,
-        SessionCommandOutcome,
+        CommandCaller, CommandIngressSource, CommandSessionSource, SessionCommandFailure,
+        SessionCommandFailureKind, SessionCommandOutcome, SessionCommandSuccess,
+        SessionCommandSuccessData,
     };
     use async_trait::async_trait;
 
@@ -306,6 +314,89 @@ mod tests {
             }
             other => panic!("expected session command error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn adapt_handled_ingress_returns_not_handled_for_continue() {
+        assert!(matches!(
+            adapt_handled_ingress(IngressDecision::Continue),
+            HandledIngress::NotHandled
+        ));
+    }
+
+    #[test]
+    fn adapt_handled_ingress_preserves_success_outcome() {
+        let success = SessionCommandSuccess {
+            command: "/tldr",
+            session_id: "session-1".to_string(),
+            message: "summary".to_string(),
+            data: SessionCommandSuccessData::None,
+        };
+
+        assert!(matches!(
+            adapt_handled_ingress(IngressDecision::SessionCommand {
+                outcome: SessionCommandOutcome::Success(success.clone()),
+            }),
+            HandledIngress::Handled(HandledIngressOutcome::SessionCommandSuccess(actual))
+                if actual == success
+        ));
+    }
+
+    #[test]
+    fn adapt_handled_ingress_classifies_permission_failures() {
+        for kind in [
+            SessionCommandFailureKind::MissingCallerScope,
+            SessionCommandFailureKind::PermissionDenied,
+        ] {
+            let failure = SessionCommandFailure {
+                command: "/resume",
+                kind: kind.clone(),
+                session_id: Some("session-1".to_string()),
+                message: "denied".to_string(),
+            };
+
+            assert!(matches!(
+                adapt_handled_ingress(IngressDecision::SessionCommand {
+                    outcome: SessionCommandOutcome::Failure(failure.clone()),
+                }),
+                HandledIngress::Handled(HandledIngressOutcome::SessionCommandFailure {
+                    class: SessionCommandFailureClass::PermissionDenied,
+                    failure: actual,
+                }) if actual == failure
+            ));
+        }
+    }
+
+    #[test]
+    fn adapt_handled_ingress_classifies_generic_failures() {
+        let failure = SessionCommandFailure {
+            command: "/tldr",
+            kind: SessionCommandFailureKind::InvalidArguments,
+            session_id: Some("session-1".to_string()),
+            message: "bad args".to_string(),
+        };
+
+        assert!(matches!(
+            adapt_handled_ingress(IngressDecision::SessionCommand {
+                outcome: SessionCommandOutcome::Failure(failure.clone()),
+            }),
+            HandledIngress::Handled(HandledIngressOutcome::SessionCommandFailure {
+                class: SessionCommandFailureClass::Failed,
+                failure: actual,
+            }) if actual == failure
+        ));
+    }
+
+    #[test]
+    fn adapt_handled_ingress_preserves_blocking_outcomes() {
+        let blocking = BlockingOutcome::Fallback {
+            response: "fallback response".to_string(),
+        };
+
+        assert!(matches!(
+            adapt_handled_ingress(IngressDecision::Blocking(blocking.clone())),
+            HandledIngress::Handled(HandledIngressOutcome::Blocking(actual)) if actual == blocking
+        ));
     }
 
     #[test]

--- a/clients/agent-runtime/src/pre_execution/session_command_adapter.rs
+++ b/clients/agent-runtime/src/pre_execution/session_command_adapter.rs
@@ -1,6 +1,6 @@
 use crate::pre_execution::{BlockingOutcome, IngressDecision};
 use crate::session_commands::{
-    SessionCommandFailure, SessionCommandFailureKind, SessionCommandSuccess,
+    SessionCommandFailure, SessionCommandFailureKind, SessionCommandOutcome, SessionCommandSuccess,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -32,12 +32,12 @@ pub fn adapt_handled_ingress(decision: IngressDecision) -> HandledIngress {
             HandledIngress::Handled(HandledIngressOutcome::Blocking(blocking))
         }
         IngressDecision::SessionCommand { outcome } => match outcome {
-            crate::session_commands::SessionCommandOutcome::Success(success) => {
+            SessionCommandOutcome::Success(success) => {
                 HandledIngress::Handled(HandledIngressOutcome::SessionCommandSuccess(success))
             }
-            crate::session_commands::SessionCommandOutcome::Failure(failure) => {
+            SessionCommandOutcome::Failure(failure) => {
                 HandledIngress::Handled(HandledIngressOutcome::SessionCommandFailure {
-                    class: classify_session_command_failure(&failure.kind),
+                    class: classify_session_command_failure(failure.kind.clone()),
                     failure,
                 })
             }
@@ -45,9 +45,7 @@ pub fn adapt_handled_ingress(decision: IngressDecision) -> HandledIngress {
     }
 }
 
-fn classify_session_command_failure(
-    kind: &SessionCommandFailureKind,
-) -> SessionCommandFailureClass {
+fn classify_session_command_failure(kind: SessionCommandFailureKind) -> SessionCommandFailureClass {
     match kind {
         SessionCommandFailureKind::MissingCallerScope
         | SessionCommandFailureKind::PermissionDenied => {

--- a/clients/agent-runtime/src/pre_execution/session_command_adapter.rs
+++ b/clients/agent-runtime/src/pre_execution/session_command_adapter.rs
@@ -1,0 +1,64 @@
+use crate::pre_execution::{BlockingOutcome, IngressDecision};
+use crate::session_commands::{
+    SessionCommandFailure, SessionCommandFailureKind, SessionCommandSuccess,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum HandledIngress {
+    NotHandled,
+    Handled(HandledIngressOutcome),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum HandledIngressOutcome {
+    SessionCommandSuccess(SessionCommandSuccess),
+    SessionCommandFailure {
+        class: SessionCommandFailureClass,
+        failure: SessionCommandFailure,
+    },
+    Blocking(BlockingOutcome),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionCommandFailureClass {
+    PermissionDenied,
+    Failed,
+}
+
+pub fn adapt_handled_ingress(decision: IngressDecision) -> HandledIngress {
+    match decision {
+        IngressDecision::Continue => HandledIngress::NotHandled,
+        IngressDecision::Blocking(blocking) => {
+            HandledIngress::Handled(HandledIngressOutcome::Blocking(blocking))
+        }
+        IngressDecision::SessionCommand { outcome } => match outcome {
+            crate::session_commands::SessionCommandOutcome::Success(success) => {
+                HandledIngress::Handled(HandledIngressOutcome::SessionCommandSuccess(success))
+            }
+            crate::session_commands::SessionCommandOutcome::Failure(failure) => {
+                HandledIngress::Handled(HandledIngressOutcome::SessionCommandFailure {
+                    class: classify_session_command_failure(&failure.kind),
+                    failure,
+                })
+            }
+        },
+    }
+}
+
+fn classify_session_command_failure(
+    kind: &SessionCommandFailureKind,
+) -> SessionCommandFailureClass {
+    match kind {
+        SessionCommandFailureKind::MissingCallerScope
+        | SessionCommandFailureKind::PermissionDenied => {
+            SessionCommandFailureClass::PermissionDenied
+        }
+        SessionCommandFailureKind::UnsupportedBackend
+        | SessionCommandFailureKind::UnknownSession
+        | SessionCommandFailureKind::InvalidState
+        | SessionCommandFailureKind::MissingSnapshot
+        | SessionCommandFailureKind::InvalidResumeTarget
+        | SessionCommandFailureKind::InvalidArguments
+        | SessionCommandFailureKind::StorageFailure => SessionCommandFailureClass::Failed,
+    }
+}

--- a/openspec/changes/archive/2026-04-17-slash-command-transport-parity/design.md
+++ b/openspec/changes/archive/2026-04-17-slash-command-transport-parity/design.md
@@ -1,0 +1,168 @@
+# Design: Slash Command Transport Parity
+
+## Technical Approach
+
+Keep `clients/agent-runtime/src/pre_execution/mod.rs::evaluate_ingress(...)` as the single interception seam and add one small shared adapter immediately after that seam for recognized slash-command outcomes.
+
+The adapter will convert ingress evaluation into a transport-neutral handled contract that preserves machine-readable slash failure data while leaving transport-specific response envelopes unchanged. CLI/runtime message mode, gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatch, and channel ingress will all:
+
+1. build their existing `CommandContext`,
+2. call `evaluate_ingress(...)` once,
+3. pass the result through the shared adapter,
+4. perform only final transport-local wrapping.
+
+This keeps the change small and implementation-focused: parity comes from one shared post-dispatch adaptation path, not from unifying HTTP/CLI/SSE/channel/webhook output schemas.
+
+## Architecture Decisions
+
+### Decision: Place the shared adaptation helper in `pre_execution`
+
+**Choice**: Add the helper under `clients/agent-runtime/src/pre_execution/` and re-export it from `pre_execution/mod.rs`.
+**Alternatives considered**: Put the helper in `session_commands/`; keep per-transport `match` logic.
+**Rationale**: The helper belongs to the ingress seam, not to registry/domain logic. `session_commands` should keep owning parsing, authorization, and command outcomes; `pre_execution` already owns `IngressDecision` and blocking classification, so it is the narrowest place to normalize handled results without coupling command-domain code to transport envelopes.
+
+### Decision: Normalize only internal handled results, not external envelopes
+
+**Choice**: Introduce a shared internal result like `NotHandled | Handled(Success | Failure | Blocking)`.
+**Alternatives considered**: Standardize HTTP JSON, SSE, CLI text, webhook results, and channel text into one public schema.
+**Rationale**: External envelope shaping is intentionally transport-specific today and is explicitly out of scope for #541. The only shared concern is how recognized slash results are classified and surfaced internally.
+
+### Decision: Collapse authorization-related slash failures into one internal denial category
+
+**Choice**: Map `SessionCommandFailureKind::MissingCallerScope` and `SessionCommandFailureKind::PermissionDenied` to one shared internal denial classification while preserving the original failure kind on the adapted result.
+**Alternatives considered**: Treat all failures as generic command failures; expose raw failure kinds directly in every transport.
+**Rationale**: Transports need one consistent way to distinguish permission-style failures from generic slash errors, but we should not lose the more specific source kind because some transports/tests may still inspect it or later branch on it.
+
+## Components
+
+- `pre_execution::evaluate_ingress(...)` — unchanged canonical entry seam.
+- `pre_execution::adapt_handled_ingress(...)` (new) — shared adapter that converts `IngressDecision` into a transport-neutral handled result.
+- `main.rs::maybe_handle_cli_session_command(...)` — consumes the adapter and removes the extra registry `recognizes(...)` pre-check.
+- `gateway/mod.rs::canonical_outcome_early_response(...)` — consumes the adapter for HTTP early return.
+- gateway streaming path in `gateway/mod.rs` — consumes the adapter for SSE short-circuit events/status.
+- `gateway/webhook_dispatch.rs::execute(...)` — consumes the adapter before provider execution and maps into `WebhookTurnResult`.
+- `channels/mod.rs::handle_ingress_outcome(...)` — consumes the adapter before memory enrichment and maps into channel send text.
+
+## Data Flow
+
+### Shared flow
+
+```text
+transport entrypoint
+  -> build CommandContext
+  -> pre_execution::evaluate_ingress(memory, context, message)
+      -> registry dispatch OR canonical blocking/continue
+  -> pre_execution::adapt_handled_ingress(decision)
+      -> NotHandled
+      -> Handled::SessionCommandSuccess
+      -> Handled::SessionCommandFailure
+      -> Handled::Blocking
+  -> transport-local envelope wrapping
+```
+
+### Transport responsibilities after the change
+
+```text
+CLI/runtime         -> print success text / return anyhow error / fall through
+Gateway HTTP        -> existing JSON body + current status code policy
+Gateway SSE         -> existing chunk|done or error events + current status code policy
+Webhook dispatcher  -> existing WebhookTurnResult shape
+Channels            -> existing send text behavior
+```
+
+## Failure Mapping
+
+The adapter will preserve the original `SessionCommandFailure` and expose a small classification helper for transport consumers:
+
+| Source | Shared internal classification | Notes |
+|------|--------|-------------|
+| `IngressDecision::Continue` | `NotHandled` | Unknown slash-like input still falls through. |
+| `SessionCommandOutcome::Success` | `Handled::SessionCommandSuccess` | Preserve `command`, `session_id`, `message`, and `data`. |
+| `SessionCommandFailureKind::MissingCallerScope` | `Handled::SessionCommandFailure { class: PermissionDenied }` | Preserve original failure kind alongside the shared class. |
+| `SessionCommandFailureKind::PermissionDenied` | `Handled::SessionCommandFailure { class: PermissionDenied }` | Same classification across transports. |
+| Any other `SessionCommandFailureKind` | `Handled::SessionCommandFailure { class: Failed }` | Preserve original failure payload/message. |
+| `BlockingOutcome::*` | `Handled::Blocking(...)` | Existing non-slash blocking behavior stays available through the same adapter. |
+
+Out of scope: changing transport-specific external error codes, JSON field names, SSE event names, CLI formatting, channel text prefixes, or webhook result schema beyond swapping their internal input source to the adapter.
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `clients/agent-runtime/src/pre_execution/mod.rs` | Modify | Re-export the adapter and keep `evaluate_ingress(...)` as the seam. |
+| `clients/agent-runtime/src/pre_execution/session_command_adapter.rs` | Create | Define the shared handled-result types and adaptation helper. |
+| `clients/agent-runtime/src/main.rs` | Modify | Remove `default_registry().recognizes(...)` pre-check and map CLI message-mode behavior from the adapter. |
+| `clients/agent-runtime/src/gateway/mod.rs` | Modify | Replace HTTP/SSE slash-specific `match` trees with adapter consumption while preserving current envelopes. |
+| `clients/agent-runtime/src/gateway/webhook_dispatch.rs` | Modify | Use the adapter before provider execution and map into existing `WebhookTurnResult`. |
+| `clients/agent-runtime/src/channels/mod.rs` | Modify | Use the adapter before memory enrichment and preserve current channel send text behavior. |
+| `clients/agent-runtime/src/pre_execution/mod.rs` tests | Modify | Add focused adapter tests for continue/success/failure/blocking classification. |
+| transport tests in `main.rs`, `gateway/mod.rs`, `channels/mod.rs`, and/or `gateway/webhook_dispatch.rs` | Modify | Add regression coverage proving parity and envelope preservation. |
+
+## Interfaces / Contracts
+
+```rust
+pub enum HandledIngress {
+    NotHandled,
+    Handled(HandledIngressOutcome),
+}
+
+pub enum HandledIngressOutcome {
+    SessionCommandSuccess(SessionCommandSuccess),
+    SessionCommandFailure {
+        class: SessionCommandFailureClass,
+        failure: SessionCommandFailure,
+    },
+    Blocking(BlockingOutcome),
+}
+
+pub enum SessionCommandFailureClass {
+    PermissionDenied,
+    Failed,
+}
+
+pub fn adapt_handled_ingress(decision: IngressDecision) -> HandledIngress;
+```
+
+Notes:
+
+- `SessionCommandFailure` stays the non-lossy payload; the class is only a convenience for shared transport branching.
+- No changes are required to the slash registry contract.
+- `SessionCommandFailureKind` should be reused as-is unless implementation uncovers a real missing classification.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Adapter classification for continue, success, permission-style failure, generic failure, and blocking | Add focused tests under `pre_execution` using existing outcome structs. |
+| Integration | CLI message-mode short-circuits through the shared seam without the `recognizes(...)` pre-check | Update `main.rs` tests to assert known slash commands still handle and unknown slash-like input still falls through. |
+| Integration | Gateway HTTP and SSE preserve outward envelopes while consuming the adapter | Update/add tests around `canonical_outcome_early_response(...)` and slash-stream early return paths. |
+| Integration | Webhook dispatcher returns the same `WebhookTurnResult` semantics for handled slash results | Add/update dispatcher-focused tests before provider execution. |
+| Integration | Channel ingress still short-circuits before memory enrichment and preserves sent text behavior | Extend existing `handle_ingress_outcome(...)` tests. |
+
+## Validation Guidance
+
+Run the smallest Rust checks that prove the change:
+
+1. targeted `cargo test --manifest-path clients/agent-runtime/Cargo.toml` for the updated slash-ingress tests,
+2. `cargo test --manifest-path clients/agent-runtime/Cargo.toml` if targeted selection is insufficient,
+3. `cargo clippy --manifest-path clients/agent-runtime/Cargo.toml --all-targets -- -D warnings` before handoff if code changed materially.
+
+Do not add a build step for this slice. Validation should focus on regression tests and lint for the affected runtime module.
+
+## Migration / Rollout
+
+No migration required. This is an internal routing cleanup with no storage, schema, or public API migration.
+
+## Rollback
+
+Rollback is straightforward:
+
+1. remove the shared adapter module,
+2. restore the current transport-local `match` branches in `main.rs`, `gateway/mod.rs`, `gateway/webhook_dispatch.rs`, and `channels/mod.rs`,
+3. keep `evaluate_ingress(...)` and the registry/type groundwork unchanged.
+
+Because the change does not alter persistence or transport schemas, rollback is limited to internal branching restoration.
+
+## Open Questions
+
+- [ ] None.

--- a/openspec/changes/archive/2026-04-17-slash-command-transport-parity/exploration.md
+++ b/openspec/changes/archive/2026-04-17-slash-command-transport-parity/exploration.md
@@ -1,0 +1,52 @@
+## Exploration: issue #541 slash command transport parity
+
+### Current State
+The slash command registry and typed execution context already exist in `clients/agent-runtime/src/session_commands/` and `clients/agent-runtime/src/pre_execution/mod.rs`. `pre_execution::evaluate_ingress(...)` is now the shared interception seam: it builds a `SessionCommandService`, dispatches recognized slash commands through `default_registry().dispatch(...)`, and only falls through to canonical prompt/blocking evaluation when the registry does not recognize the input.
+
+Transport entrypoints are partially aligned but still branch independently around that seam:
+- **CLI/runtime message mode**: `clients/agent-runtime/src/main.rs` `handle_agent_command(...)` and `handle_code_command(...)` call `maybe_handle_cli_session_command(...)` before agent startup. That helper first checks `default_registry().recognizes(message)`, then builds CLI `CommandContext`, then calls `evaluate_ingress(...)`, then converts success to `Ok(Some(message))` and failure to a raw `anyhow` error.
+- **Gateway HTTP `/webhook`**: `clients/agent-runtime/src/gateway/mod.rs` uses `canonical_outcome_early_response(...)`, which builds gateway HTTP `CommandContext`, calls `evaluate_ingress(...)`, and maps slash outcomes into HTTP JSON. This helper is called in two places: preview mode before session upsert and the legacy non-dispatcher path before plan/cost guards.
+- **Gateway streaming `/web/chat/stream`**: `clients/agent-runtime/src/gateway/mod.rs` builds gateway stream `CommandContext`, calls `evaluate_ingress(...)`, and if handled, emits SSE directly (`chunk` + `done` on success, `error` on failure).
+- **Webhook dispatcher path**: `clients/agent-runtime/src/gateway/webhook_dispatch.rs` builds webhook `CommandContext`, calls `evaluate_ingress(...)`, and converts handled slash outcomes into `WebhookTurnResult` before any provider execution.
+- **Channel-backed ingress**: `clients/agent-runtime/src/channels/mod.rs` `process_channel_message(...)` calls `handle_ingress_outcome(...)` before memory enrichment. That helper hashes `channel:sender` into derived caller scope, builds channel `CommandContext`, calls `evaluate_ingress(...)`, and sends either success/failure text or blocking text back through the channel.
+
+What is already true today:
+- recognized slash commands reach the same registry and typed context seam in all listed transports;
+- unknown slash-like input falls through in all listed transports;
+- gateway/webhook/channel tests already prove short-circuit behavior in several places.
+
+### Affected Areas
+- `clients/agent-runtime/src/pre_execution/mod.rs` — current canonical slash interception seam.
+- `clients/agent-runtime/src/session_commands/types.rs` — typed caller/session/ingress context and machine-readable failure kinds.
+- `clients/agent-runtime/src/main.rs` — CLI/runtime fast-path still performs extra transport-specific recognition and formatting.
+- `clients/agent-runtime/src/gateway/mod.rs` — HTTP and SSE each re-map slash outcomes separately; `/webhook` has duplicated early-response wiring.
+- `clients/agent-runtime/src/gateway/webhook_dispatch.rs` — dispatcher path repeats outcome conversion again.
+- `clients/agent-runtime/src/channels/mod.rs` — channel ingress has its own outcome-to-text mapping and sender-derived caller scope handling.
+
+### Approaches
+1. **Extract a shared slash transport adapter** — keep `evaluate_ingress(...)` as the seam, but add one transport-neutral helper that converts `IngressDecision::SessionCommand` into a canonical internal handled-result shape (success/failure kind/message/session metadata), then let each transport only wrap that result into CLI text, HTTP JSON, SSE, or channel send operations.
+   - Pros: smallest slice; removes duplicated branching; preserves current envelopes; gives one place to classify permission-denied vs generic failure.
+   - Cons: still leaves final envelope shaping per transport.
+   - Effort: Low
+
+2. **Unify full external slash response envelopes across transports** — force HTTP, SSE, CLI, webhook dispatcher, and channels to expose one shared response/error schema.
+   - Pros: strongest visible parity.
+   - Cons: too broad for #541, risks breaking current clients/channels, and violates the current spec direction that envelope formatting stays transport-specific.
+   - Effort: Medium/High
+
+### Recommendation
+Use **Approach 1**. The codebase already has the hard part in place: one registry and one typed ingress seam. The remaining #541 gap is not registry lookup; it is duplicated transport-side handling after lookup. A small helper layer should centralize handled slash outcomes and failure classification while preserving existing transport envelopes.
+
+Recommended implementation slice for #541:
+- add a transport-neutral slash result adapter near `pre_execution` or `session_commands` that returns `NotHandled | Handled(Success/Failure/Blocking)` with machine-readable failure kind preserved;
+- replace CLI `recognizes(...)` pre-check with direct seam usage so CLI matches other transports and avoids double parsing;
+- have `/webhook`, `/web/chat/stream`, `webhook_dispatch::execute(...)`, and channel ingress all consume the same adapter instead of hand-rolled `match` trees;
+- preserve existing external payload/text shapes for this slice, but map permission-related failures from the preserved failure kind rather than treating everything as generic `session_command_failed` internally.
+
+### Risks
+- CLI interactive input may still sit outside this exact fast path; proposal should define whether #541 is limited to current message-based runtime entrypoints or also includes interactive loop entry.
+- Gateway JSON/SSE tests may be sensitive to small status/code changes if permission-denied becomes more explicit.
+- Over-centralizing envelope formatting would expand scope and risk coupling transports that intentionally differ today.
+
+### Ready for Proposal
+Yes — foundations from #539/#540 are already present. The proposal should describe #541 as a focused transport-integration cleanup that centralizes handled slash outcome adaptation and closes the remaining parity gap around transport-specific branching and failure classification.

--- a/openspec/changes/archive/2026-04-17-slash-command-transport-parity/exploration.md
+++ b/openspec/changes/archive/2026-04-17-slash-command-transport-parity/exploration.md
@@ -1,6 +1,7 @@
-## Exploration: issue #541 slash command transport parity
+# Exploration: issue #541 slash command transport parity
 
 ### Current State
+
 The slash command registry and typed execution context already exist in `clients/agent-runtime/src/session_commands/` and `clients/agent-runtime/src/pre_execution/mod.rs`. `pre_execution::evaluate_ingress(...)` is now the shared interception seam: it builds a `SessionCommandService`, dispatches recognized slash commands through `default_registry().dispatch(...)`, and only falls through to canonical prompt/blocking evaluation when the registry does not recognize the input.
 
 Transport entrypoints are partially aligned but still branch independently around that seam:
@@ -15,7 +16,9 @@ What is already true today:
 - unknown slash-like input falls through in all listed transports;
 - gateway/webhook/channel tests already prove short-circuit behavior in several places.
 
+
 ### Affected Areas
+
 - `clients/agent-runtime/src/pre_execution/mod.rs` — current canonical slash interception seam.
 - `clients/agent-runtime/src/session_commands/types.rs` — typed caller/session/ingress context and machine-readable failure kinds.
 - `clients/agent-runtime/src/main.rs` — CLI/runtime fast-path still performs extra transport-specific recognition and formatting.
@@ -23,7 +26,9 @@ What is already true today:
 - `clients/agent-runtime/src/gateway/webhook_dispatch.rs` — dispatcher path repeats outcome conversion again.
 - `clients/agent-runtime/src/channels/mod.rs` — channel ingress has its own outcome-to-text mapping and sender-derived caller scope handling.
 
+
 ### Approaches
+
 1. **Extract a shared slash transport adapter** — keep `evaluate_ingress(...)` as the seam, but add one transport-neutral helper that converts `IngressDecision::SessionCommand` into a canonical internal handled-result shape (success/failure kind/message/session metadata), then let each transport only wrap that result into CLI text, HTTP JSON, SSE, or channel send operations.
    - Pros: smallest slice; removes duplicated branching; preserves current envelopes; gives one place to classify permission-denied vs generic failure.
    - Cons: still leaves final envelope shaping per transport.
@@ -34,7 +39,9 @@ What is already true today:
    - Cons: too broad for #541, risks breaking current clients/channels, and violates the current spec direction that envelope formatting stays transport-specific.
    - Effort: Medium/High
 
+
 ### Recommendation
+
 Use **Approach 1**. The codebase already has the hard part in place: one registry and one typed ingress seam. The remaining #541 gap is not registry lookup; it is duplicated transport-side handling after lookup. A small helper layer should centralize handled slash outcomes and failure classification while preserving existing transport envelopes.
 
 Recommended implementation slice for #541:
@@ -43,10 +50,14 @@ Recommended implementation slice for #541:
 - have `/webhook`, `/web/chat/stream`, `webhook_dispatch::execute(...)`, and channel ingress all consume the same adapter instead of hand-rolled `match` trees;
 - preserve existing external payload/text shapes for this slice, but map permission-related failures from the preserved failure kind rather than treating everything as generic `session_command_failed` internally.
 
+
 ### Risks
+
 - CLI interactive input may still sit outside this exact fast path; proposal should define whether #541 is limited to current message-based runtime entrypoints or also includes interactive loop entry.
 - Gateway JSON/SSE tests may be sensitive to small status/code changes if permission-denied becomes more explicit.
 - Over-centralizing envelope formatting would expand scope and risk coupling transports that intentionally differ today.
 
+
 ### Ready for Proposal
+
 Yes — foundations from #539/#540 are already present. The proposal should describe #541 as a focused transport-integration cleanup that centralizes handled slash outcome adaptation and closes the remaining parity gap around transport-specific branching and failure classification.

--- a/openspec/changes/archive/2026-04-17-slash-command-transport-parity/proposal.md
+++ b/openspec/changes/archive/2026-04-17-slash-command-transport-parity/proposal.md
@@ -1,0 +1,73 @@
+# Proposal: Slash Command Transport Parity
+
+## Intent
+
+Close the remaining transport-parity gap for slash commands by removing duplicated post-dispatch branching around the shared pre-execution seam while preserving each transport's existing external response envelope.
+
+The registry, typed command context, and shared `pre_execution::evaluate_ingress(...)` seam are already in place from #539 and #540. Issue #541 is now a focused integration cleanup: centralize handled slash outcome adaptation and failure classification so CLI/runtime, gateway HTTP, gateway streaming, webhook dispatch, and channel ingress all consume the same internal handled-result contract instead of maintaining separate transport-side match trees.
+
+## Scope
+
+### In Scope
+- Introduce one shared handled-slash adaptation layer after `pre_execution::evaluate_ingress(...)` that preserves machine-readable outcome and failure-kind data while exposing a transport-neutral handled result.
+- Replace duplicated transport-side branching in CLI/runtime message mode, gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher, and channel ingress with that shared adapter.
+- Remove the extra CLI `recognizes(...)` pre-check so CLI/runtime message entry uses the same shared seam and handled-result contract as the other transports.
+- Preserve existing external transport envelopes while making permission-denied, command-not-found fallthrough, and generic command failure classification consistent at the internal adaptation boundary.
+- Add focused regression coverage proving the supported transports share dispatch and handled-result adaptation while keeping their current outward payload/text shapes.
+
+### Out of Scope
+- Broad envelope unification across HTTP JSON, SSE, webhook results, CLI text, and channel message bodies.
+- New slash command families beyond the existing integrated command set needed to validate transport parity.
+- Reworking command handler authorization policy, backend persistence policy, or registry-core responsibilities beyond the minimal adapter integration required for #541.
+- Expanding scope into interactive CLI UX beyond the current message-based runtime entrypoints unless already covered by the existing fast path.
+
+## Approach
+
+Keep `pre_execution::evaluate_ingress(...)` as the canonical interception seam and add a small transport-neutral adapter near `pre_execution`/`session_commands` that converts handled slash outcomes into a shared internal shape such as `NotHandled | Handled(Success | Failure | Blocking)`. That adapter will preserve the existing non-lossy command outcome and failure kinds from `session_commands/types.rs`, especially authorization-sensitive denials, while leaving final envelope shaping outside the shared contract.
+
+Each transport surface will then do only the last mile:
+
+1. Build the transport-appropriate `CommandContext` using its current caller/session semantics.
+2. Call the shared ingress seam once.
+3. Consume the shared handled-result adapter.
+4. Wrap the adapted result into its existing external envelope (CLI text, HTTP JSON, SSE events, webhook result, or channel send operations).
+
+This keeps #541 small: parity is achieved by sharing the handled slash adaptation path, not by forcing transport output schemas to match.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `clients/agent-runtime/src/pre_execution/mod.rs` | Modified | Keep the canonical ingress seam and expose the shared handled-slash adaptation boundary. |
+| `clients/agent-runtime/src/session_commands/types.rs` | Modified | Reuse or lightly extend machine-readable slash outcome/failure kinds consumed by the adapter. |
+| `clients/agent-runtime/src/main.rs` | Modified | Remove CLI/runtime duplicate recognition branching and consume the shared handled-result adapter for message-mode entry. |
+| `clients/agent-runtime/src/gateway/mod.rs` | Modified | Replace duplicated `/webhook` and `/web/chat/stream` slash outcome mapping with the shared adapter while preserving JSON and SSE envelopes. |
+| `clients/agent-runtime/src/gateway/webhook_dispatch.rs` | Modified | Reuse the shared handled-result adapter before provider execution and preserve webhook-specific result wrapping. |
+| `clients/agent-runtime/src/channels/mod.rs` | Modified | Replace channel-specific handled slash branching with shared adaptation while preserving channel send text behavior and derived caller scope semantics. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Small internal failure-kind changes alter existing HTTP/SSE/channel test expectations | Medium | Preserve external envelopes exactly and limit changes to internal classification/adaptation; add regression tests per transport. |
+| CLI message-mode parity work accidentally expands into broader interactive-loop behavior | Medium | Keep proposal/spec scope explicitly tied to current message-based runtime fast paths unless exploration proves the same seam already governs interactive entry. |
+| Shared adapter grows into transport-envelope unification | Low | Keep the adapter transport-neutral and internal; require each transport to continue owning its final response wrapper. |
+
+## Rollback Plan
+
+Revert the shared handled-result adapter and restore the current transport-local outcome mapping in `main.rs`, `gateway/mod.rs`, `gateway/webhook_dispatch.rs`, and `channels/mod.rs`. Because this slice is a routing/integration cleanup with no persistence or schema changes, rollback is limited to restoring the prior branching paths and internal mapping helpers.
+
+## Dependencies
+
+- Slash command registry baseline from #539.
+- Typed command context and non-lossy outcome contract from #540.
+- Existing runtime surfaces already wired to `pre_execution::evaluate_ingress(...)`, especially CLI/runtime, gateway HTTP, gateway streaming, webhook dispatch, and channel ingress.
+- Parent epic #527 Slash Commands Platform and issue #541 as the scoped transport-parity integration slice.
+
+## Success Criteria
+
+- [ ] CLI/runtime message mode, gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher, and channel ingress all adapt handled slash outcomes through one shared internal adapter after `pre_execution::evaluate_ingress(...)`.
+- [ ] Transport-specific divergence for recognized slash commands is reduced to caller-context construction and final envelope wrapping only.
+- [ ] Permission-denied and generic command failure classification remain machine-readable and consistent across transports without forcing a shared external envelope.
+- [ ] Unknown slash-like input continues to fall through consistently in all supported transports.
+- [ ] Focused regression tests cover the supported transport paths and confirm current outward envelope/text shapes are preserved.

--- a/openspec/changes/archive/2026-04-17-slash-command-transport-parity/proposal.md
+++ b/openspec/changes/archive/2026-04-17-slash-command-transport-parity/proposal.md
@@ -9,6 +9,7 @@ The registry, typed command context, and shared `pre_execution::evaluate_ingress
 ## Scope
 
 ### In Scope
+
 - Introduce one shared handled-slash adaptation layer after `pre_execution::evaluate_ingress(...)` that preserves machine-readable outcome and failure-kind data while exposing a transport-neutral handled result.
 - Replace duplicated transport-side branching in CLI/runtime message mode, gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher, and channel ingress with that shared adapter.
 - Remove the extra CLI `recognizes(...)` pre-check so CLI/runtime message entry uses the same shared seam and handled-result contract as the other transports.
@@ -16,6 +17,7 @@ The registry, typed command context, and shared `pre_execution::evaluate_ingress
 - Add focused regression coverage proving the supported transports share dispatch and handled-result adaptation while keeping their current outward payload/text shapes.
 
 ### Out of Scope
+
 - Broad envelope unification across HTTP JSON, SSE, webhook results, CLI text, and channel message bodies.
 - New slash command families beyond the existing integrated command set needed to validate transport parity.
 - Reworking command handler authorization policy, backend persistence policy, or registry-core responsibilities beyond the minimal adapter integration required for #541.

--- a/openspec/changes/archive/2026-04-17-slash-command-transport-parity/specs/slash-command-registry/spec.md
+++ b/openspec/changes/archive/2026-04-17-slash-command-transport-parity/specs/slash-command-registry/spec.md
@@ -34,7 +34,7 @@ Transport-specific code MUST be limited to constructing the transport-appropriat
 - WHEN the transport evaluates ingress through `pre_execution::evaluate_ingress(...)`
 - THEN the shared handled-result adaptation contract MUST report that the input was not handled
 - AND each transport MUST preserve its existing non-command fallthrough behavior
-- AND no transport MUST require a separate pre-dispatch recognition branch to determine that fallthrough.
+- AND transports MUST NOT require a separate pre-dispatch recognition branch to determine fallthrough.
 
 #### Scenario: Blocking outcomes remain shared internally while outward wrappers stay transport-specific
 
@@ -67,7 +67,7 @@ Unknown commands or non-command input MUST preserve existing fallthrough behavio
 - GIVEN CLI/runtime message fast path, gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher execution, and channel-backed ingress each receive the same recognized slash command
 - WHEN they classify that input
 - THEN each transport MUST dispatch the command through `pre_execution::evaluate_ingress(...)`
-- AND no transport MUST bypass that seam with a transport-specific command execution path for the handled slash case.
+- AND transports MUST NOT bypass that seam with a transport-specific command execution path for the handled slash case.
 
 ### Requirement: Transport Parity for Recognized Slash Commands
 

--- a/openspec/changes/archive/2026-04-17-slash-command-transport-parity/specs/slash-command-registry/spec.md
+++ b/openspec/changes/archive/2026-04-17-slash-command-transport-parity/specs/slash-command-registry/spec.md
@@ -1,0 +1,93 @@
+# Delta for slash-command-registry
+
+## ADDED Requirements
+
+### Requirement: Shared Handled Slash Outcome Adaptation Contract
+
+The system MUST adapt handled slash command outcomes through one shared internal contract immediately after `pre_execution::evaluate_ingress(...)`.
+
+For CLI/runtime message fast path, gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher execution, and channel-backed ingress, that shared contract MUST preserve whether ingress was:
+- not handled and allowed to fall through;
+- handled with a success outcome;
+- handled with a blocking outcome; or
+- handled with a failure outcome whose machine-readable failure kind remains observable.
+
+Transport-specific code MUST be limited to constructing the transport-appropriate typed command context before ingress evaluation and wrapping the adapted handled result into that transport's existing external envelope after adaptation. The shared contract MUST NOT require those transports to adopt one shared external payload, event, or text schema.
+
+#### Scenario: Supported transports share one handled-success adaptation boundary
+
+- GIVEN the same recognized slash command is submitted through CLI/runtime message fast path, gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher execution, and channel-backed ingress
+- WHEN `pre_execution::evaluate_ingress(...)` handles that command successfully
+- THEN each transport MUST consume the same shared handled-result adaptation contract after the pre-execution seam
+- AND each transport MUST preserve its current outward envelope shape while wrapping that adapted success.
+
+#### Scenario: Permission-denied failures stay machine-readable across all supported transports
+
+- GIVEN a recognized slash command is denied for authorization reasons through CLI/runtime message fast path, gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher execution, and channel-backed ingress
+- WHEN the handled result is adapted after `pre_execution::evaluate_ingress(...)`
+- THEN the shared contract MUST preserve a machine-readable authorization-denied failure kind for every transport
+- AND transport-specific code MUST derive its outward error wrapper from that shared classified failure instead of reclassifying the denial independently.
+
+#### Scenario: Unknown slash-like input falls through consistently without transport-local recognition branches
+
+- GIVEN slash-like input does not resolve to a registered command in CLI/runtime message fast path, gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher execution, and channel-backed ingress
+- WHEN the transport evaluates ingress through `pre_execution::evaluate_ingress(...)`
+- THEN the shared handled-result adaptation contract MUST report that the input was not handled
+- AND each transport MUST preserve its existing non-command fallthrough behavior
+- AND no transport MUST require a separate pre-dispatch recognition branch to determine that fallthrough.
+
+#### Scenario: Blocking outcomes remain shared internally while outward wrappers stay transport-specific
+
+- GIVEN a recognized slash command produces a blocking outcome through gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher execution, or channel-backed ingress
+- WHEN the handled result is adapted after `pre_execution::evaluate_ingress(...)`
+- THEN the shared contract MUST preserve that blocking classification distinctly from success and failure
+- AND each transport MAY continue rendering that blocking outcome through its current outward JSON, SSE, webhook, or channel text wrapper.
+
+## MODIFIED Requirements
+
+### Requirement: Centralized Dispatch Through the Pre-Execution Seam
+
+The system MUST route recognized slash commands through the existing pre-execution ingress seam.
+
+`pre_execution::evaluate_ingress(...)` SHALL remain the canonical short-circuit seam for recognized slash commands. CLI/runtime message fast path, gateway HTTP request paths, gateway streaming paths, webhook dispatch, and channel-backed ingress MUST call that seam directly for slash interception instead of using transport-local recognition or command-specific branching before shared ingress evaluation.
+
+Unknown commands or non-command input MUST preserve existing fallthrough behavior into normal prompt handling or transport-specific non-command handling.
+
+(Previously: `pre_execution::evaluate_ingress(...)` was required to be the canonical short-circuit seam for recognized slash commands, but the requirement did not forbid transport-local recognition branches before the shared seam.)
+
+#### Scenario: CLI/runtime fast path uses the shared seam without a transport-local recognition gate
+
+- GIVEN CLI/runtime message fast path receives a recognized slash command input
+- WHEN it evaluates ingress
+- THEN it MUST call `pre_execution::evaluate_ingress(...)` without requiring a separate transport-local registry recognition pre-check
+- AND any handled slash result observed by the CLI/runtime fast path MUST come from the shared post-seam handled-result adaptation contract.
+
+#### Scenario: Supported transports preserve one ingress dispatch path for recognized commands
+
+- GIVEN CLI/runtime message fast path, gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher execution, and channel-backed ingress each receive the same recognized slash command
+- WHEN they classify that input
+- THEN each transport MUST dispatch the command through `pre_execution::evaluate_ingress(...)`
+- AND no transport MUST bypass that seam with a transport-specific command execution path for the handled slash case.
+
+### Requirement: Transport Parity for Recognized Slash Commands
+
+The system MUST preserve transport parity for slash command recognition, dispatch, and handled-result adaptation across the canonical runtime entry points that rely on the shared ingress seam.
+
+CLI/runtime message fast path, gateway HTTP request paths, gateway streaming paths, webhook dispatch, and channel-backed ingress MUST classify recognized slash commands through the same pre-execution seam and MUST adapt handled slash outcomes through the same shared internal handled-result contract. Surface-specific caller identity semantics MAY differ, and those differences MUST remain explicit in the typed execution context rather than being normalized away. Transport-specific response-envelope formatting MUST remain outside this change.
+
+(Previously: transport parity required the supported entry points to share slash recognition and dispatch through the central registry contract, but it did not explicitly require a shared handled-result adaptation path after the seam.)
+
+#### Scenario: Supported transports share dispatch and handled adaptation while keeping caller semantics explicit
+
+- GIVEN the same recognized slash command is submitted through CLI/runtime message fast path, gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher execution, and channel-backed ingress
+- WHEN each transport reaches pre-execution ingress evaluation and post-seam handled-result adaptation
+- THEN each transport MUST use the same shared dispatch path and the same shared handled-result adaptation contract
+- AND each resulting internal execution context MUST preserve that transport's own caller-scope semantics
+- AND the system MUST NOT collapse those semantics into a fake unified caller identity model.
+
+#### Scenario: Transport parity remains internal and does not unify outward envelopes
+
+- GIVEN supported transports already expose different external response-envelope shapes for handled slash commands
+- WHEN slash transport parity is enforced for the shared seam and handled-result adaptation contract
+- THEN those transports MAY continue using their existing JSON, SSE, webhook, CLI text, or channel text wrappers
+- AND this change MUST NOT require envelope unification or the introduction of new slash commands.

--- a/openspec/changes/archive/2026-04-17-slash-command-transport-parity/state.yaml
+++ b/openspec/changes/archive/2026-04-17-slash-command-transport-parity/state.yaml
@@ -1,0 +1,12 @@
+change: slash-command-transport-parity
+current_phase: verify
+completed:
+  - explore
+  - propose
+  - spec
+  - design
+  - tasks
+  - apply
+  - verify
+next: archive
+updated: 2026-04-16T00:00:00Z

--- a/openspec/changes/archive/2026-04-17-slash-command-transport-parity/tasks.md
+++ b/openspec/changes/archive/2026-04-17-slash-command-transport-parity/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Slash Command Transport Parity
+
+## Phase 1: Shared adapter foundation
+
+- [x] 1.1 RED: Extend `clients/agent-runtime/src/pre_execution/mod.rs` tests to cover `adapt_handled_ingress(...)` for continue, success, permission-style failure, generic failure, and blocking outcomes.
+- [x] 1.2 GREEN: Create `clients/agent-runtime/src/pre_execution/session_command_adapter.rs` with `HandledIngress`, `HandledIngressOutcome`, `SessionCommandFailureClass`, and `adapt_handled_ingress(...)`.
+- [x] 1.3 REFACTOR: Re-export the adapter from `clients/agent-runtime/src/pre_execution/mod.rs` and keep `evaluate_ingress(...)` unchanged as the canonical seam.
+
+## Phase 2: CLI and gateway transport adoption
+
+- [x] 2.1 RED: Update `clients/agent-runtime/src/main.rs` tests so `maybe_handle_cli_session_command(...)` proves handled slash input uses the seam and unknown slash-like input still falls through without a registry pre-check.
+- [x] 2.2 GREEN: Modify `clients/agent-runtime/src/main.rs` to remove `default_registry().recognizes(...)` and map CLI handled results from `adapt_handled_ingress(...)`.
+- [x] 2.3 RED: Extend `clients/agent-runtime/src/gateway/mod.rs` tests for `/webhook` and `/web/chat/stream` early returns to preserve current JSON/SSE envelopes while consuming the shared handled-result contract.
+- [x] 2.4 GREEN: Replace gateway HTTP and stream post-seam `match` trees in `clients/agent-runtime/src/gateway/mod.rs` with adapter consumption only.
+
+## Phase 3: Webhook and channel transport adoption
+
+- [x] 3.1 RED: Update `clients/agent-runtime/src/gateway/webhook_dispatch.rs` tests to assert handled slash results still short-circuit before provider execution and unknown slash-like input still reaches normal provider flow.
+- [x] 3.2 GREEN: Modify `clients/agent-runtime/src/gateway/webhook_dispatch.rs` to map handled ingress through the adapter into the existing `WebhookTurnResult` envelope.
+- [x] 3.3 RED: Extend `clients/agent-runtime/src/channels/mod.rs` tests to assert handled slash results still short-circuit before memory enrichment, preserve sent text, and keep unknown slash-like fallthrough.
+- [x] 3.4 GREEN: Replace `handle_ingress_outcome(...)` branching in `clients/agent-runtime/src/channels/mod.rs` with adapter-driven wrapping.
+
+## Phase 4: Cleanup and Rust-only validation
+
+- [x] 4.1 REFACTOR: Remove duplicated handled-result mapping left in touched runtime files and keep transport code limited to context building plus final envelope wrapping.
+- [x] 4.2 VALIDATE: Run targeted `cargo test --manifest-path clients/agent-runtime/Cargo.toml` for updated pre-execution, CLI, gateway, webhook, and channel slash-ingress tests; run full runtime `cargo test` only if targeted selection is insufficient.
+- [x] 4.3 VALIDATE: Run `cargo clippy --manifest-path clients/agent-runtime/Cargo.toml --all-targets -- -D warnings`.

--- a/openspec/changes/archive/2026-04-17-slash-command-transport-parity/verify-report.md
+++ b/openspec/changes/archive/2026-04-17-slash-command-transport-parity/verify-report.md
@@ -1,0 +1,97 @@
+# Verification Report
+
+**Change**: `slash-command-transport-parity`
+**Verdict**: PASS WITH WARNINGS
+
+## Completeness
+
+| Metric | Value |
+|---|---:|
+| Tasks total | 14 |
+| Tasks complete | 14 |
+| Tasks incomplete | 0 |
+
+All checklist items in `openspec/changes/slash-command-transport-parity/tasks.md` are marked complete.
+
+## Validation Execution
+
+### Commands run
+
+- `cargo fmt --manifest-path clients/agent-runtime/Cargo.toml --all -- --check` → ✅ passed
+- `cargo clippy --manifest-path clients/agent-runtime/Cargo.toml --all-targets -- -D warnings` → ✅ passed
+- `cargo test --manifest-path clients/agent-runtime/Cargo.toml adapt_handled_ingress_ -- --nocapture` → ✅ 5 passed
+- `cargo test --manifest-path clients/agent-runtime/Cargo.toml cli_session_commands_are_handled_before_agent_execution -- --nocapture` → ✅ 1 passed
+- `cargo test --manifest-path clients/agent-runtime/Cargo.toml cli_unknown_slash_like_input_falls_through -- --nocapture` → ✅ 1 passed
+- `cargo test --manifest-path clients/agent-runtime/Cargo.toml canonical_outcome_early_response_ -- --nocapture` → ✅ 4 passed
+- `cargo test --manifest-path clients/agent-runtime/Cargo.toml web_chat_stream_returns_ -- --nocapture` → ✅ 2 passed
+- `cargo test --manifest-path clients/agent-runtime/Cargo.toml web_chat_stream_unknown_slash_like_input_falls_through_to_provider_execution -- --nocapture` → ✅ 1 passed
+- `cargo test --manifest-path clients/agent-runtime/Cargo.toml execute_ -- --nocapture` → ✅ relevant slash-webhook tests passed, including success, permission-denied, and unknown-fallthrough regressions
+- `cargo test --manifest-path clients/agent-runtime/Cargo.toml ingress_outcome_ -- --nocapture` → ✅ 5 passed
+
+Relevant behavioral evidence now includes:
+
+- HTTP `/webhook`: success, permission-denied, and unknown slash-like fallthrough
+- `/web/chat/stream`: success, generic error, and unknown slash-like fallthrough
+- webhook dispatcher: success, permission-denied, and unknown slash-like fallthrough
+- channel ingress: pre-memory short-circuit, plan-mode handling, success, permission-denied, and unknown slash-like fallthrough
+
+### Build / type check
+
+Skipped intentionally. `openspec/config.yaml` does not define a `build_command`, and `design.md` explicitly says not to add a build step for this slice.
+
+### Coverage
+
+Not configured in `openspec/config.yaml`.
+
+## Spec Compliance Matrix
+
+| Requirement | Scenario | Evidence | Result |
+|---|---|---|---|
+| Shared Handled Slash Outcome Adaptation Contract | Supported transports share one handled-success adaptation boundary | Adapter success unit test passes; HTTP `/webhook`, `/web/chat/stream`, webhook dispatcher, and channel success regressions pass. No CLI success-path regression was found. | ⚠️ PARTIAL |
+| Shared Handled Slash Outcome Adaptation Contract | Permission-denied failures stay machine-readable across all supported transports | Adapter permission-classification unit test passes; HTTP `/webhook`, webhook dispatcher, and channel permission-denied regressions pass. No CLI or SSE permission-denied regression was found. | ⚠️ PARTIAL |
+| Shared Handled Slash Outcome Adaptation Contract | Unknown slash-like input falls through consistently without transport-local recognition branches | CLI, HTTP `/webhook`, `/web/chat/stream`, webhook dispatcher, and channel fallthrough regressions all pass; `main.rs` no longer uses a pre-dispatch `recognizes(...)` gate. | ✅ COMPLIANT |
+| Shared Handled Slash Outcome Adaptation Contract | Blocking outcomes remain shared internally while outward wrappers stay transport-specific | `pre_execution::tests::adapt_handled_ingress_preserves_blocking_outcomes` passes and transport code preserves transport-local wrappers, but no transport-level slash-triggered blocking regression was found. | ⚠️ PARTIAL |
+| Centralized Dispatch Through the Pre-Execution Seam | CLI/runtime fast path uses the shared seam without a transport-local recognition gate | `main.rs::maybe_handle_cli_session_command(...)` routes through `evaluate_ingress(...)` + `adapt_handled_ingress(...)`; handled and fallthrough CLI regressions pass. | ✅ COMPLIANT |
+| Centralized Dispatch Through the Pre-Execution Seam | Supported transports preserve one ingress dispatch path for recognized commands | CLI/runtime, gateway HTTP, gateway SSE, webhook dispatch, and channel ingress all consume the shared seam and adapter; targeted regressions pass across those surfaces. | ✅ COMPLIANT |
+| Transport Parity for Recognized Slash Commands | Supported transports share dispatch and handled adaptation while keeping caller semantics explicit | Shared adapter is used everywhere and typed-context tests preserve caller semantics; runtime evidence is strong for HTTP/SSE/webhook/channel but still incomplete for CLI success/denial parity and slash-blocking transport behavior. | ⚠️ PARTIAL |
+| Transport Parity for Recognized Slash Commands | Transport parity remains internal and does not unify outward envelopes | Code paths and regressions preserve transport-specific JSON, SSE, webhook, and channel wrappers instead of unifying envelopes. | ✅ COMPLIANT |
+
+## Correctness (Static)
+
+| Requirement | Status | Notes |
+|---|---|---|
+| Shared handled-result contract after `evaluate_ingress(...)` | ✅ Implemented | `pre_execution/session_command_adapter.rs` introduces `HandledIngress`, `HandledIngressOutcome`, `SessionCommandFailureClass`, and `adapt_handled_ingress(...)`. |
+| Shared transport adoption | ✅ Implemented | CLI/runtime, gateway HTTP, gateway SSE, webhook dispatch, and channel ingress all consume `adapt_handled_ingress(...)`. |
+| Remove CLI pre-recognition branch | ✅ Implemented | `main.rs::maybe_handle_cli_session_command(...)` calls the seam directly and no longer uses `default_registry().recognizes(...)`. |
+| Preserve transport-specific envelopes | ✅ Implemented | HTTP JSON, SSE events/status, webhook result shape, CLI strings, and channel text remain transport-local wrappers. |
+
+## Coherence (Design)
+
+| Decision | Followed? | Notes |
+|---|---|---|
+| Place shared adaptation helper in `pre_execution` | ✅ Yes | New adapter module lives under `clients/agent-runtime/src/pre_execution/` and is re-exported from `mod.rs`. |
+| Normalize only internal handled results | ✅ Yes | Shared contract is internal only; outward envelopes remain transport-specific. |
+| Collapse permission-style failures into one shared denial class while preserving source kind | ✅ Yes | Adapter maps `MissingCallerScope` and `PermissionDenied` to `SessionCommandFailureClass::PermissionDenied` while preserving the original `failure.kind`. |
+| File changes align with design table | ✅ Yes | Expected runtime files and tests were updated; new adapter file was added. |
+
+## Issues Found
+
+### CRITICAL
+
+None.
+
+### WARNING
+
+1. Behavioral proof is still partial for full all-transport success parity because no CLI success-path regression was found for a recognized slash command.
+2. Behavioral proof is still partial for full all-transport permission-denied parity because no CLI or gateway SSE permission-denied regression was found.
+3. Blocking-outcome transport evidence remains partial: the shared adapter proves blocking classification, but there is still no transport-level regression demonstrating a slash-driven blocking outcome through HTTP, SSE, webhook dispatch, or channels.
+
+### SUGGESTION
+
+1. Add one CLI success regression, one SSE permission-denied regression, and—if a slash command can legitimately yield blocking at runtime—one transport-level blocking regression to close the remaining parity-proof gaps.
+
+## Verdict
+
+PASS WITH WARNINGS
+
+The implementation now satisfies the formatting, lint, and targeted runtime validation gates, and the newly added HTTP `/webhook`, webhook dispatcher, channel `/resume`, and `/web/chat/stream` fallthrough regressions materially strengthen spec coverage. Remaining gaps are evidence gaps around complete all-transport success/denial parity and slash-driven blocking behavior, not failing behavior in the validated paths.

--- a/openspec/specs/slash-command-registry/spec.md
+++ b/openspec/specs/slash-command-registry/spec.md
@@ -140,26 +140,95 @@ Unknown slash-like input MUST fall through without partial or best-effort matchi
 The system MUST route recognized slash commands through the existing pre-execution ingress seam.
 
 `pre_execution::evaluate_ingress(...)` SHALL remain the canonical short-circuit seam for recognized
-slash commands. Once ingress classification identifies a supported slash command, the system MUST
-delegate lookup and dispatch to the central registry instead of using command-specific branching in
-entry-point code.
+slash commands. CLI/runtime message fast path, gateway HTTP request paths, gateway streaming paths,
+webhook dispatch, and channel-backed ingress MUST call that seam directly for slash interception
+instead of using transport-local recognition or command-specific branching before shared ingress
+evaluation.
 
 Unknown commands or non-command input MUST preserve existing fallthrough behavior into normal prompt
-handling.
+handling or transport-specific non-command handling.
 
-#### Scenario: Recognized slash command dispatches through the shared seam
+#### Scenario: CLI/runtime fast path uses the shared seam without a transport-local recognition gate
 
-- GIVEN a canonical runtime entry point receives a recognized slash command input
-- WHEN `pre_execution::evaluate_ingress(...)` evaluates ingress
-- THEN the system MUST perform command lookup and dispatch through the central slash command registry
-- AND the system MUST short-circuit normal prompt execution for that request.
+- GIVEN CLI/runtime message fast path receives a recognized slash command input
+- WHEN it evaluates ingress
+- THEN it MUST call `pre_execution::evaluate_ingress(...)` without requiring a separate
+  transport-local registry recognition pre-check
+- AND any handled slash result observed by the CLI/runtime fast path MUST come from the shared
+  post-seam handled-result adaptation contract.
 
-#### Scenario: Unknown slash-like input preserves normal handling
+#### Scenario: Supported transports preserve one ingress dispatch path for recognized commands
 
-- GIVEN a canonical runtime entry point receives an input that starts with `/` but does not resolve in the registry
-- WHEN `pre_execution::evaluate_ingress(...)` evaluates ingress
-- THEN the system MUST preserve existing non-command prompt handling semantics
-- AND the registry MUST NOT synthesize or guess a closest command match.
+- GIVEN CLI/runtime message fast path, gateway HTTP `/webhook`, gateway streaming
+  `/web/chat/stream`, webhook dispatcher execution, and channel-backed ingress each receive the same
+  recognized slash command
+- WHEN they classify that input
+- THEN each transport MUST dispatch the command through `pre_execution::evaluate_ingress(...)`
+- AND no transport MUST bypass that seam with a transport-specific command execution path for the
+  handled slash case.
+
+### Requirement: Shared Handled Slash Outcome Adaptation Contract
+
+The system MUST adapt handled slash command outcomes through one shared internal contract
+immediately after `pre_execution::evaluate_ingress(...)`.
+
+For CLI/runtime message fast path, gateway HTTP `/webhook`, gateway streaming
+`/web/chat/stream`, webhook dispatcher execution, and channel-backed ingress, that shared contract
+MUST preserve whether ingress was:
+- not handled and allowed to fall through;
+- handled with a success outcome;
+- handled with a blocking outcome; or
+- handled with a failure outcome whose machine-readable failure kind remains observable.
+
+Transport-specific code MUST be limited to constructing the transport-appropriate typed command
+context before ingress evaluation and wrapping the adapted handled result into that transport's
+existing external envelope after adaptation. The shared contract MUST NOT require those transports
+to adopt one shared external payload, event, or text schema.
+
+#### Scenario: Supported transports share one handled-success adaptation boundary
+
+- GIVEN the same recognized slash command is submitted through CLI/runtime message fast path,
+  gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher execution, and
+  channel-backed ingress
+- WHEN `pre_execution::evaluate_ingress(...)` handles that command successfully
+- THEN each transport MUST consume the same shared handled-result adaptation contract after the
+  pre-execution seam
+- AND each transport MUST preserve its current outward envelope shape while wrapping that adapted
+  success.
+
+#### Scenario: Permission-denied failures stay machine-readable across all supported transports
+
+- GIVEN a recognized slash command is denied for authorization reasons through CLI/runtime message
+  fast path, gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher
+  execution, and channel-backed ingress
+- WHEN the handled result is adapted after `pre_execution::evaluate_ingress(...)`
+- THEN the shared contract MUST preserve a machine-readable authorization-denied failure kind for
+  every transport
+- AND transport-specific code MUST derive its outward error wrapper from that shared classified
+  failure instead of reclassifying the denial independently.
+
+#### Scenario: Unknown slash-like input falls through consistently without transport-local
+recognition branches
+
+- GIVEN slash-like input does not resolve to a registered command in CLI/runtime message fast path,
+  gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher execution, and
+  channel-backed ingress
+- WHEN the transport evaluates ingress through `pre_execution::evaluate_ingress(...)`
+- THEN the shared handled-result adaptation contract MUST report that the input was not handled
+- AND each transport MUST preserve its existing non-command fallthrough behavior
+- AND no transport MUST require a separate pre-dispatch recognition branch to determine that
+  fallthrough.
+
+#### Scenario: Blocking outcomes remain shared internally while outward wrappers stay
+transport-specific
+
+- GIVEN a recognized slash command produces a blocking outcome through gateway HTTP `/webhook`,
+  gateway streaming `/web/chat/stream`, webhook dispatcher execution, or channel-backed ingress
+- WHEN the handled result is adapted after `pre_execution::evaluate_ingress(...)`
+- THEN the shared contract MUST preserve that blocking classification distinctly from success and
+  failure
+- AND each transport MAY continue rendering that blocking outcome through its current outward JSON,
+  SSE, webhook, or channel text wrapper.
 
 ### Requirement: Existing Slash Session Behavior Preservation
 
@@ -189,24 +258,37 @@ session-command behavior.
 
 ### Requirement: Transport Parity for Recognized Slash Commands
 
-The system MUST preserve transport parity for slash command recognition and dispatch across the canonical runtime entry points that rely on the shared ingress seam.
+The system MUST preserve transport parity for slash command recognition, dispatch, and handled-result
+adaptation across the canonical runtime entry points that rely on the shared ingress seam.
 
-CLI/direct runtime entry, gateway HTTP request paths, gateway streaming paths, webhook dispatch, and channel-backed ingress MUST all classify recognized slash commands through the same pre-execution seam and central registry contract. Surface-specific caller identity semantics MAY differ, and those differences MUST remain explicit in the typed execution context rather than being normalized away. Transport-specific response-envelope formatting MUST remain outside this change.
+CLI/runtime message fast path, gateway HTTP request paths, gateway streaming paths, webhook
+dispatch, and channel-backed ingress MUST classify recognized slash commands through the same
+pre-execution seam and MUST adapt handled slash outcomes through the same shared internal
+handled-result contract. Surface-specific caller identity semantics MAY differ, and those
+differences MUST remain explicit in the typed execution context rather than being normalized away.
+Transport-specific response-envelope formatting MUST remain outside this change.
 
-#### Scenario: Multiple transports share dispatch while preserving distinct identity semantics
+#### Scenario: Supported transports share dispatch and handled adaptation while keeping caller semantics explicit
 
-- GIVEN the same recognized slash command is submitted through two supported ingress transports with different caller identity semantics
-- WHEN each transport reaches pre-execution ingress evaluation
-- THEN each transport MUST resolve and dispatch the command through the same central registry contract
-- AND each resulting internal execution context MUST preserve that transport's own caller-scope semantics
-- AND the system MUST NOT collapse those semantics into a single fake identity model for parity.
+- GIVEN the same recognized slash command is submitted through CLI/runtime message fast path,
+  gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher execution, and
+  channel-backed ingress
+- WHEN each transport reaches pre-execution ingress evaluation and post-seam handled-result
+  adaptation
+- THEN each transport MUST use the same shared dispatch path and the same shared handled-result
+  adaptation contract
+- AND each resulting internal execution context MUST preserve that transport's own caller-scope
+  semantics
+- AND the system MUST NOT collapse those semantics into a fake unified caller identity model.
 
-#### Scenario: Transport parity does not force envelope parity in this slice
+#### Scenario: Transport parity remains internal and does not unify outward envelopes
 
-- GIVEN two supported transports already return different external response-envelope shapes for recognized slash commands
-- WHEN the internal slash command contract is upgraded for typed context and non-lossy outcomes
-- THEN the transports MAY continue using their existing external envelope shapes for this slice
-- AND the internal contract MUST remain compatible with later transport-envelope work without requiring it now.
+- GIVEN supported transports already expose different external response-envelope shapes for handled
+  slash commands
+- WHEN slash transport parity is enforced for the shared seam and handled-result adaptation contract
+- THEN those transports MAY continue using their existing JSON, SSE, webhook, CLI text, or channel
+  text wrappers
+- AND this change MUST NOT require envelope unification or the introduction of new slash commands.
 
 ### Requirement: Registry-Core Separation from Backend and Authorization Policy
 

--- a/openspec/specs/slash-command-registry/spec.md
+++ b/openspec/specs/slash-command-registry/spec.md
@@ -207,8 +207,7 @@ to adopt one shared external payload, event, or text schema.
 - AND transport-specific code MUST derive its outward error wrapper from that shared classified
   failure instead of reclassifying the denial independently.
 
-#### Scenario: Unknown slash-like input falls through consistently without transport-local
-recognition branches
+#### Scenario: Unknown slash-like input falls through consistently without transport-local recognition branches
 
 - GIVEN slash-like input does not resolve to a registered command in CLI/runtime message fast path,
   gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher execution, and
@@ -216,11 +215,10 @@ recognition branches
 - WHEN the transport evaluates ingress through `pre_execution::evaluate_ingress(...)`
 - THEN the shared handled-result adaptation contract MUST report that the input was not handled
 - AND each transport MUST preserve its existing non-command fallthrough behavior
-- AND no transport MUST require a separate pre-dispatch recognition branch to determine that
+- AND transports MUST NOT require a separate pre-dispatch recognition branch to determine
   fallthrough.
 
-#### Scenario: Blocking outcomes remain shared internally while outward wrappers stay
-transport-specific
+#### Scenario: Blocking outcomes remain shared internally while outward wrappers stay transport-specific
 
 - GIVEN a recognized slash command produces a blocking outcome through gateway HTTP `/webhook`,
   gateway streaming `/web/chat/stream`, webhook dispatcher execution, or channel-backed ingress


### PR DESCRIPTION
## Related Issues

Fixes #541

---

## Summary

This PR unifies slash command transport handling through the shared pre-execution adapter and preserves transport-specific external envelopes.

It also fixes a stream contract regression introduced during the #541 work: dispatcher-backed `/web/chat/stream` blocking outcomes now stay on HTTP 200 and emit `event: error` payloads in the SSE body instead of switching the response status to 403/408.

---

## Tested Information

Validated with focused runtime checks and the repository pre-push hook:

- `cargo test --manifest-path "clients/agent-runtime/Cargo.toml" web_chat_stream_preserves_sse_contract_for_approval_required_blocking -- --nocapture`
- `cargo test --manifest-path "clients/agent-runtime/Cargo.toml" web_chat_stream_preserves_sse_contract_for_timeout_blocking -- --nocapture`
- `cargo fmt --manifest-path "clients/agent-runtime/Cargo.toml" --all -- --check`
- pre-push hook: Rust checks + full runtime test suite (`3562` tests passed)

Reviewers should focus on SSE behavior for blocking outcomes in `clients/agent-runtime/src/gateway/mod.rs`.

---

## Documentation Impact

- Docs updated in:
  - `openspec/specs/slash-command-registry/spec.md`
  - `openspec/changes/archive/2026-04-17-slash-command-transport-parity/`
- No docs update required because: N/A
- I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
