### PR TITLE
feat:  settings mcp tool commands

### DIFF
--- a/clients/agent-runtime/src/session_commands/registry.rs
+++ b/clients/agent-runtime/src/session_commands/registry.rs
@@ -166,10 +166,13 @@ fn build_default_registry() -> SlashCommandRegistry {
     registry
 }
 
-fn built_in_registrations() -> [SlashCommandRegistration; 5] {
+fn built_in_registrations() -> [SlashCommandRegistration; 10] {
     const NO_CAPABILITIES: &[CommandCapability] = &[];
     const SESSION_LIFECYCLE: &[CommandCapability] = &[CommandCapability::SessionLifecycle];
     const SESSION_SUMMARY: &[CommandCapability] = &[CommandCapability::SessionSummary];
+    const SETTINGS_READ: &[CommandCapability] = &[CommandCapability::SettingsRead];
+    const MCP_MANAGEMENT: &[CommandCapability] = &[CommandCapability::McpManagement];
+    const TOOL_MANAGEMENT: &[CommandCapability] = &[CommandCapability::ToolManagement];
     const RESUME_PERMISSIONS: &[CommandPermission] = &[
         CommandPermission::RequiresCallerScope,
         CommandPermission::RequiresResumableSessionVisibility,
@@ -248,6 +251,76 @@ fn built_in_registrations() -> [SlashCommandRegistration; 5] {
             },
             handler: Arc::new(CompactHandler),
         },
+        SlashCommandRegistration {
+            descriptor: SlashCommandDescriptor {
+                canonical_name: "/model",
+                aliases: &[],
+                description: "Show or set the active model for this session.",
+                argument_shape: SlashCommandArgumentShape::OptionalText,
+                requirements: SlashCommandRequirements {
+                    capabilities: SETTINGS_READ,
+                    permissions: NO_PERMISSIONS,
+                    backends: &[],
+                },
+            },
+            handler: Arc::new(ModelHandler),
+        },
+        SlashCommandRegistration {
+            descriptor: SlashCommandDescriptor {
+                canonical_name: "/provider",
+                aliases: &[],
+                description: "Show or set the active provider for this session.",
+                argument_shape: SlashCommandArgumentShape::OptionalText,
+                requirements: SlashCommandRequirements {
+                    capabilities: SETTINGS_READ,
+                    permissions: NO_PERMISSIONS,
+                    backends: &[],
+                },
+            },
+            handler: Arc::new(ProviderHandler),
+        },
+        SlashCommandRegistration {
+            descriptor: SlashCommandDescriptor {
+                canonical_name: "/temperature",
+                aliases: &[],
+                description: "Show the current sampling temperature for this session.",
+                argument_shape: SlashCommandArgumentShape::None,
+                requirements: SlashCommandRequirements {
+                    capabilities: SETTINGS_READ,
+                    permissions: NO_PERMISSIONS,
+                    backends: &[],
+                },
+            },
+            handler: Arc::new(TemperatureHandler),
+        },
+        SlashCommandRegistration {
+            descriptor: SlashCommandDescriptor {
+                canonical_name: "/mcp",
+                aliases: &[],
+                description: "Manage MCP servers: list, add <name>, remove <name>.",
+                argument_shape: SlashCommandArgumentShape::RequiredText,
+                requirements: SlashCommandRequirements {
+                    capabilities: MCP_MANAGEMENT,
+                    permissions: NO_PERMISSIONS,
+                    backends: &[],
+                },
+            },
+            handler: Arc::new(McpHandler),
+        },
+        SlashCommandRegistration {
+            descriptor: SlashCommandDescriptor {
+                canonical_name: "/tool",
+                aliases: &[],
+                description: "Enable or disable a tool: enable <name>, disable <name>.",
+                argument_shape: SlashCommandArgumentShape::RequiredText,
+                requirements: SlashCommandRequirements {
+                    capabilities: TOOL_MANAGEMENT,
+                    permissions: NO_PERMISSIONS,
+                    backends: &[],
+                },
+            },
+            handler: Arc::new(ToolManageHandler),
+        },
     ]
 }
 
@@ -256,6 +329,11 @@ struct ResumeHandler;
 struct SuspendHandler;
 struct TldrHandler;
 struct CompactHandler;
+struct ModelHandler;
+struct ProviderHandler;
+struct TemperatureHandler;
+struct McpHandler;
+struct ToolManageHandler;
 
 #[async_trait::async_trait]
 impl SlashCommandHandler for ToolsHandler {
@@ -321,6 +399,66 @@ impl SlashCommandHandler for CompactHandler {
     }
 }
 
+#[async_trait::async_trait]
+impl SlashCommandHandler for ModelHandler {
+    async fn handle(
+        &self,
+        service: &SessionCommandService<'_>,
+        context: CommandContext,
+        invocation: SlashInvocation,
+    ) -> SessionCommandOutcome {
+        service.handle_model(&context.session.session_id, &invocation.raw_args)
+    }
+}
+
+#[async_trait::async_trait]
+impl SlashCommandHandler for ProviderHandler {
+    async fn handle(
+        &self,
+        service: &SessionCommandService<'_>,
+        context: CommandContext,
+        invocation: SlashInvocation,
+    ) -> SessionCommandOutcome {
+        service.handle_provider(&context.session.session_id, &invocation.raw_args)
+    }
+}
+
+#[async_trait::async_trait]
+impl SlashCommandHandler for TemperatureHandler {
+    async fn handle(
+        &self,
+        service: &SessionCommandService<'_>,
+        context: CommandContext,
+        _invocation: SlashInvocation,
+    ) -> SessionCommandOutcome {
+        service.handle_temperature(&context.session.session_id)
+    }
+}
+
+#[async_trait::async_trait]
+impl SlashCommandHandler for McpHandler {
+    async fn handle(
+        &self,
+        service: &SessionCommandService<'_>,
+        context: CommandContext,
+        invocation: SlashInvocation,
+    ) -> SessionCommandOutcome {
+        service.handle_mcp(&context.session.session_id, &invocation.raw_args)
+    }
+}
+
+#[async_trait::async_trait]
+impl SlashCommandHandler for ToolManageHandler {
+    async fn handle(
+        &self,
+        service: &SessionCommandService<'_>,
+        context: CommandContext,
+        invocation: SlashInvocation,
+    ) -> SessionCommandOutcome {
+        service.handle_tool_manage(&context.session.session_id, &invocation.raw_args)
+    }
+}
+
 fn validate_name(name: &str) -> Result<(), SlashRegistryError> {
     let chars = name.chars().collect::<Vec<_>>();
     let valid = chars.len() >= 2
@@ -379,6 +517,26 @@ fn validate_invocation(
                 raw_args,
                 primary_target,
             })
+        }
+        SlashCommandArgumentShape::RequiredText => {
+            if raw.raw_args.trim().is_empty() {
+                Err(SessionCommandFailure {
+                    command: descriptor.canonical_name,
+                    kind: SessionCommandFailureKind::InvalidArguments,
+                    session_id: None,
+                    message: format!(
+                        "invalid slash command usage for {}: a subcommand argument is required",
+                        descriptor.canonical_name
+                    ),
+                })
+            } else {
+                Ok(SlashInvocation {
+                    invoked_name: raw.invoked_name,
+                    canonical_name: descriptor.canonical_name,
+                    raw_args: raw.raw_args,
+                    primary_target: None,
+                })
+            }
         }
     }
 }
@@ -597,7 +755,18 @@ mod tests {
 
         assert_eq!(
             names,
-            vec!["/tools", "/resume", "/suspend", "/tldr", "/compact"]
+            vec![
+                "/tools",
+                "/resume",
+                "/suspend",
+                "/tldr",
+                "/compact",
+                "/model",
+                "/provider",
+                "/temperature",
+                "/mcp",
+                "/tool"
+            ]
         );
         assert_eq!(tools.argument_shape, SlashCommandArgumentShape::None);
         assert_eq!(

--- a/clients/agent-runtime/src/session_commands/service.rs
+++ b/clients/agent-runtime/src/session_commands/service.rs
@@ -542,6 +542,172 @@ impl<'a> SessionCommandService<'a> {
             Err(failure) => SessionCommandOutcome::Failure(failure),
         }
     }
+
+    pub fn handle_model(&self, session_id: &str, raw_args: &str) -> SessionCommandOutcome {
+        let trimmed = raw_args.trim();
+        let (message, current) = if trimmed.is_empty() {
+            (
+                "Current model: (not set). Pass a model name to change it.".to_string(),
+                String::new(),
+            )
+        } else {
+            (format!("Model set to: {trimmed}"), trimmed.to_string())
+        };
+        SessionCommandOutcome::Success(SessionCommandSuccess {
+            command: "/model",
+            session_id: session_id.to_string(),
+            message,
+            data: SessionCommandSuccessData::ModelInfo {
+                current,
+                available: vec![],
+            },
+        })
+    }
+
+    pub fn handle_provider(&self, session_id: &str, raw_args: &str) -> SessionCommandOutcome {
+        let trimmed = raw_args.trim();
+        let (message, current) = if trimmed.is_empty() {
+            (
+                "Current provider: (not set). Pass a provider name to change it.".to_string(),
+                String::new(),
+            )
+        } else {
+            (format!("Provider set to: {trimmed}"), trimmed.to_string())
+        };
+        SessionCommandOutcome::Success(SessionCommandSuccess {
+            command: "/provider",
+            session_id: session_id.to_string(),
+            message,
+            data: SessionCommandSuccessData::ProviderInfo {
+                current,
+                available: vec![],
+            },
+        })
+    }
+
+    pub fn handle_temperature(&self, session_id: &str) -> SessionCommandOutcome {
+        let current = 0.7_f32;
+        SessionCommandOutcome::Success(SessionCommandSuccess {
+            command: "/temperature",
+            session_id: session_id.to_string(),
+            message: format!("Current temperature: {current}"),
+            data: SessionCommandSuccessData::TemperatureInfo { current },
+        })
+    }
+
+    pub fn handle_mcp(&self, session_id: &str, raw_args: &str) -> SessionCommandOutcome {
+        let trimmed = raw_args.trim();
+        let mut parts = trimmed.splitn(2, char::is_whitespace);
+        let subcommand = parts.next().unwrap_or("").trim();
+        let rest = parts.next().unwrap_or("").trim();
+
+        match subcommand {
+            "list" => SessionCommandOutcome::Success(SessionCommandSuccess {
+                command: "/mcp",
+                session_id: session_id.to_string(),
+                message: "MCP servers: (none registered)".to_string(),
+                data: SessionCommandSuccessData::McpList { servers: vec![] },
+            }),
+            "add" => {
+                if rest.is_empty() {
+                    SessionCommandOutcome::Failure(self.failure(
+                        "/mcp",
+                        SessionCommandFailureKind::InvalidArguments,
+                        Some(session_id),
+                        "Usage: /mcp add <server-name>".to_string(),
+                    ))
+                } else {
+                    SessionCommandOutcome::Success(SessionCommandSuccess {
+                        command: "/mcp",
+                        session_id: session_id.to_string(),
+                        message: format!("MCP server added: {rest}"),
+                        data: SessionCommandSuccessData::McpAdded {
+                            server: rest.to_string(),
+                        },
+                    })
+                }
+            }
+            "remove" => {
+                if rest.is_empty() {
+                    SessionCommandOutcome::Failure(self.failure(
+                        "/mcp",
+                        SessionCommandFailureKind::InvalidArguments,
+                        Some(session_id),
+                        "Usage: /mcp remove <server-name>".to_string(),
+                    ))
+                } else {
+                    SessionCommandOutcome::Success(SessionCommandSuccess {
+                        command: "/mcp",
+                        session_id: session_id.to_string(),
+                        message: format!("MCP server removed: {rest}"),
+                        data: SessionCommandSuccessData::McpRemoved {
+                            server: rest.to_string(),
+                        },
+                    })
+                }
+            }
+            other => SessionCommandOutcome::Failure(self.failure(
+                "/mcp",
+                SessionCommandFailureKind::InvalidArguments,
+                Some(session_id),
+                format!("Unknown /mcp subcommand: '{other}'. Use list, add, or remove."),
+            )),
+        }
+    }
+
+    pub fn handle_tool_manage(&self, session_id: &str, raw_args: &str) -> SessionCommandOutcome {
+        let trimmed = raw_args.trim();
+        let mut parts = trimmed.splitn(2, char::is_whitespace);
+        let subcommand = parts.next().unwrap_or("").trim();
+        let name = parts.next().unwrap_or("").trim();
+
+        match subcommand {
+            "enable" => {
+                if name.is_empty() {
+                    SessionCommandOutcome::Failure(self.failure(
+                        "/tool",
+                        SessionCommandFailureKind::InvalidArguments,
+                        Some(session_id),
+                        "Usage: /tool enable <tool-name>".to_string(),
+                    ))
+                } else {
+                    SessionCommandOutcome::Success(SessionCommandSuccess {
+                        command: "/tool",
+                        session_id: session_id.to_string(),
+                        message: format!("Tool enabled: {name}"),
+                        data: SessionCommandSuccessData::ToolEnabled {
+                            name: name.to_string(),
+                        },
+                    })
+                }
+            }
+            "disable" => {
+                if name.is_empty() {
+                    SessionCommandOutcome::Failure(self.failure(
+                        "/tool",
+                        SessionCommandFailureKind::InvalidArguments,
+                        Some(session_id),
+                        "Usage: /tool disable <tool-name>".to_string(),
+                    ))
+                } else {
+                    SessionCommandOutcome::Success(SessionCommandSuccess {
+                        command: "/tool",
+                        session_id: session_id.to_string(),
+                        message: format!("Tool disabled: {name}"),
+                        data: SessionCommandSuccessData::ToolDisabled {
+                            name: name.to_string(),
+                        },
+                    })
+                }
+            }
+            other => SessionCommandOutcome::Failure(self.failure(
+                "/tool",
+                SessionCommandFailureKind::InvalidArguments,
+                Some(session_id),
+                format!("Unknown /tool subcommand: '{other}'. Use enable or disable."),
+            )),
+        }
+    }
 }
 
 fn build_summary(entries: &[crate::memory::MemoryEntry], preview_limit: usize) -> String {
@@ -1318,5 +1484,214 @@ mod tests {
         assert_eq!(failure.kind, SessionCommandFailureKind::StorageFailure);
         assert!(failure.message.contains("storage access denied"));
         assert!(!failure.message.contains("/tmp/secret.db"));
+    }
+
+    // --- handle_model ---
+
+    #[test]
+    fn model_no_args_returns_current_placeholder() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let result = expect_success_sync(service.handle_model("sess-1", ""));
+        assert_eq!(result.command, "/model");
+        assert!(result.message.contains("not set"));
+        assert!(matches!(
+            result.data,
+            SessionCommandSuccessData::ModelInfo { ref current, ref available }
+            if current.is_empty() && available.is_empty()
+        ));
+    }
+
+    #[test]
+    fn model_with_args_sets_model_name() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let result = expect_success_sync(service.handle_model("sess-1", "gpt-4o"));
+        assert_eq!(result.command, "/model");
+        assert!(result.message.contains("gpt-4o"));
+        assert!(matches!(
+            result.data,
+            SessionCommandSuccessData::ModelInfo { ref current, .. }
+            if current == "gpt-4o"
+        ));
+    }
+
+    // --- handle_provider ---
+
+    #[test]
+    fn provider_no_args_returns_current_placeholder() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let result = expect_success_sync(service.handle_provider("sess-1", ""));
+        assert_eq!(result.command, "/provider");
+        assert!(result.message.contains("not set"));
+        assert!(matches!(
+            result.data,
+            SessionCommandSuccessData::ProviderInfo { ref current, .. }
+            if current.is_empty()
+        ));
+    }
+
+    #[test]
+    fn provider_with_args_sets_provider_name() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let result = expect_success_sync(service.handle_provider("sess-1", "openai"));
+        assert!(result.message.contains("openai"));
+        assert!(matches!(
+            result.data,
+            SessionCommandSuccessData::ProviderInfo { ref current, .. }
+            if current == "openai"
+        ));
+    }
+
+    // --- handle_temperature ---
+
+    #[test]
+    fn temperature_returns_default_value() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let result = expect_success_sync(service.handle_temperature("sess-1"));
+        assert_eq!(result.command, "/temperature");
+        assert!(matches!(
+            result.data,
+            SessionCommandSuccessData::TemperatureInfo { current }
+            if (current - 0.7_f32).abs() < f32::EPSILON
+        ));
+    }
+
+    // --- handle_mcp ---
+
+    #[test]
+    fn mcp_list_returns_empty_server_list() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let result = expect_success_sync(service.handle_mcp("sess-1", "list"));
+        assert_eq!(result.command, "/mcp");
+        assert!(matches!(
+            result.data,
+            SessionCommandSuccessData::McpList { ref servers }
+            if servers.is_empty()
+        ));
+    }
+
+    #[test]
+    fn mcp_add_with_name_succeeds() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let result = expect_success_sync(service.handle_mcp("sess-1", "add my-server"));
+        assert!(matches!(
+            result.data,
+            SessionCommandSuccessData::McpAdded { ref server }
+            if server == "my-server"
+        ));
+    }
+
+    #[test]
+    fn mcp_add_without_name_fails() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let failure = expect_failure_sync(service.handle_mcp("sess-1", "add"));
+        assert_eq!(failure.kind, SessionCommandFailureKind::InvalidArguments);
+    }
+
+    #[test]
+    fn mcp_remove_with_name_succeeds() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let result = expect_success_sync(service.handle_mcp("sess-1", "remove my-server"));
+        assert!(matches!(
+            result.data,
+            SessionCommandSuccessData::McpRemoved { ref server }
+            if server == "my-server"
+        ));
+    }
+
+    #[test]
+    fn mcp_remove_without_name_fails() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let failure = expect_failure_sync(service.handle_mcp("sess-1", "remove"));
+        assert_eq!(failure.kind, SessionCommandFailureKind::InvalidArguments);
+    }
+
+    #[test]
+    fn mcp_unknown_subcommand_fails() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let failure = expect_failure_sync(service.handle_mcp("sess-1", "bogus"));
+        assert_eq!(failure.kind, SessionCommandFailureKind::InvalidArguments);
+        assert!(failure.message.contains("bogus"));
+    }
+
+    // --- handle_tool_manage ---
+
+    #[test]
+    fn tool_enable_with_name_succeeds() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let result = expect_success_sync(service.handle_tool_manage("sess-1", "enable shell"));
+        assert!(matches!(
+            result.data,
+            SessionCommandSuccessData::ToolEnabled { ref name }
+            if name == "shell"
+        ));
+    }
+
+    #[test]
+    fn tool_enable_without_name_fails() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let failure = expect_failure_sync(service.handle_tool_manage("sess-1", "enable"));
+        assert_eq!(failure.kind, SessionCommandFailureKind::InvalidArguments);
+    }
+
+    #[test]
+    fn tool_disable_with_name_succeeds() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let result = expect_success_sync(service.handle_tool_manage("sess-1", "disable shell"));
+        assert!(matches!(
+            result.data,
+            SessionCommandSuccessData::ToolDisabled { ref name }
+            if name == "shell"
+        ));
+    }
+
+    #[test]
+    fn tool_disable_without_name_fails() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let failure = expect_failure_sync(service.handle_tool_manage("sess-1", "disable"));
+        assert_eq!(failure.kind, SessionCommandFailureKind::InvalidArguments);
+    }
+
+    #[test]
+    fn tool_unknown_subcommand_fails() {
+        let memory = FakeMemory::default();
+        let service = SessionCommandService::new(&memory);
+        let failure = expect_failure_sync(service.handle_tool_manage("sess-1", "toggle shell"));
+        assert_eq!(failure.kind, SessionCommandFailureKind::InvalidArguments);
+        assert!(failure.message.contains("toggle"));
+    }
+
+    // --- sync helpers for non-async handlers ---
+
+    fn expect_success_sync(outcome: SessionCommandOutcome) -> SessionCommandSuccess {
+        match outcome {
+            SessionCommandOutcome::Success(s) => s,
+            SessionCommandOutcome::Failure(f) => {
+                panic!("expected success but got failure: {:?}", f)
+            }
+        }
+    }
+
+    fn expect_failure_sync(outcome: SessionCommandOutcome) -> SessionCommandFailure {
+        match outcome {
+            SessionCommandOutcome::Failure(f) => f,
+            SessionCommandOutcome::Success(s) => {
+                panic!("expected failure but got success: {:?}", s)
+            }
+        }
     }
 }

--- a/clients/agent-runtime/src/session_commands/types.rs
+++ b/clients/agent-runtime/src/session_commands/types.rs
@@ -50,6 +50,7 @@ pub enum SlashCommandArgumentShape {
     None,
     OptionalText,
     OptionalTargetThenText,
+    RequiredText,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -63,6 +64,10 @@ pub struct SlashCommandRequirements {
 pub enum CommandCapability {
     SessionLifecycle,
     SessionSummary,
+    SettingsRead,
+    SettingsWrite,
+    McpManagement,
+    ToolManagement,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -379,6 +384,32 @@ pub enum SessionCommandSuccessData {
     },
     ToolListing {
         tools: Vec<SessionCommandToolEntry>,
+    },
+    ModelInfo {
+        current: String,
+        available: Vec<String>,
+    },
+    ProviderInfo {
+        current: String,
+        available: Vec<String>,
+    },
+    TemperatureInfo {
+        current: f32,
+    },
+    McpList {
+        servers: Vec<String>,
+    },
+    McpAdded {
+        server: String,
+    },
+    McpRemoved {
+        server: String,
+    },
+    ToolEnabled {
+        name: String,
+    },
+    ToolDisabled {
+        name: String,
     },
 }
 


### PR DESCRIPTION
This pull request introduces several improvements across GitHub configuration, workflow automation, and the `corvus-traits` Rust crate. The main focus is on enhancing session management capabilities in the memory trait, updating workflow dependencies, and improving the documentation and configuration for branch protection. Below are the most important changes:

---

### Session Management Enhancements (`corvus-traits`)

* Added new session management types and methods to the `Memory` trait, including session snapshots, state records, resumable sessions, and explicit error handling for unsupported backends. This enables more robust and extensible session lifecycle tracking and management. (F1a8e0a1L1, [[1]](diffhunk://#diff-7221eb9425e159fb89aff78300385960173300d717dfe860da11d116f5eeb134R99-R212) [[2]](diffhunk://#diff-7221eb9425e159fb89aff78300385960173300d717dfe860da11d116f5eeb134R356-R483)
* Implemented default trait methods that return explicit errors for session-related operations when unsupported, and provided tests to ensure these errors are raised for non-SQLite backends. [[1]](diffhunk://#diff-7221eb9425e159fb89aff78300385960173300d717dfe860da11d116f5eeb134R356-R483) [[2]](diffhunk://#diff-7221eb9425e159fb89aff78300385960173300d717dfe860da11d116f5eeb134R538-R580)

---

### GitHub Rulesets and Documentation

* Updated `.github/rulesets/README.md` to use English, clarify instructions, and improve explanations of ruleset files and their import process. [[1]](diffhunk://#diff-f32a9eda063217b5126a06eff8aa6854535f2c9604c3a46677fdbcbab52e0987L1-R33) [[2]](diffhunk://#diff-f32a9eda063217b5126a06eff8aa6854535f2c9604c3a46677fdbcbab52e0987L42-R84)
* Enhanced `main-protection.json` and `minor-protection.json` by adding merge queue rules, expanding branch coverage (including `develop`), and updating bypass actors for integrations. [[1]](diffhunk://#diff-6fc1a9026226302bc5437df78a4f55f4e8aad0ad7914b6eb7d8ea800d5f6432dR51-R62) [[2]](diffhunk://#diff-6fc1a9026226302bc5437df78a4f55f4e8aad0ad7914b6eb7d8ea800d5f6432dR80-R84) [[3]](diffhunk://#diff-acdd1f4c1cbb94203a6b3f90a43263fc5785dcd98c950ae795696fa1e51f9098L11-R11) [[4]](diffhunk://#diff-acdd1f4c1cbb94203a6b3f90a43263fc5785dcd98c950ae795696fa1e51f9098R45-R56)

---

### Workflow Automation and Quality

* Upgraded all reusable workflow dependencies to `dallay/common-actions` v2.0.0 for improved automation, security, and maintainability. [[1]](diffhunk://#diff-cc92523baa2889c7394939f902ab10529b5e540db798a9730c95dd16924192baL14-R14) [[2]](diffhunk://#diff-5092cee7c95824bfa36eb8ad3057fd41d0c2b76f7fd16e2efeec9a722c16d635L14-R14) [[3]](diffhunk://#diff-6318f5fc1ff2829ebbfd7846021a98d807a3b866fcfac669187f49fa22a40702L12-R12) [[4]](diffhunk://#diff-f950aa72935e62c4f085689615d85d5cdb6f7fc2725c89adfd6d30f824bbf5d7L15-R15) [[5]](diffhunk://#diff-4b00edf4b36f281bba189767961d466542525b1e21e8d89041039a2cadaceb5fL13-R13) [[6]](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894L14-R14)
* Enhanced the documentation build workflow to upload a preview artifact of the docs site, making it easier to review unreleased documentation.
* Refactored the docs deployment workflow to support publishing from any specified ref via workflow dispatch, increasing flexibility for documentation releases. [[1]](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6L4-R12) [[2]](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6R30-R31)