### PR TITLE
fix(workflows): update dallay/common-actions to v2.0.0 (pinned SHA)

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   cleanup:
-    uses: dallay/common-actions/.github/workflows/cleanup-cache.yml@0f8de7c46309882e873a878e1fcc636bf56ad586 # v1.2.0
+    uses: dallay/common-actions/.github/workflows/cleanup-cache.yml@6ecd716dcfb6a9e8a9c494d1eac210cc1d73d75f # v2.0.0
     secrets: inherit

--- a/.github/workflows/contributor-report.yml
+++ b/.github/workflows/contributor-report.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   report:
-    uses: dallay/common-actions/.github/workflows/contributor-report.yml@0f8de7c46309882e873a878e1fcc636bf56ad586 # v1.2.0
+    uses: dallay/common-actions/.github/workflows/contributor-report.yml@6ecd716dcfb6a9e8a9c494d1eac210cc1d73d75f # v2.0.0
     with:
       trusted-users: dependabot[bot],renovate[bot],github-copilot[bot],github-actions[bot],codecov[bot],sonarcloud[bot],dallay-bot[bot]
     secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -9,5 +9,5 @@ permissions:
 
 jobs:
   greet:
-    uses: dallay/common-actions/.github/workflows/greetings.yml@0f8de7c46309882e873a878e1fcc636bf56ad586 # v1.2.0
+    uses: dallay/common-actions/.github/workflows/greetings.yml@6ecd716dcfb6a9e8a9c494d1eac210cc1d73d75f # v2.0.0
     secrets: inherit

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   label:
-    uses: dallay/common-actions/.github/workflows/pr-size-labeler.yml@v1.2.0
+    uses: dallay/common-actions/.github/workflows/pr-size-labeler.yml@6ecd716dcfb6a9e8a9c494d1eac210cc1d73d75f # v2.0.0
     secrets: inherit

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   lint:
-    uses: dallay/common-actions/.github/workflows/semantic-pr.yml@0f8de7c46309882e873a878e1fcc636bf56ad586 # v1.2.0
+    uses: dallay/common-actions/.github/workflows/semantic-pr.yml@6ecd716dcfb6a9e8a9c494d1eac210cc1d73d75f # v2.0.0
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   stale:
-    uses: dallay/common-actions/.github/workflows/stale.yml@0f8de7c46309882e873a878e1fcc636bf56ad586 # v1.2.0
+    uses: dallay/common-actions/.github/workflows/stale.yml@6ecd716dcfb6a9e8a9c494d1eac210cc1d73d75f # v2.0.0
     secrets: inherit


### PR DESCRIPTION
## Summary

- Update 6 GitHub Actions workflows to use v2.0.0 of dallay/common-actions
- All workflows now use pinned SHA for security: `6ecd716dcfb6a9e8a9c494d1eac210cc1d73d75f`

### Updated workflows:
- `cleanup-cache.yml`
- `contributor-report.yml`
- `greetings.yml`
- `pr-size-labeler.yml`
- `semantic-pull-request.yml`
- `stale.yml`

## Security Note

⚠️ **59 Dependabot vulnerabilities detected** (24 high, 28 moderate, 7 low) - these should be addressed separately.