### PR TITLE
refactor(agent-runtime): finalize session command registry routing (#542)

### DIFF
--- a/clients/agent-runtime/src/channels/mod.rs
+++ b/clients/agent-runtime/src/channels/mod.rs
@@ -701,7 +701,7 @@ async fn process_channel_message(ctx: Arc<ChannelRuntimeContext>, mut msg: trait
 
     let user_text = extract_user_text(&msg);
 
-    if handle_ingress_outcome(
+    if maybe_handle_channel_ingress(
         target_channel.as_ref(),
         ctx.memory.as_ref(),
         &session_id,
@@ -1851,7 +1851,7 @@ fn build_history(
     history
 }
 
-async fn handle_ingress_outcome(
+async fn maybe_handle_channel_ingress(
     channel: Option<&Arc<dyn Channel>>,
     memory: &dyn Memory,
     session_id: &str,
@@ -3290,12 +3290,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ingress_outcome_handles_slash_session_commands_before_memory_enrichment() {
+    async fn ingress_outcome_handles_tldr_through_shared_ingress_before_memory_enrichment() {
         let channel = Arc::new(RecordingChannel::default());
         let channel_dyn: Arc<dyn Channel> = channel.clone();
         let memory = CountingMemory::default();
 
-        let handled = handle_ingress_outcome(
+        let handled = maybe_handle_channel_ingress(
             Some(&channel_dyn),
             &memory,
             "session-1",
@@ -3310,17 +3310,17 @@ mod tests {
         let sent = channel.sent_messages.lock().await.clone();
         assert_eq!(sent.len(), 1);
         assert!(sent[0].contains("require sqlite"));
-        // Verify that memory enrichment (recall/store) was NOT called — slash commands
-        // are handled before memory enrichment, so counters must remain zero.
+        // Verify that memory enrichment (recall/store) was NOT called — handled ingress
+        // short-circuits before memory enrichment, so counters must remain zero.
         assert_eq!(
             memory.recall_calls.load(Ordering::SeqCst),
             0,
-            "memory.recall should not be called for slash session commands"
+            "memory.recall should not be called for handled ingress commands"
         );
         assert_eq!(
             memory.store_calls.load(Ordering::SeqCst),
             0,
-            "memory.store should not be called for slash session commands"
+            "memory.store should not be called for handled ingress commands"
         );
     }
 
@@ -3330,7 +3330,7 @@ mod tests {
         let channel_dyn: Arc<dyn Channel> = channel.clone();
         let memory = CountingMemory::default();
 
-        let handled = handle_ingress_outcome(
+        let handled = maybe_handle_channel_ingress(
             Some(&channel_dyn),
             &memory,
             "session-1",
@@ -3352,7 +3352,7 @@ mod tests {
         let memory = CountingMemory::default();
 
         // Verify slash commands work in Plan mode too
-        let handled = handle_ingress_outcome(
+        let handled = maybe_handle_channel_ingress(
             Some(&channel_dyn),
             &memory,
             "session-plan",
@@ -3379,7 +3379,7 @@ mod tests {
         let scope = channel_caller_scope(channel_dyn.name(), "tester");
         seed_resumable_session(&memory, "session-target", &scope).await;
 
-        let handled = handle_ingress_outcome(
+        let handled = maybe_handle_channel_ingress(
             Some(&channel_dyn),
             &memory,
             "session-control",
@@ -3407,7 +3407,7 @@ mod tests {
         let memory = SqliteMemory::new(tmp.path()).unwrap();
         seed_resumable_session(&memory, "session-target", "other-scope").await;
 
-        let handled = handle_ingress_outcome(
+        let handled = maybe_handle_channel_ingress(
             Some(&channel_dyn),
             &memory,
             "session-control",

--- a/clients/agent-runtime/src/gateway/mod.rs
+++ b/clients/agent-runtime/src/gateway/mod.rs
@@ -1761,7 +1761,7 @@ fn parse_webhook_body(body: WebhookJsonBody) -> Result<WebhookBody, WebhookRespo
     }
 }
 
-async fn canonical_outcome_early_response(
+async fn maybe_handle_http_ingress(
     state: &AppState,
     session_id: &str,
     session_source: crate::session_commands::CommandSessionSource,
@@ -2021,7 +2021,7 @@ async fn handle_webhook(
                 crate::session_commands::CommandSessionSource::Generated
             }
         };
-        if let Some((response, persist_idempotency)) = canonical_outcome_early_response(
+        if let Some((response, persist_idempotency)) = maybe_handle_http_ingress(
             &state,
             &session_id,
             http_source,
@@ -2095,8 +2095,8 @@ async fn handle_webhook(
         return response;
     }
 
-    // Intercept deterministic session commands (e.g. /tldr, /resume) before plan/cost guards
-    // so they can short-circuit without being blocked by execution-mode or cost checks.
+    // Intercept shared handled-ingress commands before plan/cost guards so they can
+    // short-circuit without being blocked by execution-mode or cost checks.
     let http_source = match session_source {
         webhook_dispatch::WebhookSessionSource::Explicit => {
             crate::session_commands::CommandSessionSource::Explicit
@@ -2105,7 +2105,7 @@ async fn handle_webhook(
             crate::session_commands::CommandSessionSource::Generated
         }
     };
-    if let Some((response, persist_idempotency)) = canonical_outcome_early_response(
+    if let Some((response, persist_idempotency)) = maybe_handle_http_ingress(
         &state,
         &session_id,
         http_source,
@@ -4111,7 +4111,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn canonical_outcome_early_response_intercepts_slash_session_commands() {
+    async fn maybe_handle_http_ingress_intercepts_compact_through_shared_ingress() {
         // Use SqliteMemory to test real slash-session behavior with actual storage
         let tmp = tempfile::TempDir::new().unwrap();
         let mem = Arc::new(crate::memory::SqliteMemory::new(tmp.path()).unwrap());
@@ -4136,15 +4136,15 @@ mod tests {
             audio_config: crate::config::AudioConfig::default(),
         };
 
-        let response = canonical_outcome_early_response(
+        let response = maybe_handle_http_ingress(
             &state,
             "session-1",
             crate::session_commands::CommandSessionSource::Explicit,
-            "/tldr",
+            "/compact",
             None,
         )
         .await
-        .expect("slash session command should short-circuit");
+        .expect("compact should short-circuit through shared ingress");
         let ((status, Json(body)), _persist) = response;
 
         // Slash-session lookup failures still return 422 with a stable error code.
@@ -4154,7 +4154,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn canonical_outcome_early_response_ignores_unknown_slash_like_input() {
+    async fn maybe_handle_http_ingress_ignores_unknown_slash_like_input() {
         let state = AppState {
             config: Arc::new(Mutex::new(Config::default())),
             cost_tracker: None,
@@ -4176,7 +4176,7 @@ mod tests {
             audio_config: crate::config::AudioConfig::default(),
         };
 
-        let response = canonical_outcome_early_response(
+        let response = maybe_handle_http_ingress(
             &state,
             "session-1",
             crate::session_commands::CommandSessionSource::Explicit,
@@ -4189,7 +4189,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn canonical_outcome_early_response_preserves_resume_success_for_authorized_scope() {
+    async fn maybe_handle_http_ingress_preserves_resume_success_for_authorized_scope() {
         let tmp = tempfile::TempDir::new().unwrap();
         let mem = Arc::new(crate::memory::SqliteMemory::new(tmp.path()).unwrap());
         seed_resumable_session(mem.as_ref(), "session-target", "caller-hash").await;
@@ -4215,7 +4215,7 @@ mod tests {
             audio_config: crate::config::AudioConfig::default(),
         };
 
-        let response = canonical_outcome_early_response(
+        let response = maybe_handle_http_ingress(
             &state,
             "session-control",
             crate::session_commands::CommandSessionSource::Explicit,
@@ -4236,7 +4236,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn canonical_outcome_early_response_preserves_permission_denied_for_resume_target() {
+    async fn maybe_handle_http_ingress_preserves_permission_denied_for_resume_target() {
         let tmp = tempfile::TempDir::new().unwrap();
         let mem = Arc::new(crate::memory::SqliteMemory::new(tmp.path()).unwrap());
         seed_resumable_session(mem.as_ref(), "session-target", "owner-hash").await;
@@ -4262,7 +4262,7 @@ mod tests {
             audio_config: crate::config::AudioConfig::default(),
         };
 
-        let response = canonical_outcome_early_response(
+        let response = maybe_handle_http_ingress(
             &state,
             "session-control",
             crate::session_commands::CommandSessionSource::Explicit,

--- a/clients/agent-runtime/src/gateway/webhook_dispatch.rs
+++ b/clients/agent-runtime/src/gateway/webhook_dispatch.rs
@@ -1112,7 +1112,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_intercepts_slash_session_commands_before_provider_execution() {
+    async fn execute_intercepts_suspend_through_shared_ingress_before_provider_execution() {
         let (_temp, config) = test_config();
         let provider_impl = Arc::new(ScriptedProvider::new(vec![ChatResponse {
             text: Some("should not be called".into()),
@@ -1131,7 +1131,7 @@ mod tests {
                 session_id: "session-slash".into(),
                 session_source: WebhookSessionSource::Explicit,
                 caller_token_hash: None,
-                message: "/tldr".into(),
+                message: "/suspend".into(),
                 execution_mode: ExecutionMode::Standard,
                 include_sse_frames: false,
             },

--- a/clients/agent-runtime/src/main.rs
+++ b/clients/agent-runtime/src/main.rs
@@ -1416,7 +1416,7 @@ async fn handle_agent_command(
     let mut config = effective_config;
 
     if let Some(raw_message) = message.as_deref() {
-        if let Some(result_message) = maybe_handle_cli_session_command(&config, raw_message).await?
+        if let Some(result_message) = maybe_handle_cli_handled_ingress(&config, raw_message).await?
         {
             println!("{result_message}");
             return Ok(());
@@ -1527,7 +1527,7 @@ async fn handle_agent_command(
     run_result
 }
 
-async fn maybe_handle_cli_session_command(
+async fn maybe_handle_cli_handled_ingress(
     config: &Config,
     message: &str,
 ) -> Result<Option<String>> {
@@ -1580,9 +1580,9 @@ async fn handle_code_command(
 ) -> Result<()> {
     let config = apply_code_session_config(config, provider, model, temperature, plan);
 
-    // Intercept slash session commands before agent initialization
+    // Intercept shared handled-ingress commands before agent initialization.
     if let Some(raw_message) = message.as_deref() {
-        if let Some(result_message) = maybe_handle_cli_session_command(&config, raw_message).await?
+        if let Some(result_message) = maybe_handle_cli_handled_ingress(&config, raw_message).await?
         {
             println!("{result_message}");
             return Ok(());
@@ -3427,12 +3427,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cli_session_commands_are_handled_before_agent_execution() {
+    async fn cli_shared_ingress_handles_compact_before_agent_execution() {
         let tmp = TempDir::new().unwrap();
         let mut config = crate::test_support::test_config(&tmp);
         config.memory.backend = "none".into();
 
-        let error = maybe_handle_cli_session_command(&config, "/tldr")
+        let error = maybe_handle_cli_handled_ingress(&config, "/compact")
             .await
             .unwrap_err();
 
@@ -3449,7 +3449,7 @@ mod tests {
             .await
             .unwrap();
 
-        let handled = maybe_handle_cli_session_command(&config, "/tldr")
+        let handled = maybe_handle_cli_handled_ingress(&config, "/tldr")
             .await
             .unwrap();
 
@@ -3464,7 +3464,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let config = crate::test_support::test_config(&tmp);
 
-        let handled = maybe_handle_cli_session_command(&config, "/resume-later")
+        let handled = maybe_handle_cli_handled_ingress(&config, "/resume-later")
             .await
             .unwrap();
 

--- a/clients/agent-runtime/src/pre_execution/mod.rs
+++ b/clients/agent-runtime/src/pre_execution/mod.rs
@@ -242,35 +242,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ingress_classifies_supported_slash_commands_before_pre_execution() {
-        let decision = evaluate_ingress(
-            &IngressMemory,
-            CommandContext::for_cli(
-                "session-1",
-                CommandSessionSource::Existing,
-                ExecutionMode::Standard,
-                None,
-            ),
-            "/tldr",
-            true,
-        )
-        .await;
+    async fn ingress_classifies_in_scope_session_commands_through_shared_seam() {
+        for prompt in ["/resume", "/suspend", "/tldr", "/compact"] {
+            let decision = evaluate_ingress(
+                &IngressMemory,
+                CommandContext::for_cli(
+                    "session-1",
+                    CommandSessionSource::Existing,
+                    ExecutionMode::Standard,
+                    None,
+                ),
+                prompt,
+                true,
+            )
+            .await;
 
-        match decision {
-            IngressDecision::SessionCommand { outcome } => {
-                assert_eq!(
-                    outcome,
-                    SessionCommandOutcome::Failure(crate::session_commands::SessionCommandFailure {
-                        command: "/tldr",
-                        kind: SessionCommandFailureKind::UnsupportedBackend,
-                        session_id: Some("session-1".to_string()),
-                        message:
-                            "slash-session commands require sqlite memory backend (backend=none)"
-                                .to_string(),
-                    })
-                );
+            match decision {
+                IngressDecision::SessionCommand { outcome } => {
+                    assert_eq!(
+                        outcome,
+                        SessionCommandOutcome::Failure(
+                            crate::session_commands::SessionCommandFailure {
+                                command: prompt,
+                                kind: SessionCommandFailureKind::UnsupportedBackend,
+                                session_id: Some("session-1".to_string()),
+                                message: "slash-session commands require sqlite memory backend (backend=none)"
+                                    .to_string(),
+                            }
+                        )
+                    );
+                }
+                other => {
+                    panic!("expected session command interception for {prompt}, got {other:?}")
+                }
             }
-            other => panic!("expected session command interception, got {other:?}"),
         }
     }
 

--- a/clients/agent-runtime/src/session_commands/registry.rs
+++ b/clients/agent-runtime/src/session_commands/registry.rs
@@ -116,12 +116,6 @@ impl SlashCommandRegistry {
             .map(|registration| &registration.descriptor)
     }
 
-    pub fn recognizes(&self, prompt: &str) -> bool {
-        SessionCommandParser::parse(prompt)
-            .and_then(|raw| self.get(&raw.invoked_name))
-            .is_some()
-    }
-
     fn iter(&self) -> impl Iterator<Item = &SlashCommandDescriptor> {
         self.registrations
             .iter()

--- a/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/design.md
+++ b/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/design.md
@@ -1,0 +1,192 @@
+# Design: Finalize Session Command Registry Routing
+
+## Technical Approach
+
+This slice is a cleanup-and-proof pass, not a new registry migration. Production routing already goes
+through `pre_execution::evaluate_ingress(...)` and `session_commands::default_registry()`.
+Implementation should therefore stay narrow:
+
+- remove leftover migration-only helpers that imply transports still need a separate registry
+  recognition phase;
+- rename transport-local helpers/comments so they describe the shared handled-ingress seam rather
+  than a legacy “session command” fast path; and
+- add focused regression proof that the in-scope commands (`/resume`, `/suspend`, `/tldr`,
+  `/compact`) still short-circuit through the shared seam while preserving current behavior.
+
+This design maps directly to the proposal and the existing main specs:
+
+- `openspec/specs/slash-command-registry/spec.md`
+- `openspec/specs/sessions/spec.md`
+
+## Architecture Decisions
+
+### Decision: Keep the shared ingress seam as the only production dispatch entry
+
+**Choice**: Keep `pre_execution::evaluate_ingress(...)` as the canonical short-circuit seam and keep
+`default_registry().dispatch(...)` as the only production binding from slash command names to
+handlers.
+
+**Alternatives considered**:
+- Re-introduce transport-local recognition checks before ingress evaluation.
+- Push more transport-specific dispatch logic into CLI, gateway, webhook, or channels.
+
+**Rationale**: The runtime already satisfies the registry migration functionally. The cleanup slice
+should make that architecture easier to see, not change it.
+
+### Decision: Delete dead recognition helpers instead of preserving compatibility noise
+
+**Choice**: Remove `SlashCommandRegistry::recognizes(...)` and any comments/tests that imply a
+separate pre-dispatch registry recognition branch is still part of production flow.
+
+**Alternatives considered**:
+- Leave the helper in place as a convenience API.
+- Start using the helper in transports before `evaluate_ingress(...)`.
+
+**Rationale**: The helper has no production callers and suggests an architecture that the current
+spec explicitly avoids. Deleting it is the clearest proof that transports rely on the shared seam.
+
+### Decision: Prove routing at the seam, not with a full transport-by-command matrix explosion
+
+**Choice**: Add focused seam-level regression coverage for all four in-scope commands, then keep
+transport tests narrow: one handled-command interception path per surface plus `/resume`
+authorization preservation where that behavior matters.
+
+**Alternatives considered**:
+- Add exhaustive transport × command × outcome test permutations.
+- Add no new tests because the production migration already exists.
+
+**Rationale**: A closure slice needs evidence, but it should stay small. Seam-level tests prove the
+registry owns command recognition, and transport tests prove envelopes and authz-sensitive handling
+remain intact.
+
+## Data Flow
+
+### Shared handled-ingress path
+
+```text
+CLI / Gateway HTTP / Gateway Stream / Webhook Dispatcher / Channel
+            |
+            v
+   build transport-specific CommandContext
+            |
+            v
+ pre_execution::evaluate_ingress(...)
+            |
+            +--> default_registry().dispatch(...)
+                     |
+                     v
+            SessionCommandService handlers
+                     |
+                     v
+     SessionCommandOutcome / Blocking / Continue
+            |
+            v
+ pre_execution::adapt_handled_ingress(...)
+            |
+            v
+ transport-specific outward wrapper
+```
+
+### What remains unchanged
+
+- `SessionCommandService` continues to own backend validation and session ownership/authz checks.
+- `pre_execution::adapt_handled_ingress(...)` remains the shared post-seam contract.
+- CLI text output, gateway JSON, webhook terminal outcomes, SSE framing, and channel reply text stay
+  transport-local and unchanged in shape.
+- Unknown slash-like input still falls through to the existing non-command path.
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `clients/agent-runtime/src/session_commands/registry.rs` | Modify | Remove the unused `recognizes(...)` helper and tighten comments/tests so the registry is described as a dispatch-only core used from the shared ingress seam. |
+| `clients/agent-runtime/src/pre_execution/mod.rs` | Modify | Keep logic unchanged; add/refresh focused seam tests proving `/resume`, `/suspend`, `/tldr`, and `/compact` are classified as handled registry commands and that unknown slash-like input still falls through. |
+| `clients/agent-runtime/src/main.rs` | Modify | Rename the CLI helper/commentary to describe shared ingress short-circuiting rather than a separate session-command path; keep CLI success/error mapping unchanged. |
+| `clients/agent-runtime/src/gateway/mod.rs` | Modify | Rename the early handled-ingress helper/commentary to reflect shared ingress dispatch; preserve HTTP/SSE wrapper behavior, idempotency handling, and failure code mapping. |
+| `clients/agent-runtime/src/gateway/webhook_dispatch.rs` | Modify | Align helper naming/comments with shared ingress terminology and refresh focused provider-bypass regression coverage. |
+| `clients/agent-runtime/src/channels/mod.rs` | Modify | Clarify handled-ingress naming/comments and keep channel reply shaping unchanged while refreshing focused regression coverage. |
+
+## Interfaces / Contracts
+
+No new interfaces or transport contracts are introduced.
+
+The following contracts remain authoritative and unchanged:
+
+```rust
+pub async fn evaluate_ingress(
+    memory: &dyn Memory,
+    context: CommandContext,
+    prompt: &str,
+    include_blocking_fallback: bool,
+) -> IngressDecision
+```
+
+```rust
+pub async fn dispatch(
+    &self,
+    service: &SessionCommandService<'_>,
+    context: CommandContext,
+    prompt: &str,
+) -> Option<SessionCommandOutcome>
+```
+
+```rust
+pub enum HandledIngress {
+    NotHandled,
+    Handled(HandledIngressOutcome),
+}
+```
+
+Behavior explicitly preserved:
+
+- `/resume`, `/suspend`, `/tldr`, and `/compact` remain the only in-scope commands for this change.
+- `SessionCommandFailureKind` classification stays machine-readable.
+- Authorization-sensitive `/resume` failures continue to be decided in the service layer, not in the
+  registry core.
+- Outward transport envelopes stay where they are today.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Shared seam recognition for `/resume`, `/suspend`, `/tldr`, `/compact` | Extend `pre_execution::tests` with focused handled-command assertions using existing test helpers and backend expectations. |
+| Unit | Unknown slash-like fallthrough and invalid-argument handling | Keep/update existing `pre_execution` tests so cleanup does not reintroduce transport-local pre-gates. |
+| Integration-ish module tests | CLI helper, gateway HTTP helper, webhook dispatcher, and channel ingress still short-circuit before normal execution/provider paths | Refresh existing inline tests in `main.rs`, `gateway/mod.rs`, `gateway/webhook_dispatch.rs`, and `channels/mod.rs`; prefer one interception proof per surface rather than a full Cartesian matrix. |
+| Integration-ish module tests | `/resume` authorized and denied outcomes remain preserved after cleanup | Keep existing gateway/webhook/channel resume tests and update only as needed for renamed helpers or comments. |
+| E2E | None | Not required for this closure cleanup slice. Existing module-level proof is sufficient. |
+
+## Validation Guidance
+
+Run the smallest relevant Rust checks after implementation:
+
+```bash
+cargo test --manifest-path clients/agent-runtime/Cargo.toml pre_execution::
+cargo test --manifest-path clients/agent-runtime/Cargo.toml gateway::
+cargo test --manifest-path clients/agent-runtime/Cargo.toml webhook_dispatch::
+cargo test --manifest-path clients/agent-runtime/Cargo.toml channels::
+cargo clippy --manifest-path clients/agent-runtime/Cargo.toml --all-targets -- -D warnings
+cargo fmt --manifest-path clients/agent-runtime/Cargo.toml --all -- --check
+```
+
+If targeted test filters are awkward because tests are inline module tests, run the smallest
+file-adjacent `cargo test --manifest-path clients/agent-runtime/Cargo.toml` command that covers the
+modified modules and report any skipped validation explicitly.
+
+## Migration / Rollout
+
+No migration required.
+
+This change does not alter persisted data, command registration contents, authz policy, or transport
+contracts. Rollout is a normal code deploy.
+
+## Rollback Considerations
+
+Rollback is a single revert of the cleanup/proof patch.
+
+Because the slice does not change storage schema, registry contents, command semantics, or outward
+transport envelopes, reverting restores the previous helper names/comments and test state without any
+data repair.
+
+## Open Questions
+
+- [ ] None.

--- a/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/exploration.md
+++ b/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/exploration.md
@@ -1,0 +1,37 @@
+## Exploration: issue #542 session command registry migration
+
+### Current State
+`/resume`, `/suspend`, `/tldr`, and `/compact` already execute through the central registry in production code. `pre_execution::evaluate_ingress(...)` constructs `SessionCommandService`, calls `default_registry().dispatch(...)`, and returns early before any blocking fallback. The CLI fast path (`main.rs`), gateway HTTP early response and SSE path (`gateway/mod.rs`), webhook dispatcher (`gateway/webhook_dispatch.rs`), and channel ingress (`channels/mod.rs`) all route recognized slash input through that shared seam rather than calling session-command handlers directly.
+
+There is no remaining production path that invokes `SessionCommandService::handle_resume`, `handle_suspend`, `handle_tldr`, or `handle_compact` directly outside the registry handlers in `session_commands/registry.rs`. The remaining legacy surface is routing/adaptation glue, not duplicate command execution.
+
+### Affected Areas
+- `clients/agent-runtime/src/pre_execution/mod.rs` — canonical ingress seam; registry dispatch already happens here.
+- `clients/agent-runtime/src/session_commands/registry.rs` — built-in registrations and the only production bindings from command names to handlers.
+- `clients/agent-runtime/src/session_commands/service.rs` — preserved command behavior and authz/backend checks behind registry handlers.
+- `clients/agent-runtime/src/main.rs` — CLI compatibility shim still named around “session commands,” but already calls the shared ingress seam.
+- `clients/agent-runtime/src/gateway/mod.rs` — legacy HTTP/SSE transport still keeps an early-response helper for deterministic slash interception before plan/cost guards.
+- `clients/agent-runtime/src/gateway/webhook_dispatch.rs` — dispatcher path already uses the shared ingress seam.
+- `clients/agent-runtime/src/channels/mod.rs` — channel ingress already uses the shared ingress seam.
+
+### Approaches
+1. **Declare #542 complete as-is** — treat the current state as satisfying the migration.
+   - Pros: no code churn; execution is already registry-backed.
+   - Cons: leaves small cleanup debt and “session command” compatibility naming that makes completion less obvious during review.
+   - Effort: Low
+
+2. **Do a closure cleanup slice** — keep behavior unchanged, but remove the leftover migration noise.
+   - Pros: smallest code change that makes completion obvious; avoids broadening into new command families.
+   - Cons: mostly cleanup/documentation/tests rather than functional migration.
+   - Effort: Low
+
+### Recommendation
+Use **Approach 2**. The functional migration is already done, so the smallest focused slice is a closure pass that removes or isolates the last compatibility artifacts: drop the unused `SlashCommandRegistry::recognizes(...)` helper, rename transport-local helpers/comments that still imply a separate session-command path, and add/refresh targeted tests that assert all four commands short-circuit through `pre_execution::evaluate_ingress(...)` across the existing ingress surfaces. That closes #542 cleanly without inventing new slash command families.
+
+### Risks
+- Reviewers may expect visible behavior changes even though the remaining work is mostly cleanup and proof.
+- Renaming helper functions/comments can create small merge conflicts with nearby slash-command work such as #543.
+- If the team interprets “old special-case routing” to include transport-specific outward envelope adaptation, #542 could be blocked by a larger refactor; current spec language does not require that refactor.
+
+### Ready for Proposal
+Yes — propose a narrow cleanup/proof change named `finalize-session-command-registry-routing` focused on isolating/removing leftover migration shims without changing command behavior.

--- a/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/proposal.md
+++ b/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/proposal.md
@@ -1,0 +1,62 @@
+# Proposal: Finalize Session Command Registry Routing
+
+## Intent
+
+Issue #542 is no longer a core migration of `/resume`, `/suspend`, `/tldr`, and `/compact` into the slash command registry; exploration shows those commands already execute through the registry in production. This change finalizes that migration by removing leftover migration shims and naming noise, and by adding focused proof that the canonical ingress seam still preserves current behavior, authz checks, and transport parity.
+
+## Scope
+
+### In Scope
+- Remove or isolate leftover migration-only routing helpers and comments that imply a separate session-command execution path when recognized commands already short-circuit through `pre_execution::evaluate_ingress(...)`.
+- Simplify registry-adjacent compatibility noise in the runtime surfaces involved in slash command ingress, while preserving existing outward transport envelopes.
+- Add or refresh targeted proof tests for `/resume`, `/suspend`, `/tldr`, and `/compact` across the existing ingress surfaces so #542 can be closed with evidence.
+
+### Out of Scope
+- Adding new slash command families beyond `/resume`, `/suspend`, `/tldr`, and `/compact`.
+- Broad refactors of transport envelope shaping, gateway response models, or cross-surface payload unification.
+- Reworking session-command service behavior, ownership/authz policy, or persistence semantics defined by the sessions spec.
+- Folding in adjacent slash-command platform work from #543 or other #527 follow-ups.
+
+## Approach
+
+Treat this slice as closure cleanup, not a feature migration. Keep `pre_execution::evaluate_ingress(...)` as the canonical interception seam, keep `session_commands/registry.rs` as the only production binding from command names to handlers, and prune leftover compatibility artifacts that obscure that reality. Then add narrow tests proving that CLI/runtime, gateway, webhook, and channel-backed ingress continue to route the four in-scope commands through the shared registry-backed path without changing command semantics or transport-specific outward wrappers.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `clients/agent-runtime/src/pre_execution/mod.rs` | Modified | Preserve and clarify the canonical shared ingress seam for recognized slash commands. |
+| `clients/agent-runtime/src/session_commands/registry.rs` | Modified | Remove leftover migration noise and keep built-in command registration as the sole production dispatch binding. |
+| `clients/agent-runtime/src/session_commands/service.rs` | Verified | Preserve existing command behavior, ownership checks, and backend validation behind registry handlers without broad logic changes. |
+| `clients/agent-runtime/src/main.rs` | Modified | Clean up CLI compatibility naming/shims that still suggest a separate session-command path. |
+| `clients/agent-runtime/src/gateway/mod.rs` | Modified | Isolate or rename early-response helpers/comments so they clearly reflect shared ingress dispatch rather than legacy special-case routing. |
+| `clients/agent-runtime/src/gateway/webhook_dispatch.rs` | Modified | Keep webhook dispatch aligned to the shared ingress seam and add proof coverage where needed. |
+| `clients/agent-runtime/src/channels/mod.rs` | Modified | Keep channel-backed ingress aligned to the shared ingress seam and add proof coverage where needed. |
+| `clients/agent-runtime/tests/` or relevant runtime test modules | Modified | Add targeted regression coverage proving registry-backed routing for the four in-scope commands. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Cleanup-only scope may look smaller than reviewers expect for a “migration” issue | Medium | State clearly that functional migration is already complete and this slice closes the remaining parity and deprecation evidence. |
+| Renames around shared slash routing may conflict with nearby #543 work | Medium | Keep patch small, prefer localized helper/comment cleanup, and avoid unrelated structural refactors. |
+| Tests may accidentally assert transport envelope details instead of shared dispatch behavior | Low | Focus assertions on ingress routing, handled-result classification, and preserved command semantics rather than outward wrapper formatting. |
+
+## Rollback Plan
+
+Revert the cleanup patch and targeted tests in a single changeset. Because the proposal preserves current behavior and does not introduce new command families or transport contracts, rollback returns the runtime to its prior compatibility naming and proof state without data migration or persistent state changes.
+
+## Dependencies
+
+- Exploration artifact: `openspec/changes/finalize-session-command-registry-routing/exploration.md`
+- Issue definition: `tmp/claudio-issues/542-migrate-session-commands.md`
+- Parent epic: `#527 Slash Commands Platform`
+- Runtime contract references: `openspec/specs/slash-command-registry/spec.md`, `openspec/specs/sessions/spec.md`
+
+## Success Criteria
+
+- [ ] The proposal remains narrowly scoped to finalizing #542 for `/resume`, `/suspend`, `/tldr`, and `/compact` only.
+- [ ] Leftover migration helpers, naming, or comments that imply duplicate session-command routing are removed or clearly isolated for deprecation.
+- [ ] Targeted tests prove recognized in-scope commands short-circuit through `pre_execution::evaluate_ingress(...)` across the supported runtime ingress surfaces.
+- [ ] Existing behavior remains intact, including session ownership/authz checks, unsupported-backend handling, and current transport-specific outward envelopes.
+- [ ] The resulting runtime surfaces are easier to review and maintain because registry-backed routing is explicit and legacy migration noise is reduced.

--- a/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/specs/slash-command-registry/spec.md
+++ b/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/specs/slash-command-registry/spec.md
@@ -1,0 +1,73 @@
+# Delta for Slash Command Registry
+
+## MODIFIED Requirements
+
+### Requirement: Centralized Dispatch Through the Pre-Execution Seam
+
+The system MUST route `/resume`, `/suspend`, `/tldr`, and `/compact` through the existing registry-backed pre-execution ingress seam.
+
+`pre_execution::evaluate_ingress(...)` SHALL remain the canonical production short-circuit seam for these four session commands. CLI/runtime message fast path, gateway HTTP request paths, gateway streaming paths, webhook dispatch, and channel-backed ingress MUST submit recognized in-scope session commands to that shared seam, and production routing MUST NOT depend on transport-local direct-handler branches for those commands.
+
+(Previously: the spec required recognized slash commands in general to use the shared pre-execution seam, but it did not explicitly close issue #542 by naming the four migrated session commands or by prohibiting lingering production direct-handler routing for them.)
+
+#### Scenario: In-scope session commands use the shared seam across supported ingress surfaces
+
+- GIVEN CLI/runtime message fast path, gateway HTTP `/webhook`, gateway streaming `/web/chat/stream`, webhook dispatcher execution, and channel-backed ingress each receive `/resume`, `/suspend`, `/tldr`, or `/compact`
+- WHEN the runtime classifies that recognized command input
+- THEN each supported ingress surface MUST route the command through `pre_execution::evaluate_ingress(...)`
+- AND the handled command dispatch MUST come from the registry-backed ingress path rather than a transport-local command execution branch.
+
+#### Scenario: Unknown or non-command input still falls through normally
+
+- GIVEN any supported ingress surface receives non-command input or slash-like input that is not `/resume`, `/suspend`, `/tldr`, or `/compact`
+- WHEN the runtime evaluates ingress
+- THEN the system MUST preserve existing non-command or unknown-command fallthrough behavior
+- AND this change MUST NOT introduce new command recognition behavior outside the four in-scope session commands.
+
+### Requirement: Existing Slash Session Behavior Preservation
+
+The system MUST preserve the current behavior of `/resume`, `/suspend`, `/tldr`, and `/compact` while finalizing their registry-backed routing.
+
+For this change, registry-backed ingress routing MUST preserve the same command semantics already defined by the sessions specification. Authorization-sensitive `/resume` behavior, unsupported-backend outcomes for slash-session persistence commands, invalid-target handling, unknown-session handling, and success results MUST remain equivalent to the current session-command behavior. Routing cleanup for #542 MUST reorganize ingress and dispatch proof only; it MUST NOT broaden, weaken, or bypass service-layer authorization or backend checks.
+
+(Previously: the spec required existing slash session behavior to remain intact during registry adoption, but it did not explicitly tie #542 completion to preservation of authorization and backend validation while removing lingering direct-routing assumptions.)
+
+#### Scenario: Resume authorization rules remain intact after registry-backed dispatch
+
+- GIVEN a recognized `/resume` command is routed through `pre_execution::evaluate_ingress(...)`
+- AND the current caller scope is not authorized to view or resume the target session under the existing sessions rules
+- WHEN the registry-backed handler evaluates the command
+- THEN the system MUST return the same explicit authorization-denied outcome required by the sessions specification
+- AND the runtime MUST NOT resume the target session
+- AND registry-backed routing MUST NOT bypass or reinterpret that authorization decision.
+
+#### Scenario: Slash-session backend checks remain intact after registry-backed dispatch
+
+- GIVEN a recognized `/suspend`, `/tldr`, `/compact`, or `/resume` command is routed through `pre_execution::evaluate_ingress(...)`
+- AND the configured backend does not satisfy the existing slash-session persistence requirements
+- WHEN the registry-backed handler evaluates the command
+- THEN the system MUST return the same explicit unsupported outcome required by the sessions specification
+- AND the system MUST NOT replace that outcome with fallback success, silent no-op behavior, or generic conversational handling.
+
+## ADDED Requirements
+
+### Requirement: Registry Bindings Are the Sole Production Session-Command Dispatch Entry
+
+The system MUST treat the registry's built-in bindings for `/resume`, `/suspend`, `/tldr`, and `/compact` as the only production command-name-to-handler dispatch entry for those commands.
+
+Production runtime surfaces MAY keep transport-specific context construction and outward response-envelope adaptation, but they MUST NOT keep a separate production routing path that directly selects or invokes the four session-command handlers outside registry-backed dispatch. Any remaining compatibility or deprecation scaffolding MUST be isolated so it does not change production routing for the four in-scope commands.
+
+#### Scenario: Registry binding remains the only production dispatch entry for in-scope session commands
+
+- GIVEN `/resume`, `/suspend`, `/tldr`, and `/compact` are available as built-in session commands
+- WHEN production runtime code resolves one of those command names for execution
+- THEN the system MUST dispatch through the registry binding for that canonical command
+- AND production routing MUST NOT require a separate direct-handler selection path for that command name.
+
+#### Scenario: Transport-specific wrappers stay outside the production dispatch decision
+
+- GIVEN a supported transport already has its own outward wrapper for handled slash-command results
+- WHEN `/resume`, `/suspend`, `/tldr`, or `/compact` completes through registry-backed ingress dispatch
+- THEN the transport MAY keep its existing outward response wrapper
+- AND that wrapper MUST be applied after the shared handled-result classification
+- AND the wrapper MUST NOT become a separate production routing path for selecting the command handler.

--- a/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/state.yaml
+++ b/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/state.yaml
@@ -1,0 +1,12 @@
+change: finalize-session-command-registry-routing
+current_phase: verify
+completed:
+  - explore
+  - propose
+  - spec
+  - design
+  - tasks
+  - apply
+  - verify
+next: archive
+updated: 2026-04-17T00:00:00Z

--- a/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/tasks.md
+++ b/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: Finalize Session Command Registry Routing
+
+## Phase 1: Regression Proof (RED)
+
+- [x] 1.1 Extend `clients/agent-runtime/src/pre_execution/mod.rs` tests to assert `/resume`, `/suspend`, `/tldr`, and `/compact` are handled through `evaluate_ingress(...)`, and that unknown slash-like input still falls through.
+- [x] 1.2 Refresh focused interception tests in `clients/agent-runtime/src/main.rs`, `clients/agent-runtime/src/gateway/mod.rs`, `clients/agent-runtime/src/gateway/webhook_dispatch.rs`, and `clients/agent-runtime/src/channels/mod.rs` so each surface proves handled commands enter the shared ingress seam instead of a transport-local branch.
+- [x] 1.3 Keep or add one focused `/resume` authorization-preservation regression in the affected surface tests so cleanup cannot bypass service-layer denial behavior.
+
+## Phase 2: Minimal Cleanup and Wiring (GREEN)
+
+- [x] 2.1 Remove the unused `SlashCommandRegistry::recognizes(...)` helper from `clients/agent-runtime/src/session_commands/registry.rs` and tighten nearby comments/tests so registry bindings remain the only production dispatch entry.
+- [x] 2.2 Rename legacy “session command fast path” helper names/comments in `clients/agent-runtime/src/main.rs` and `clients/agent-runtime/src/gateway/mod.rs` to describe shared handled-ingress routing, without changing outward CLI/HTTP/SSE behavior.
+- [x] 2.3 Align helper names/comments in `clients/agent-runtime/src/gateway/webhook_dispatch.rs` and `clients/agent-runtime/src/channels/mod.rs` with shared ingress terminology while preserving current wrapper and reply shaping.
+
+## Phase 3: Refactor and Rust Validation
+
+- [x] 3.1 Refactor touched tests/helpers only as needed to remove migration wording duplication and keep assertions centered on shared ingress classification, not transport envelope formatting.
+- [x] 3.2 Run targeted Rust validation for the modified runtime modules: `cargo test --manifest-path clients/agent-runtime/Cargo.toml pre_execution::`, `cargo test --manifest-path clients/agent-runtime/Cargo.toml gateway::`, `cargo test --manifest-path clients/agent-runtime/Cargo.toml webhook_dispatch::`, and `cargo test --manifest-path clients/agent-runtime/Cargo.toml channels::` (or the smallest equivalent module-adjacent commands).
+- [x] 3.3 Run Rust quality checks for this slice: `cargo fmt --manifest-path clients/agent-runtime/Cargo.toml --all -- --check` and `cargo clippy --manifest-path clients/agent-runtime/Cargo.toml --all-targets -- -D warnings`.

--- a/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/verify-report.md
+++ b/openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/verify-report.md
@@ -1,0 +1,113 @@
+## Verification Report
+
+**Change**: finalize-session-command-registry-routing  
+**Version**: N/A
+
+---
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 9 |
+| Tasks complete | 9 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/finalize-session-command-registry-routing/tasks.md` are marked complete.
+
+---
+
+### Build & Tests Execution
+
+**Build / type-check**: ✅ Passed
+
+```text
+cargo fmt --manifest-path clients/agent-runtime/Cargo.toml --all -- --check
+cargo clippy --manifest-path clients/agent-runtime/Cargo.toml --all-targets -- -D warnings
+```
+
+- `cargo fmt` exited successfully.
+- `cargo clippy` exited successfully with `-D warnings`.
+
+**Tests**: ✅ Passed
+
+```text
+cargo test --manifest-path clients/agent-runtime/Cargo.toml pre_execution::
+  -> 14 passed / 0 failed (src/lib.rs)
+  -> 14 passed / 0 failed (src/main.rs)
+
+cargo test --manifest-path clients/agent-runtime/Cargo.toml gateway::
+  -> 256 passed / 0 failed (src/lib.rs)
+  -> 256 passed / 0 failed (src/main.rs)
+
+cargo test --manifest-path clients/agent-runtime/Cargo.toml webhook_dispatch::
+  -> 19 passed / 0 failed (src/lib.rs)
+  -> 19 passed / 0 failed (src/main.rs)
+
+cargo test --manifest-path clients/agent-runtime/Cargo.toml channels::
+  -> 766 passed / 0 failed (src/lib.rs)
+  -> 766 passed / 0 failed (src/main.rs)
+
+Focused behavioral proofs:
+- cargo test --manifest-path clients/agent-runtime/Cargo.toml cli_shared_ingress_handles_compact_before_agent_execution
+  -> 1 passed / 0 failed
+- cargo test --manifest-path clients/agent-runtime/Cargo.toml cli_unknown_slash_like_input_falls_through
+  -> 1 passed / 0 failed
+- cargo test --manifest-path clients/agent-runtime/Cargo.toml dispatch_preserves_resume_authorization_after_registry_lookup
+  -> 1 passed / 0 failed (src/lib.rs) and 1 passed / 0 failed (src/main.rs)
+- cargo test --manifest-path clients/agent-runtime/Cargo.toml dispatch_routes_suspend_via_registry
+  -> 1 passed / 0 failed (src/lib.rs) and 1 passed / 0 failed (src/main.rs)
+```
+
+**Coverage**: ➖ Not configured in `openspec/config.yaml`
+
+---
+
+### Spec Compliance Matrix
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Centralized Dispatch Through the Pre-Execution Seam | In-scope session commands use the shared seam across supported ingress surfaces | `src/pre_execution/mod.rs > ingress_classifies_in_scope_session_commands_through_shared_seam`; `src/main.rs > cli_shared_ingress_handles_compact_before_agent_execution`; `src/gateway/mod.rs > maybe_handle_http_ingress_intercepts_compact_through_shared_ingress`; `src/gateway/webhook_dispatch.rs > execute_intercepts_suspend_through_shared_ingress_before_provider_execution`; `src/channels/mod.rs > ingress_outcome_handles_tldr_through_shared_ingress_before_memory_enrichment` | ✅ COMPLIANT |
+| Centralized Dispatch Through the Pre-Execution Seam | Unknown or non-command input still falls through normally | `src/pre_execution/mod.rs > ingress_preserves_unknown_slash_like_input`; `src/main.rs > cli_unknown_slash_like_input_falls_through`; `src/gateway/mod.rs > maybe_handle_http_ingress_ignores_unknown_slash_like_input`; `src/gateway/webhook_dispatch.rs > execute_preserves_unknown_slash_like_input_for_normal_provider_flow`; `src/channels/mod.rs > ingress_outcome_preserves_unknown_slash_like_input` | ✅ COMPLIANT |
+| Existing Slash Session Behavior Preservation | Resume authorization rules remain intact after registry-backed dispatch | `src/session_commands/registry.rs > dispatch_preserves_resume_authorization_after_registry_lookup`; `src/gateway/mod.rs > maybe_handle_http_ingress_preserves_permission_denied_for_resume_target`; `src/gateway/webhook_dispatch.rs > execute_preserves_permission_denied_for_resume_target`; `src/channels/mod.rs > ingress_outcome_preserves_permission_denied_for_resume_target` | ✅ COMPLIANT |
+| Existing Slash Session Behavior Preservation | Slash-session backend checks remain intact after registry-backed dispatch | `src/pre_execution/mod.rs > ingress_classifies_in_scope_session_commands_through_shared_seam`; `src/main.rs > cli_shared_ingress_handles_compact_before_agent_execution`; `src/gateway/webhook_dispatch.rs > execute_intercepts_suspend_through_shared_ingress_before_provider_execution`; `src/channels/mod.rs > ingress_outcome_handles_tldr_through_shared_ingress_before_memory_enrichment` | ✅ COMPLIANT |
+| Registry Bindings Are the Sole Production Session-Command Dispatch Entry | Registry binding remains the only production dispatch entry for in-scope session commands | `src/session_commands/registry.rs > dispatch_routes_suspend_via_registry`; `src/session_commands/registry.rs > dispatch_preserves_resume_authorization_after_registry_lookup`; `src/pre_execution/mod.rs > ingress_classifies_in_scope_session_commands_through_shared_seam` | ✅ COMPLIANT |
+| Registry Bindings Are the Sole Production Session-Command Dispatch Entry | Transport-specific wrappers stay outside the production dispatch decision | `src/gateway/mod.rs > maybe_handle_http_ingress_preserves_resume_success_for_authorized_scope`; `src/gateway/webhook_dispatch.rs > execute_intercepts_authorized_resume_success_before_provider_execution`; `src/channels/mod.rs > ingress_outcome_preserves_resume_success_for_authorized_scope`; `src/main.rs > cli_session_command_success_returns_message` | ✅ COMPLIANT |
+
+**Compliance summary**: 6/6 scenarios compliant
+
+---
+
+### Correctness (Static — Structural Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Centralized Dispatch Through the Pre-Execution Seam | ✅ Implemented | `clients/agent-runtime/src/pre_execution/mod.rs` keeps `default_registry().dispatch(...)` inside `evaluate_ingress(...)`, and CLI/gateway/webhook/channels all route through that seam before transport-specific wrapping. |
+| Existing Slash Session Behavior Preservation | ✅ Implemented | Service-layer outcomes remain unchanged; surface tests still observe authorization-denied and unsupported-backend behavior instead of bypassing service checks. |
+| Registry Bindings Are the Sole Production Session-Command Dispatch Entry | ✅ Implemented | `SlashCommandRegistry::recognizes(...)` was removed from `clients/agent-runtime/src/session_commands/registry.rs`; no remaining production `recognizes(` call sites were found under `clients/agent-runtime/src`. |
+
+---
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Keep the shared ingress seam as the only production dispatch entry | ✅ Yes | All touched transports call `evaluate_ingress(...)` and adapt via handled-ingress classification. |
+| Delete dead recognition helpers instead of preserving compatibility noise | ✅ Yes | `recognizes(...)` is removed and helper/comment names now describe shared handled-ingress routing. |
+| Prove routing at the seam, not with a full transport-by-command matrix explosion | ✅ Yes | Verification found one seam-level multi-command test plus focused per-surface interception and authz regressions, matching the narrow proof strategy in `design.md`. |
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+None
+
+**WARNING** (should fix):
+None
+
+**SUGGESTION** (nice to have):
+None
+
+---
+
+### Verdict
+PASS
+
+Implementation matches the change spec, design, and task list, and the required Rust verification commands plus focused behavioral regressions all passed.

--- a/openspec/specs/slash-command-registry/spec.md
+++ b/openspec/specs/slash-command-registry/spec.md
@@ -137,35 +137,34 @@ Unknown slash-like input MUST fall through without partial or best-effort matchi
 
 ### Requirement: Centralized Dispatch Through the Pre-Execution Seam
 
-The system MUST route recognized slash commands through the existing pre-execution ingress seam.
+The system MUST route `/resume`, `/suspend`, `/tldr`, and `/compact` through the existing
+registry-backed pre-execution ingress seam.
 
-`pre_execution::evaluate_ingress(...)` SHALL remain the canonical short-circuit seam for recognized
-slash commands. CLI/runtime message fast path, gateway HTTP request paths, gateway streaming paths,
-webhook dispatch, and channel-backed ingress MUST call that seam directly for slash interception
-instead of using transport-local recognition or command-specific branching before shared ingress
-evaluation.
+`pre_execution::evaluate_ingress(...)` SHALL remain the canonical production short-circuit seam for
+these four session commands. CLI/runtime message fast path, gateway HTTP request paths, gateway
+streaming paths, webhook dispatch, and channel-backed ingress MUST submit recognized in-scope
+session commands to that shared seam, and production routing MUST NOT depend on transport-local
+direct-handler branches for those commands.
 
-Unknown commands or non-command input MUST preserve existing fallthrough behavior into normal prompt
-handling or transport-specific non-command handling.
-
-#### Scenario: CLI/runtime fast path uses the shared seam without a transport-local recognition gate
-
-- GIVEN CLI/runtime message fast path receives a recognized slash command input
-- WHEN it evaluates ingress
-- THEN it MUST call `pre_execution::evaluate_ingress(...)` without requiring a separate
-  transport-local registry recognition pre-check
-- AND any handled slash result observed by the CLI/runtime fast path MUST come from the shared
-  post-seam handled-result adaptation contract.
-
-#### Scenario: Supported transports preserve one ingress dispatch path for recognized commands
+#### Scenario: In-scope session commands use the shared seam across supported ingress surfaces
 
 - GIVEN CLI/runtime message fast path, gateway HTTP `/webhook`, gateway streaming
-  `/web/chat/stream`, webhook dispatcher execution, and channel-backed ingress each receive the same
-  recognized slash command
-- WHEN they classify that input
-- THEN each transport MUST dispatch the command through `pre_execution::evaluate_ingress(...)`
-- AND no transport MUST bypass that seam with a transport-specific command execution path for the
-  handled slash case.
+  `/web/chat/stream`, webhook dispatcher execution, and channel-backed ingress each receive
+  `/resume`, `/suspend`, `/tldr`, or `/compact`
+- WHEN the runtime classifies that recognized command input
+- THEN each supported ingress surface MUST route the command through
+  `pre_execution::evaluate_ingress(...)`
+- AND the handled command dispatch MUST come from the registry-backed ingress path rather than a
+  transport-local command execution branch.
+
+#### Scenario: Unknown or non-command input still falls through normally
+
+- GIVEN any supported ingress surface receives non-command input or slash-like input that is not
+  `/resume`, `/suspend`, `/tldr`, or `/compact`
+- WHEN the runtime evaluates ingress
+- THEN the system MUST preserve existing non-command or unknown-command fallthrough behavior
+- AND this change MUST NOT introduce new command recognition behavior outside the four in-scope
+  session commands.
 
 ### Requirement: Shared Handled Slash Outcome Adaptation Contract
 
@@ -230,29 +229,66 @@ to adopt one shared external payload, event, or text schema.
 
 ### Requirement: Existing Slash Session Behavior Preservation
 
-The system MUST preserve the current user-visible and deterministic behavior of the existing slash
-session commands while moving them onto the central registry core.
+The system MUST preserve the current behavior of `/resume`, `/suspend`, `/tldr`, and `/compact`
+while finalizing their registry-backed routing.
 
-For this slice, `/resume`, `/suspend`, `/tldr`, and `/compact` MUST remain recognized slash session
-commands. Their existing deterministic handling, error behavior, persistence expectations, and
-session-state semantics defined by the session and agent-loop specifications MUST remain intact.
+For this change, registry-backed ingress routing MUST preserve the same command semantics already
+defined by the sessions specification. Authorization-sensitive `/resume` behavior,
+unsupported-backend outcomes for slash-session persistence commands, invalid-target handling,
+unknown-session handling, and success results MUST remain equivalent to the current
+session-command behavior. Routing cleanup for #542 MUST reorganize ingress and dispatch proof only;
+it MUST NOT broaden, weaken, or bypass service-layer authorization or backend checks.
 
-Registry adoption MUST reorganize lookup and dispatch only; it MUST NOT weaken or broaden current
-session-command behavior.
+#### Scenario: Resume authorization rules remain intact after registry-backed dispatch
 
-#### Scenario: Existing slash session commands remain available after registry adoption
+- GIVEN a recognized `/resume` command is routed through `pre_execution::evaluate_ingress(...)`
+- AND the current caller scope is not authorized to view or resume the target session under the
+  existing sessions rules
+- WHEN the registry-backed handler evaluates the command
+- THEN the system MUST return the same explicit authorization-denied outcome required by the
+  sessions specification
+- AND the runtime MUST NOT resume the target session
+- AND registry-backed routing MUST NOT bypass or reinterpret that authorization decision.
 
-- GIVEN a user invokes `/tldr`, `/compact`, `/suspend`, or `/resume`
-- WHEN the runtime uses the central slash command registry
-- THEN the system MUST recognize those commands through the registry
-- AND the user-visible command outcome MUST remain consistent with the existing session specifications.
+#### Scenario: Slash-session backend checks remain intact after registry-backed dispatch
 
-#### Scenario: Registry migration does not change unsupported-backend behavior
+- GIVEN a recognized `/suspend`, `/tldr`, `/compact`, or `/resume` command is routed through
+  `pre_execution::evaluate_ingress(...)`
+- AND the configured backend does not satisfy the existing slash-session persistence requirements
+- WHEN the registry-backed handler evaluates the command
+- THEN the system MUST return the same explicit unsupported outcome required by the sessions
+  specification
+- AND the system MUST NOT replace that outcome with fallback success, silent no-op behavior, or
+  generic conversational handling.
 
-- GIVEN the runtime is configured with a backend that does not satisfy the existing slash-session persistence requirements
-- WHEN a user invokes `/tldr`, `/compact`, `/suspend`, or `/resume`
-- THEN the system MUST preserve the existing explicit unsupported or authorization outcome for that command
-- AND the registry core MUST NOT replace that behavior with fallback success, silent no-op handling, or generic conversational execution.
+### Requirement: Registry Bindings Are the Sole Production Session-Command Dispatch Entry
+
+The system MUST treat the registry's built-in bindings for `/resume`, `/suspend`, `/tldr`, and
+`/compact` as the only production command-name-to-handler dispatch entry for those commands.
+
+Production runtime surfaces MAY keep transport-specific context construction and outward
+response-envelope adaptation, but they MUST NOT keep a separate production routing path that
+directly selects or invokes the four session-command handlers outside registry-backed dispatch. Any
+remaining compatibility or deprecation scaffolding MUST be isolated so it does not change
+production routing for the four in-scope commands.
+
+#### Scenario: Registry binding remains the only production dispatch entry for in-scope session commands
+
+- GIVEN `/resume`, `/suspend`, `/tldr`, and `/compact` are available as built-in session commands
+- WHEN production runtime code resolves one of those command names for execution
+- THEN the system MUST dispatch through the registry binding for that canonical command
+- AND production routing MUST NOT require a separate direct-handler selection path for that command
+  name.
+
+#### Scenario: Transport-specific wrappers stay outside the production dispatch decision
+
+- GIVEN a supported transport already has its own outward wrapper for handled slash-command results
+- WHEN `/resume`, `/suspend`, `/tldr`, or `/compact` completes through registry-backed ingress
+  dispatch
+- THEN the transport MAY keep its existing outward response wrapper
+- AND that wrapper MUST be applied after the shared handled-result classification
+- AND the wrapper MUST NOT become a separate production routing path for selecting the command
+  handler.
 
 ### Requirement: Transport Parity for Recognized Slash Commands
 


### PR DESCRIPTION
## Related Issues

Fixes #542
Related to #527

---

## Summary

This PR finalizes the session-command registry migration for `/resume`, `/suspend`, `/tldr`, and `/compact`.

The production migration was already functionally in place, so this change closes the issue by removing leftover registry-routing noise, proving the shared `pre_execution::evaluate_ingress(...)` seam across CLI/gateway/webhook/channel entrypoints, and syncing the finalized routing guarantees into OpenSpec.

---

## Tested Information

Validated with focused runtime checks and repository hooks:

- `cargo test --manifest-path clients/agent-runtime/Cargo.toml pre_execution::`
- `cargo test --manifest-path clients/agent-runtime/Cargo.toml gateway::`
- `cargo test --manifest-path clients/agent-runtime/Cargo.toml webhook_dispatch::`
- `cargo test --manifest-path clients/agent-runtime/Cargo.toml channels::`
- `cargo fmt --manifest-path clients/agent-runtime/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path clients/agent-runtime/Cargo.toml --all-targets -- -D warnings`
- pre-push hook: Rust checks + full runtime suite (`3562` tests passed)

Reviewers should focus on:
- removal of the dead `SlashCommandRegistry::recognizes(...)` helper
- helper/comment renames that clarify shared handled-ingress routing
- seam-level regressions proving `/resume`, `/suspend`, `/tldr`, and `/compact` route through the registry-backed ingress path

---

## Documentation Impact

- Docs updated in:
  - `openspec/specs/slash-command-registry/spec.md`
  - `openspec/changes/archive/2026-04-17-finalize-session-command-registry-routing/`
- No docs update required because:
- I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
