### PR TITLE
fix(cerebro): reject blank memory update fields

### DIFF
--- a/modules/cerebro/src/tools.rs
+++ b/modules/cerebro/src/tools.rs
@@ -1,7 +1,7 @@
 use crate::errors::CerebroError;
 use crate::server::AuthContext;
 use crate::storage::{MemoryRecord, Storage};
-use crate::validation::require_non_empty;
+use crate::validation::{require_non_empty, require_optional_non_empty};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -582,6 +582,8 @@ impl CerebroTools {
         let input: ToolInput<MemUpdateRequest> = serde_json::from_value(payload)
             .map_err(|err| CerebroError::Validation(err.to_string()))?;
         require_non_empty("memory_id", &input.input.memory_id)?;
+        require_optional_non_empty("topic_key", input.input.topic_key.as_deref())?;
+        require_optional_non_empty("scope", input.input.scope.as_deref())?;
 
         let mut record = self
             .storage

--- a/modules/cerebro/src/validation.rs
+++ b/modules/cerebro/src/validation.rs
@@ -8,3 +8,13 @@ pub fn require_non_empty(field: &str, value: &str) -> Result<(), CerebroError> {
     }
     Ok(())
 }
+
+pub fn require_optional_non_empty(
+    field: &str,
+    value: Option<&str>,
+) -> Result<(), CerebroError> {
+    if let Some(value) = value {
+        require_non_empty(field, value)?;
+    }
+    Ok(())
+}

--- a/modules/cerebro/tests/mcp_tools_contract.rs
+++ b/modules/cerebro/tests/mcp_tools_contract.rs
@@ -220,3 +220,53 @@ async fn deleted_fetch_without_record_returns_not_found() {
     let error = response.error.expect("expected not_found error");
     assert_eq!(error.code, -32005);
 }
+
+#[tokio::test]
+async fn mem_update_rejects_blank_topic_key() {
+    let storage = InMemoryStorage::new();
+    let config = CerebroConfig {
+        auth_token: Some(SecretString::new("secret".to_string().into())),
+        ..CerebroConfig::default()
+    };
+    let service = CerebroService::new(config, storage);
+
+    let save = call_tool(
+        &service,
+        Some("Bearer secret"),
+        "mem_save",
+        json!({
+            "input": {
+                "scope": "shared",
+                "topic_key": "topic",
+                "observation": { "content": "Hello" }
+            }
+        }),
+    )
+    .await;
+    assert!(save.error.is_none());
+    let memory_id = save
+        .result
+        .as_ref()
+        .and_then(|value| value.get("output"))
+        .and_then(|value| value.get("memory_id"))
+        .and_then(|value| value.as_str())
+        .expect("mem_save should return memory_id")
+        .to_string();
+
+    let update = call_tool(
+        &service,
+        Some("Bearer secret"),
+        "mem_update",
+        json!({
+            "input": {
+                "memory_id": memory_id,
+                "topic_key": "   "
+            }
+        }),
+    )
+    .await;
+
+    let error = update.error.expect("expected validation error");
+    assert_eq!(error.code, -32000);
+    assert!(error.message.contains("topic_key must be non-empty"));
+}


### PR DESCRIPTION
## Related Issues

- None.

---

## Summary

This PR closes a small validation gap in Cerebro memory updates.

- add `require_optional_non_empty` for optional string fields that still must not be blank when provided
- reject whitespace-only `topic_key` and `scope` values in `mem_update`
- add a regression test covering a blank `topic_key` update request through the MCP tools contract

---

## Tested Information

- `cargo test --manifest-path modules/cerebro/Cargo.toml mem_update_rejects_blank_topic_key`
- `cargo test --manifest-path modules/cerebro/Cargo.toml --test mcp_tools_contract`

---

## Documentation Impact

- Docs updated in:
- No docs update required because this is a small validation fix for existing Cerebro tool behavior and does not change setup, APIs, or user-facing documentation.
- I verified the documentation matches the current behavior.

---

## Breaking Changes

- None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
