### PR TITLE
feat(rook): add admin API for operator management

### DIFF
--- a/clients/rook/src/admin/handlers.rs
+++ b/clients/rook/src/admin/handlers.rs
@@ -1,0 +1,506 @@
+use crate::admin::types::{
+    AccountView, AddPoolMemberRequest, AdminErrorResponse, CreateAccountRequest, CreatePoolRequest,
+    CreateRouteRequest, HealthAccountView, HealthSummaryView, PoolView, RouteView, SettingsView,
+    UpdateAccountRequest, UpdatePoolRequest, UpdateRouteRequest, UpdateSettingsRequest,
+    UsageStatusView,
+};
+use crate::domain::{ProviderAccount, ProviderPool, RookError};
+use crate::registry::RookRegistry;
+use crate::services::{
+    account::AccountService as _, health::HealthService as _, pool::PoolService as _,
+    route::RouteService as _, settings::SettingsService as _,
+};
+use axum::{
+    extract::Json as ExtractJson,
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use serde_json::{Map, Value};
+
+type AdminJson<T> = Result<Json<T>, (StatusCode, Json<AdminErrorResponse>)>;
+type AdminCreated<T> = Result<(StatusCode, Json<T>), (StatusCode, Json<AdminErrorResponse>)>;
+type AdminEmpty = Result<StatusCode, (StatusCode, Json<AdminErrorResponse>)>;
+
+fn bad_request(message: impl Into<String>) -> (StatusCode, Json<AdminErrorResponse>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(admin_error_response("bad_request", message)),
+    )
+}
+
+fn classify_rook_error(error: RookError) -> (StatusCode, Json<AdminErrorResponse>) {
+    match error {
+        RookError::Registry(message) => classify_registry_message(message),
+        other => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(admin_error_response("internal_error", other.to_string())),
+        ),
+    }
+}
+
+fn classify_registry_message(message: String) -> (StatusCode, Json<AdminErrorResponse>) {
+    let lower = message.to_lowercase();
+    if lower.contains("not found") {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(admin_error_response("not_found", message)),
+        );
+    }
+    if lower.contains("duplicate") || lower.contains("already exists") || lower.contains("unique") {
+        return (
+            StatusCode::CONFLICT,
+            Json(admin_error_response("conflict", message)),
+        );
+    }
+    if lower.contains("foreign key")
+        || lower.contains("referenced by")
+        || lower.contains("constraint failed")
+    {
+        return (
+            StatusCode::CONFLICT,
+            Json(admin_error_response("reference_conflict", message)),
+        );
+    }
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(admin_error_response("internal_error", message)),
+    )
+}
+
+fn validate_display_name(name: &str) -> Result<(), (StatusCode, Json<AdminErrorResponse>)> {
+    if name.trim().is_empty() {
+        Err(bad_request("display_name must not be blank"))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_name(name: &str, field: &str) -> Result<(), (StatusCode, Json<AdminErrorResponse>)> {
+    if name.trim().is_empty() {
+        Err(bad_request(format!("{field} must not be blank")))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_log_level(level: &str) -> Result<(), (StatusCode, Json<AdminErrorResponse>)> {
+    if level.trim().is_empty() {
+        Err(bad_request("log_level must not be blank"))
+    } else {
+        Ok(())
+    }
+}
+
+fn account_from_request(
+    account_id: crate::domain::AccountId,
+    req: CreateAccountRequest,
+) -> ProviderAccount {
+    ProviderAccount {
+        id: account_id,
+        vendor: req.vendor,
+        display_name: req.display_name,
+        api_base_override: req.api_base_override,
+        api_key: req.api_key,
+        enabled: req.enabled,
+        weight: req.weight,
+        priority: req.priority,
+        tags: req.tags,
+        capabilities: req.capabilities,
+    }
+}
+
+fn pool_from_request(pool_id: crate::domain::PoolId, req: CreatePoolRequest) -> ProviderPool {
+    ProviderPool {
+        id: pool_id,
+        name: req.name,
+        strategy: req.strategy,
+        members: req.members,
+        fallback_pool_id: req.fallback_pool_id,
+    }
+}
+
+fn not_found(resource: &str, id: impl ToString) -> (StatusCode, Json<AdminErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(admin_error_response(
+            "not_found",
+            format!("{resource} {} not found", id.to_string()),
+        )),
+    )
+}
+
+pub async fn handle_health() -> &'static str {
+    "ok"
+}
+
+pub async fn handle_get_usage() -> Json<UsageStatusView> {
+    Json(UsageStatusView::placeholder())
+}
+
+pub async fn handle_create_account(
+    State(registry): State<RookRegistry>,
+    ExtractJson(req): ExtractJson<CreateAccountRequest>,
+) -> AdminCreated<AccountView> {
+    validate_display_name(&req.display_name)?;
+    let account = account_from_request(crate::domain::AccountId::generate(), req);
+    registry
+        .accounts()
+        .create(account.clone())
+        .await
+        .map_err(classify_rook_error)?;
+    Ok((StatusCode::CREATED, Json(AccountView::from(account))))
+}
+
+pub async fn handle_update_account(
+    Path(account_id): Path<crate::domain::AccountId>,
+    State(registry): State<RookRegistry>,
+    ExtractJson(req): ExtractJson<UpdateAccountRequest>,
+) -> AdminJson<AccountView> {
+    validate_display_name(&req.display_name)?;
+    if registry.accounts().get(account_id).await.is_none() {
+        return Err(not_found("account", account_id));
+    }
+    let account = account_from_request(account_id, req);
+    registry
+        .accounts()
+        .update(account.clone())
+        .await
+        .map_err(classify_rook_error)?;
+    Ok(Json(AccountView::from(account)))
+}
+
+pub async fn handle_delete_account(
+    Path(account_id): Path<crate::domain::AccountId>,
+    State(registry): State<RookRegistry>,
+) -> AdminEmpty {
+    if registry.accounts().get(account_id).await.is_none() {
+        return Err(not_found("account", account_id));
+    }
+    registry
+        .accounts()
+        .delete(account_id)
+        .await
+        .map_err(classify_rook_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn handle_list_accounts(State(registry): State<RookRegistry>) -> Json<Vec<AccountView>> {
+    Json(
+        registry
+            .accounts()
+            .list()
+            .await
+            .into_iter()
+            .map(AccountView::from)
+            .collect(),
+    )
+}
+
+pub async fn handle_get_account(
+    Path(account_id): Path<crate::domain::AccountId>,
+    State(registry): State<RookRegistry>,
+) -> AdminJson<AccountView> {
+    match registry.accounts().get(account_id).await {
+        Some(account) => Ok(Json(AccountView::from(account))),
+        None => Err(not_found("account", account_id)),
+    }
+}
+
+pub async fn handle_list_pools(State(registry): State<RookRegistry>) -> Json<Vec<PoolView>> {
+    Json(
+        registry
+            .pools()
+            .list()
+            .await
+            .into_iter()
+            .map(PoolView::from)
+            .collect(),
+    )
+}
+
+pub async fn handle_get_pool(
+    Path(pool_id): Path<crate::domain::PoolId>,
+    State(registry): State<RookRegistry>,
+) -> AdminJson<PoolView> {
+    match registry.pools().get(pool_id).await {
+        Some(pool) => Ok(Json(PoolView::from(pool))),
+        None => Err(not_found("pool", pool_id)),
+    }
+}
+
+pub async fn handle_create_pool(
+    State(registry): State<RookRegistry>,
+    ExtractJson(req): ExtractJson<CreatePoolRequest>,
+) -> AdminCreated<PoolView> {
+    validate_name(&req.name, "name")?;
+    let pool = pool_from_request(crate::domain::PoolId::generate(), req);
+    registry
+        .pools()
+        .create(pool.clone())
+        .await
+        .map_err(classify_rook_error)?;
+    Ok((StatusCode::CREATED, Json(PoolView::from(pool))))
+}
+
+pub async fn handle_update_pool(
+    Path(pool_id): Path<crate::domain::PoolId>,
+    State(registry): State<RookRegistry>,
+    ExtractJson(req): ExtractJson<UpdatePoolRequest>,
+) -> AdminJson<PoolView> {
+    validate_name(&req.name, "name")?;
+    if registry.pools().get(pool_id).await.is_none() {
+        return Err(not_found("pool", pool_id));
+    }
+    let pool = pool_from_request(pool_id, req);
+    registry
+        .pools()
+        .update(pool.clone())
+        .await
+        .map_err(classify_rook_error)?;
+    Ok(Json(PoolView::from(pool)))
+}
+
+pub async fn handle_delete_pool(
+    Path(pool_id): Path<crate::domain::PoolId>,
+    State(registry): State<RookRegistry>,
+) -> AdminEmpty {
+    if registry.pools().get(pool_id).await.is_none() {
+        return Err(not_found("pool", pool_id));
+    }
+    registry
+        .pools()
+        .delete(pool_id)
+        .await
+        .map_err(classify_rook_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn handle_add_pool_member(
+    Path(pool_id): Path<crate::domain::PoolId>,
+    State(registry): State<RookRegistry>,
+    ExtractJson(req): ExtractJson<AddPoolMemberRequest>,
+) -> AdminJson<PoolView> {
+    if registry.pools().get(pool_id).await.is_none() {
+        return Err(not_found("pool", pool_id));
+    }
+    if registry.accounts().get(req.account_id).await.is_none() {
+        return Err(not_found("account", req.account_id));
+    }
+    registry
+        .pools()
+        .add_member(pool_id, req.account_id)
+        .await
+        .map_err(classify_rook_error)?;
+    match registry.pools().get(pool_id).await {
+        Some(pool) => Ok(Json(PoolView::from(pool))),
+        None => Err(not_found("pool", pool_id)),
+    }
+}
+
+pub async fn handle_remove_pool_member(
+    Path((pool_id, account_id)): Path<(crate::domain::PoolId, crate::domain::AccountId)>,
+    State(registry): State<RookRegistry>,
+) -> AdminJson<PoolView> {
+    match registry.pools().get(pool_id).await {
+        Some(pool) => {
+            if !pool.members.contains(&account_id) {
+                return Err((
+                    StatusCode::CONFLICT,
+                    Json(admin_error_response(
+                        "conflict",
+                        format!("account {account_id} is not a member of pool {pool_id}"),
+                    )),
+                ));
+            }
+        }
+        None => return Err(not_found("pool", pool_id)),
+    }
+
+    registry
+        .pools()
+        .remove_member(pool_id, account_id)
+        .await
+        .map_err(classify_rook_error)?;
+    match registry.pools().get(pool_id).await {
+        Some(pool) => Ok(Json(PoolView::from(pool))),
+        None => Err(not_found("pool", pool_id)),
+    }
+}
+
+pub async fn handle_list_routes(State(registry): State<RookRegistry>) -> Json<Vec<RouteView>> {
+    Json(
+        registry
+            .routes()
+            .list()
+            .await
+            .into_iter()
+            .map(RouteView::from)
+            .collect(),
+    )
+}
+
+pub async fn handle_get_route(
+    Path(route_id): Path<crate::domain::RouteId>,
+    State(registry): State<RookRegistry>,
+) -> AdminJson<RouteView> {
+    match registry.routes().get(route_id).await {
+        Some(route) => Ok(Json(RouteView::from(route))),
+        None => Err(not_found("route", route_id)),
+    }
+}
+
+pub async fn handle_create_route(
+    State(registry): State<RookRegistry>,
+    ExtractJson(req): ExtractJson<CreateRouteRequest>,
+) -> AdminCreated<RouteView> {
+    validate_name(&req.logical_model, "logical_model")?;
+    let route = crate::domain::ModelRoute {
+        id: crate::domain::RouteId::generate(),
+        logical_model: req.logical_model,
+        target_pool_id: req.target_pool_id,
+        fallback_route_id: req.fallback_route_id,
+        capability_constraints: req.capability_constraints,
+    };
+    registry
+        .routes()
+        .create(route.clone())
+        .await
+        .map_err(classify_rook_error)?;
+    Ok((StatusCode::CREATED, Json(RouteView::from(route))))
+}
+
+pub async fn handle_update_route(
+    Path(route_id): Path<crate::domain::RouteId>,
+    State(registry): State<RookRegistry>,
+    ExtractJson(req): ExtractJson<UpdateRouteRequest>,
+) -> AdminJson<RouteView> {
+    validate_name(&req.logical_model, "logical_model")?;
+    if registry.routes().get(route_id).await.is_none() {
+        return Err(not_found("route", route_id));
+    }
+    let route = crate::domain::ModelRoute {
+        id: route_id,
+        logical_model: req.logical_model,
+        target_pool_id: req.target_pool_id,
+        fallback_route_id: req.fallback_route_id,
+        capability_constraints: req.capability_constraints,
+    };
+    registry
+        .routes()
+        .update(route.clone())
+        .await
+        .map_err(classify_rook_error)?;
+    Ok(Json(RouteView::from(route)))
+}
+
+pub async fn handle_delete_route(
+    Path(route_id): Path<crate::domain::RouteId>,
+    State(registry): State<RookRegistry>,
+) -> AdminEmpty {
+    if registry.routes().get(route_id).await.is_none() {
+        return Err(not_found("route", route_id));
+    }
+    registry
+        .routes()
+        .delete(route_id)
+        .await
+        .map_err(classify_rook_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn handle_get_settings(State(registry): State<RookRegistry>) -> Json<SettingsView> {
+    Json(SettingsView::from(registry.settings().load().await))
+}
+
+pub async fn handle_put_settings(
+    State(registry): State<RookRegistry>,
+    ExtractJson(req): ExtractJson<UpdateSettingsRequest>,
+) -> AdminJson<SettingsView> {
+    if req.gateway_port == 0 {
+        return Err(bad_request("gateway_port must be greater than 0"));
+    }
+    validate_log_level(&req.log_level)?;
+    let settings = crate::domain::RookSettings::from(req.clone());
+    registry
+        .settings()
+        .save(settings)
+        .await
+        .map_err(classify_rook_error)?;
+    Ok(Json(req))
+}
+
+pub async fn handle_list_account_health(
+    State(registry): State<RookRegistry>,
+) -> Json<Vec<HealthAccountView>> {
+    let accounts = registry.accounts().list().await;
+    let mut response = Vec::with_capacity(accounts.len());
+    for account in accounts {
+        let health = registry.health().get(account.id).await;
+        let available = registry.health().is_available(account.id).await;
+        response.push(HealthAccountView::new(&account, health, available));
+    }
+    Json(response)
+}
+
+pub async fn handle_health_summary(
+    State(registry): State<RookRegistry>,
+) -> Json<HealthSummaryView> {
+    let accounts = registry.accounts().list().await;
+    let mut summary = HealthSummaryView {
+        total: accounts.len(),
+        healthy: 0,
+        degraded: 0,
+        unhealthy: 0,
+        unknown: 0,
+    };
+
+    for account in accounts {
+        let health = registry.health().get(account.id).await;
+        match health.status {
+            crate::services::health::HealthStatus::Healthy => summary.healthy += 1,
+            crate::services::health::HealthStatus::Degraded => summary.degraded += 1,
+            crate::services::health::HealthStatus::Unhealthy => summary.unhealthy += 1,
+            crate::services::health::HealthStatus::Unknown => summary.unknown += 1,
+        }
+    }
+
+    Json(summary)
+}
+
+pub fn admin_error_response(
+    code: impl Into<String>,
+    message: impl Into<String>,
+) -> AdminErrorResponse {
+    AdminErrorResponse::new(code, message)
+}
+
+pub fn admin_error_response_with_details(
+    code: impl Into<String>,
+    message: impl Into<String>,
+    details: Map<String, Value>,
+) -> AdminErrorResponse {
+    AdminErrorResponse::new(code, message).with_details(details)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn shared_admin_error_helpers_delegate_to_transport_shape() {
+        let basic = admin_error_response("conflict", "duplicate logical model");
+        let detailed = admin_error_response_with_details(
+            "reference_conflict",
+            "pool is still referenced",
+            serde_json::Map::from_iter([(String::from("resource"), json!("pool"))]),
+        );
+
+        let basic_json = serde_json::to_value(basic).unwrap();
+        let detailed_json = serde_json::to_value(detailed).unwrap();
+
+        assert_eq!(basic_json["error"]["code"], json!("conflict"));
+        assert_eq!(detailed_json["error"]["details"]["resource"], json!("pool"));
+    }
+}

--- a/clients/rook/src/admin/handlers.rs
+++ b/clients/rook/src/admin/handlers.rs
@@ -12,11 +12,15 @@ use crate::services::{
 };
 use axum::{
     extract::Json as ExtractJson,
-    extract::{Path, State},
+    extract::{
+        rejection::{JsonRejection, PathRejection},
+        Path, State,
+    },
     http::StatusCode,
     Json,
 };
 use serde_json::{Map, Value};
+use tracing::error;
 
 type AdminJson<T> = Result<Json<T>, (StatusCode, Json<AdminErrorResponse>)>;
 type AdminCreated<T> = Result<(StatusCode, Json<T>), (StatusCode, Json<AdminErrorResponse>)>;
@@ -32,10 +36,10 @@ fn bad_request(message: impl Into<String>) -> (StatusCode, Json<AdminErrorRespon
 fn classify_rook_error(error: RookError) -> (StatusCode, Json<AdminErrorResponse>) {
     match error {
         RookError::Registry(message) => classify_registry_message(message),
-        other => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(admin_error_response("internal_error", other.to_string())),
-        ),
+        other => {
+            error!(error = %other, "unhandled admin rook error");
+            internal_error_response()
+        }
     }
 }
 
@@ -62,10 +66,36 @@ fn classify_registry_message(message: String) -> (StatusCode, Json<AdminErrorRes
             Json(admin_error_response("reference_conflict", message)),
         );
     }
+    error!(message = %message, "unclassified registry error in admin handler");
+    internal_error_response()
+}
+
+fn internal_error_response() -> (StatusCode, Json<AdminErrorResponse>) {
     (
         StatusCode::INTERNAL_SERVER_ERROR,
-        Json(admin_error_response("internal_error", message)),
+        Json(admin_error_response(
+            "internal_error",
+            "Internal server error",
+        )),
     )
+}
+
+fn parse_json<T>(
+    result: Result<ExtractJson<T>, JsonRejection>,
+) -> Result<T, (StatusCode, Json<AdminErrorResponse>)> {
+    result.map(|ExtractJson(value)| value).map_err(|rejection| {
+        error!(error = %rejection, "admin json extraction failed");
+        bad_request("invalid JSON request body")
+    })
+}
+
+fn parse_path<T>(
+    result: Result<Path<T>, PathRejection>,
+) -> Result<T, (StatusCode, Json<AdminErrorResponse>)> {
+    result.map(|Path(value)| value).map_err(|rejection| {
+        error!(error = %rejection, "admin path extraction failed");
+        bad_request("invalid path parameter")
+    })
 }
 
 fn validate_display_name(name: &str) -> Result<(), (StatusCode, Json<AdminErrorResponse>)> {
@@ -140,8 +170,9 @@ pub async fn handle_get_usage() -> Json<UsageStatusView> {
 
 pub async fn handle_create_account(
     State(registry): State<RookRegistry>,
-    ExtractJson(req): ExtractJson<CreateAccountRequest>,
+    req: Result<ExtractJson<CreateAccountRequest>, JsonRejection>,
 ) -> AdminCreated<AccountView> {
+    let req = parse_json(req)?;
     validate_display_name(&req.display_name)?;
     let account = account_from_request(crate::domain::AccountId::generate(), req);
     registry
@@ -153,10 +184,12 @@ pub async fn handle_create_account(
 }
 
 pub async fn handle_update_account(
-    Path(account_id): Path<crate::domain::AccountId>,
+    account_id: Result<Path<crate::domain::AccountId>, PathRejection>,
     State(registry): State<RookRegistry>,
-    ExtractJson(req): ExtractJson<UpdateAccountRequest>,
+    req: Result<ExtractJson<UpdateAccountRequest>, JsonRejection>,
 ) -> AdminJson<AccountView> {
+    let account_id = parse_path(account_id)?;
+    let req = parse_json(req)?;
     validate_display_name(&req.display_name)?;
     if registry.accounts().get(account_id).await.is_none() {
         return Err(not_found("account", account_id));
@@ -171,9 +204,10 @@ pub async fn handle_update_account(
 }
 
 pub async fn handle_delete_account(
-    Path(account_id): Path<crate::domain::AccountId>,
+    account_id: Result<Path<crate::domain::AccountId>, PathRejection>,
     State(registry): State<RookRegistry>,
 ) -> AdminEmpty {
+    let account_id = parse_path(account_id)?;
     if registry.accounts().get(account_id).await.is_none() {
         return Err(not_found("account", account_id));
     }
@@ -198,9 +232,10 @@ pub async fn handle_list_accounts(State(registry): State<RookRegistry>) -> Json<
 }
 
 pub async fn handle_get_account(
-    Path(account_id): Path<crate::domain::AccountId>,
+    account_id: Result<Path<crate::domain::AccountId>, PathRejection>,
     State(registry): State<RookRegistry>,
 ) -> AdminJson<AccountView> {
+    let account_id = parse_path(account_id)?;
     match registry.accounts().get(account_id).await {
         Some(account) => Ok(Json(AccountView::from(account))),
         None => Err(not_found("account", account_id)),
@@ -220,9 +255,10 @@ pub async fn handle_list_pools(State(registry): State<RookRegistry>) -> Json<Vec
 }
 
 pub async fn handle_get_pool(
-    Path(pool_id): Path<crate::domain::PoolId>,
+    pool_id: Result<Path<crate::domain::PoolId>, PathRejection>,
     State(registry): State<RookRegistry>,
 ) -> AdminJson<PoolView> {
+    let pool_id = parse_path(pool_id)?;
     match registry.pools().get(pool_id).await {
         Some(pool) => Ok(Json(PoolView::from(pool))),
         None => Err(not_found("pool", pool_id)),
@@ -231,8 +267,9 @@ pub async fn handle_get_pool(
 
 pub async fn handle_create_pool(
     State(registry): State<RookRegistry>,
-    ExtractJson(req): ExtractJson<CreatePoolRequest>,
+    req: Result<ExtractJson<CreatePoolRequest>, JsonRejection>,
 ) -> AdminCreated<PoolView> {
+    let req = parse_json(req)?;
     validate_name(&req.name, "name")?;
     let pool = pool_from_request(crate::domain::PoolId::generate(), req);
     registry
@@ -244,10 +281,12 @@ pub async fn handle_create_pool(
 }
 
 pub async fn handle_update_pool(
-    Path(pool_id): Path<crate::domain::PoolId>,
+    pool_id: Result<Path<crate::domain::PoolId>, PathRejection>,
     State(registry): State<RookRegistry>,
-    ExtractJson(req): ExtractJson<UpdatePoolRequest>,
+    req: Result<ExtractJson<UpdatePoolRequest>, JsonRejection>,
 ) -> AdminJson<PoolView> {
+    let pool_id = parse_path(pool_id)?;
+    let req = parse_json(req)?;
     validate_name(&req.name, "name")?;
     if registry.pools().get(pool_id).await.is_none() {
         return Err(not_found("pool", pool_id));
@@ -262,9 +301,10 @@ pub async fn handle_update_pool(
 }
 
 pub async fn handle_delete_pool(
-    Path(pool_id): Path<crate::domain::PoolId>,
+    pool_id: Result<Path<crate::domain::PoolId>, PathRejection>,
     State(registry): State<RookRegistry>,
 ) -> AdminEmpty {
+    let pool_id = parse_path(pool_id)?;
     if registry.pools().get(pool_id).await.is_none() {
         return Err(not_found("pool", pool_id));
     }
@@ -277,10 +317,12 @@ pub async fn handle_delete_pool(
 }
 
 pub async fn handle_add_pool_member(
-    Path(pool_id): Path<crate::domain::PoolId>,
+    pool_id: Result<Path<crate::domain::PoolId>, PathRejection>,
     State(registry): State<RookRegistry>,
-    ExtractJson(req): ExtractJson<AddPoolMemberRequest>,
+    req: Result<ExtractJson<AddPoolMemberRequest>, JsonRejection>,
 ) -> AdminJson<PoolView> {
+    let pool_id = parse_path(pool_id)?;
+    let req = parse_json(req)?;
     if registry.pools().get(pool_id).await.is_none() {
         return Err(not_found("pool", pool_id));
     }
@@ -299,9 +341,10 @@ pub async fn handle_add_pool_member(
 }
 
 pub async fn handle_remove_pool_member(
-    Path((pool_id, account_id)): Path<(crate::domain::PoolId, crate::domain::AccountId)>,
+    ids: Result<Path<(crate::domain::PoolId, crate::domain::AccountId)>, PathRejection>,
     State(registry): State<RookRegistry>,
 ) -> AdminJson<PoolView> {
+    let (pool_id, account_id) = parse_path(ids)?;
     match registry.pools().get(pool_id).await {
         Some(pool) => {
             if !pool.members.contains(&account_id) {
@@ -341,9 +384,10 @@ pub async fn handle_list_routes(State(registry): State<RookRegistry>) -> Json<Ve
 }
 
 pub async fn handle_get_route(
-    Path(route_id): Path<crate::domain::RouteId>,
+    route_id: Result<Path<crate::domain::RouteId>, PathRejection>,
     State(registry): State<RookRegistry>,
 ) -> AdminJson<RouteView> {
+    let route_id = parse_path(route_id)?;
     match registry.routes().get(route_id).await {
         Some(route) => Ok(Json(RouteView::from(route))),
         None => Err(not_found("route", route_id)),
@@ -352,8 +396,9 @@ pub async fn handle_get_route(
 
 pub async fn handle_create_route(
     State(registry): State<RookRegistry>,
-    ExtractJson(req): ExtractJson<CreateRouteRequest>,
+    req: Result<ExtractJson<CreateRouteRequest>, JsonRejection>,
 ) -> AdminCreated<RouteView> {
+    let req = parse_json(req)?;
     validate_name(&req.logical_model, "logical_model")?;
     let route = crate::domain::ModelRoute {
         id: crate::domain::RouteId::generate(),
@@ -371,10 +416,12 @@ pub async fn handle_create_route(
 }
 
 pub async fn handle_update_route(
-    Path(route_id): Path<crate::domain::RouteId>,
+    route_id: Result<Path<crate::domain::RouteId>, PathRejection>,
     State(registry): State<RookRegistry>,
-    ExtractJson(req): ExtractJson<UpdateRouteRequest>,
+    req: Result<ExtractJson<UpdateRouteRequest>, JsonRejection>,
 ) -> AdminJson<RouteView> {
+    let route_id = parse_path(route_id)?;
+    let req = parse_json(req)?;
     validate_name(&req.logical_model, "logical_model")?;
     if registry.routes().get(route_id).await.is_none() {
         return Err(not_found("route", route_id));
@@ -395,9 +442,10 @@ pub async fn handle_update_route(
 }
 
 pub async fn handle_delete_route(
-    Path(route_id): Path<crate::domain::RouteId>,
+    route_id: Result<Path<crate::domain::RouteId>, PathRejection>,
     State(registry): State<RookRegistry>,
 ) -> AdminEmpty {
+    let route_id = parse_path(route_id)?;
     if registry.routes().get(route_id).await.is_none() {
         return Err(not_found("route", route_id));
     }
@@ -415,8 +463,9 @@ pub async fn handle_get_settings(State(registry): State<RookRegistry>) -> Json<S
 
 pub async fn handle_put_settings(
     State(registry): State<RookRegistry>,
-    ExtractJson(req): ExtractJson<UpdateSettingsRequest>,
+    req: Result<ExtractJson<UpdateSettingsRequest>, JsonRejection>,
 ) -> AdminJson<SettingsView> {
+    let req = parse_json(req)?;
     if req.gateway_port == 0 {
         return Err(bad_request("gateway_port must be greater than 0"));
     }

--- a/clients/rook/src/admin/mod.rs
+++ b/clients/rook/src/admin/mod.rs
@@ -1,0 +1,881 @@
+pub mod handlers;
+pub mod types;
+
+use crate::registry::RookRegistry;
+use axum::{routing::get, Router};
+
+pub fn build_router(registry: RookRegistry) -> Router {
+    Router::new()
+        .route("/health", get(handlers::handle_health))
+        .route(
+            "/health/accounts",
+            get(handlers::handle_list_account_health),
+        )
+        .route("/health/summary", get(handlers::handle_health_summary))
+        .route(
+            "/accounts",
+            get(handlers::handle_list_accounts).post(handlers::handle_create_account),
+        )
+        .route(
+            "/accounts/{account_id}",
+            get(handlers::handle_get_account)
+                .put(handlers::handle_update_account)
+                .delete(handlers::handle_delete_account),
+        )
+        .route(
+            "/pools",
+            get(handlers::handle_list_pools).post(handlers::handle_create_pool),
+        )
+        .route(
+            "/pools/{pool_id}",
+            get(handlers::handle_get_pool)
+                .put(handlers::handle_update_pool)
+                .delete(handlers::handle_delete_pool),
+        )
+        .route(
+            "/pools/{pool_id}/accounts",
+            axum::routing::post(handlers::handle_add_pool_member),
+        )
+        .route(
+            "/pools/{pool_id}/accounts/{account_id}",
+            axum::routing::delete(handlers::handle_remove_pool_member),
+        )
+        .route(
+            "/routes",
+            get(handlers::handle_list_routes).post(handlers::handle_create_route),
+        )
+        .route(
+            "/routes/{route_id}",
+            get(handlers::handle_get_route)
+                .put(handlers::handle_update_route)
+                .delete(handlers::handle_delete_route),
+        )
+        .route(
+            "/settings",
+            get(handlers::handle_get_settings).put(handlers::handle_put_settings),
+        )
+        .route("/usage", get(handlers::handle_get_usage))
+        .with_state(registry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        PoolId, ProviderAccount, ProviderPool, ProviderVendor, RookSettings, RoutingPolicy,
+        SelectionStrategy,
+    };
+    use crate::registry::RookRegistry;
+    use crate::services::{
+        account::AccountService as _, health::HealthService as _, pool::PoolService as _,
+        route::RouteService as _, settings::SettingsService as _,
+    };
+    use axum::body::{to_bytes, Body};
+    use axum::http::{Request, StatusCode};
+    use serde_json::{json, Value};
+    use tower::util::ServiceExt;
+
+    fn make_account(name: &str, api_key: Option<&str>) -> ProviderAccount {
+        ProviderAccount {
+            id: crate::domain::AccountId::generate(),
+            vendor: ProviderVendor::OpenAi,
+            display_name: name.to_string(),
+            api_base_override: None,
+            api_key: api_key.map(ToOwned::to_owned),
+            enabled: true,
+            weight: 1,
+            priority: 0,
+            tags: vec![],
+            capabilities: vec!["chat".to_string()],
+        }
+    }
+
+    fn make_pool(member: crate::domain::AccountId) -> ProviderPool {
+        ProviderPool {
+            id: PoolId::generate(),
+            name: "primary".to_string(),
+            strategy: SelectionStrategy::RoundRobin,
+            members: vec![member],
+            fallback_pool_id: None,
+        }
+    }
+
+    fn make_route(pool_id: PoolId) -> crate::domain::ModelRoute {
+        crate::domain::ModelRoute {
+            id: crate::domain::RouteId::generate(),
+            logical_model: "gpt-4o".to_string(),
+            target_pool_id: pool_id,
+            fallback_route_id: None,
+            capability_constraints: vec!["chat".to_string()],
+        }
+    }
+
+    async fn test_api_app() -> RookRegistry {
+        RookRegistry::open_in_memory().await.unwrap()
+    }
+
+    async fn request_json(app: axum::Router, path: &str) -> (StatusCode, Value) {
+        let response = app
+            .oneshot(Request::get(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json = serde_json::from_slice::<Value>(&body).unwrap();
+        (status, json)
+    }
+
+    async fn send_json(
+        app: axum::Router,
+        method: axum::http::Method,
+        path: &str,
+        payload: Value,
+    ) -> (StatusCode, Value) {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(path)
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json = if body.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice::<Value>(&body).unwrap()
+        };
+        (status, json)
+    }
+
+    async fn request_text(app: axum::Router, path: &str) -> (StatusCode, Vec<u8>) {
+        let response = app
+            .oneshot(Request::get(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (status, body.to_vec())
+    }
+
+    #[tokio::test]
+    async fn admin_router_preserves_health_and_usage_placeholder() {
+        let registry = test_api_app().await;
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (health_status, health_body) = request_text(app.clone(), "/api/health").await;
+        assert_eq!(health_status, StatusCode::OK);
+        assert_eq!(health_body, b"ok");
+
+        let (usage_status, usage_json) = request_json(app, "/api/usage").await;
+        assert_eq!(usage_status, StatusCode::OK);
+        assert_eq!(
+            usage_json,
+            json!({
+                "available": false,
+                "reason": "usage accounting is not implemented in M1"
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_router_lists_and_gets_redacted_accounts() {
+        let registry = test_api_app().await;
+        let account = make_account("Primary OpenAI", Some("sk-secret"));
+        let account_id = account.id;
+        registry.accounts().create(account).await.unwrap();
+
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (list_status, list_json) = request_json(app.clone(), "/api/accounts").await;
+        assert_eq!(list_status, StatusCode::OK);
+        assert_eq!(list_json.as_array().unwrap().len(), 1);
+        assert_eq!(list_json[0]["has_api_key"], json!(true));
+        assert!(list_json[0].get("api_key").is_none());
+
+        let (get_status, get_json) =
+            request_json(app, &format!("/api/accounts/{account_id}")).await;
+        assert_eq!(get_status, StatusCode::OK);
+        assert_eq!(get_json["id"], json!(account_id.to_string()));
+        assert_eq!(get_json["display_name"], json!("Primary OpenAI"));
+        assert!(get_json.get("api_key").is_none());
+    }
+
+    #[tokio::test]
+    async fn admin_router_returns_structured_not_found_for_unknown_account() {
+        let registry = test_api_app().await;
+        let missing = crate::domain::AccountId::generate();
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (status, json) = request_json(app, &format!("/api/accounts/{missing}")).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(json["error"]["code"], json!("not_found"));
+    }
+
+    #[tokio::test]
+    async fn admin_router_lists_and_gets_pools_and_routes() {
+        let registry = test_api_app().await;
+        let account = make_account("Pool Member", None);
+        let account_id = account.id;
+        registry.accounts().create(account).await.unwrap();
+        let pool = make_pool(account_id);
+        let pool_id = pool.id;
+        registry.pools().create(pool).await.unwrap();
+        let route = make_route(pool_id);
+        let route_id = route.id;
+        registry.routes().create(route).await.unwrap();
+
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (pools_status, pools_json) = request_json(app.clone(), "/api/pools").await;
+        assert_eq!(pools_status, StatusCode::OK);
+        assert_eq!(pools_json[0]["id"], json!(pool_id.to_string()));
+
+        let (pool_status, pool_json) =
+            request_json(app.clone(), &format!("/api/pools/{pool_id}")).await;
+        assert_eq!(pool_status, StatusCode::OK);
+        assert_eq!(pool_json["members"], json!([account_id.to_string()]));
+
+        let (routes_status, routes_json) = request_json(app.clone(), "/api/routes").await;
+        assert_eq!(routes_status, StatusCode::OK);
+        assert_eq!(routes_json[0]["id"], json!(route_id.to_string()));
+
+        let (route_status, route_json) =
+            request_json(app, &format!("/api/routes/{route_id}")).await;
+        assert_eq!(route_status, StatusCode::OK);
+        assert_eq!(route_json["logical_model"], json!("gpt-4o"));
+    }
+
+    #[tokio::test]
+    async fn admin_router_get_settings_reads_defaults_or_saved_values() {
+        let registry = test_api_app().await;
+        let settings = RookSettings {
+            gateway_port: 4141,
+            default_routing_policy: RoutingPolicy {
+                strategy: SelectionStrategy::RoundRobin,
+                max_retries: 5,
+                cooldown_seconds: 120,
+            },
+            log_json: true,
+            log_level: "debug".to_string(),
+        };
+        registry.settings().save(settings).await.unwrap();
+
+        let app = axum::Router::new().nest("/api", build_router(registry));
+        let (status, json) = request_json(app, "/api/settings").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["gateway_port"], json!(4141));
+        assert_eq!(json["log_json"], json!(true));
+        assert_eq!(
+            json["default_routing_policy"]["strategy"],
+            json!("round_robin")
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_router_derives_health_account_list_and_summary() {
+        let registry = test_api_app().await;
+        let unknown = make_account("Unknown", None);
+        let unknown_id = unknown.id;
+        registry.accounts().create(unknown).await.unwrap();
+        let healthy = make_account("Healthy", None);
+        let healthy_id = healthy.id;
+        registry.accounts().create(healthy).await.unwrap();
+        let unhealthy = make_account("Unhealthy", None);
+        let unhealthy_id = unhealthy.id;
+        registry.accounts().create(unhealthy).await.unwrap();
+
+        registry.health().mark_success(healthy_id).await;
+        registry.health().mark_failure(unhealthy_id, 60).await;
+
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (accounts_status, accounts_json) =
+            request_json(app.clone(), "/api/health/accounts").await;
+        assert_eq!(accounts_status, StatusCode::OK);
+        assert_eq!(accounts_json.as_array().unwrap().len(), 3);
+        let unknown_row = accounts_json
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["account_id"] == json!(unknown_id.to_string()))
+            .unwrap();
+        assert_eq!(unknown_row["status"], json!("unknown"));
+        assert_eq!(unknown_row["last_checked"], Value::Null);
+        let healthy_row = accounts_json
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["account_id"] == json!(healthy_id.to_string()))
+            .unwrap();
+        assert_eq!(healthy_row["status"], json!("healthy"));
+        let unhealthy_row = accounts_json
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["account_id"] == json!(unhealthy_id.to_string()))
+            .unwrap();
+        assert_eq!(unhealthy_row["status"], json!("unhealthy"));
+
+        let (summary_status, summary_json) = request_json(app, "/api/health/summary").await;
+        assert_eq!(summary_status, StatusCode::OK);
+        assert_eq!(summary_json["total"], json!(3));
+        assert_eq!(summary_json["unknown"], json!(1));
+        assert_eq!(summary_json["healthy"], json!(1));
+        assert_eq!(summary_json["unhealthy"], json!(1));
+        assert_eq!(summary_json["degraded"], json!(0));
+    }
+
+    #[tokio::test]
+    async fn admin_router_creates_updates_and_deletes_accounts_with_redaction() {
+        let registry = test_api_app().await;
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (create_status, create_json) = send_json(
+            app.clone(),
+            axum::http::Method::POST,
+            "/api/accounts",
+            json!({
+                "vendor": "open_ai",
+                "display_name": "Primary OpenAI",
+                "api_key": "sk-secret",
+                "enabled": true,
+                "weight": 1,
+                "priority": 0,
+                "tags": ["prod"],
+                "capabilities": ["chat"]
+            }),
+        )
+        .await;
+        assert_eq!(create_status, StatusCode::CREATED);
+        assert_eq!(create_json["has_api_key"], json!(true));
+        assert!(create_json.get("api_key").is_none());
+
+        let account_id = create_json["id"].as_str().unwrap().to_string();
+        let (update_status, update_json) = send_json(
+            app.clone(),
+            axum::http::Method::PUT,
+            &format!("/api/accounts/{account_id}"),
+            json!({
+                "vendor": "open_ai",
+                "display_name": "Primary OpenAI Updated",
+                "api_base_override": "http://localhost:4000/v1",
+                "api_key": "sk-new-secret",
+                "enabled": true,
+                "weight": 2,
+                "priority": 1,
+                "tags": ["prod", "blue"],
+                "capabilities": ["chat"]
+            }),
+        )
+        .await;
+        assert_eq!(update_status, StatusCode::OK);
+        assert_eq!(update_json["display_name"], json!("Primary OpenAI Updated"));
+        assert_eq!(update_json["has_api_key"], json!(true));
+        assert!(update_json.get("api_key").is_none());
+
+        let (delete_status, delete_json) = send_json(
+            app.clone(),
+            axum::http::Method::DELETE,
+            &format!("/api/accounts/{account_id}"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(delete_status, StatusCode::NO_CONTENT);
+        assert_eq!(delete_json, Value::Null);
+
+        let (missing_status, missing_json) =
+            request_json(app, &format!("/api/accounts/{account_id}")).await;
+        assert_eq!(missing_status, StatusCode::NOT_FOUND);
+        assert_eq!(missing_json["error"]["code"], json!("not_found"));
+    }
+
+    #[tokio::test]
+    async fn admin_router_returns_not_found_for_updating_or_deleting_missing_account() {
+        let registry = test_api_app().await;
+        let missing = crate::domain::AccountId::generate();
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (update_status, update_json) = send_json(
+            app.clone(),
+            axum::http::Method::PUT,
+            &format!("/api/accounts/{missing}"),
+            json!({
+                "vendor": "open_ai",
+                "display_name": "Missing",
+                "enabled": true,
+                "weight": 1,
+                "priority": 0,
+                "tags": [],
+                "capabilities": []
+            }),
+        )
+        .await;
+        assert_eq!(update_status, StatusCode::NOT_FOUND);
+        assert_eq!(update_json["error"]["code"], json!("not_found"));
+
+        let (delete_status, delete_json) = send_json(
+            app,
+            axum::http::Method::DELETE,
+            &format!("/api/accounts/{missing}"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(delete_status, StatusCode::NOT_FOUND);
+        assert_eq!(delete_json["error"]["code"], json!("not_found"));
+    }
+
+    #[tokio::test]
+    async fn admin_router_creates_updates_and_deletes_pools() {
+        let registry = test_api_app().await;
+        let account = make_account("Pool Member", None);
+        let account_id = account.id;
+        registry.accounts().create(account).await.unwrap();
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (create_status, create_json) = send_json(
+            app.clone(),
+            axum::http::Method::POST,
+            "/api/pools",
+            json!({
+                "name": "primary",
+                "strategy": "round_robin",
+                "members": [account_id],
+                "fallback_pool_id": null
+            }),
+        )
+        .await;
+        assert_eq!(create_status, StatusCode::CREATED);
+        let pool_id = create_json["id"].as_str().unwrap().to_string();
+
+        let (update_status, update_json) = send_json(
+            app.clone(),
+            axum::http::Method::PUT,
+            &format!("/api/pools/{pool_id}"),
+            json!({
+                "name": "primary-updated",
+                "strategy": "priority",
+                "members": [account_id],
+                "fallback_pool_id": null
+            }),
+        )
+        .await;
+        assert_eq!(update_status, StatusCode::OK);
+        assert_eq!(update_json["name"], json!("primary-updated"));
+        assert_eq!(update_json["strategy"], json!("priority"));
+
+        let (delete_status, _) = send_json(
+            app,
+            axum::http::Method::DELETE,
+            &format!("/api/pools/{pool_id}"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(delete_status, StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn admin_router_creates_updates_and_deletes_routes_and_conflicts_on_duplicates() {
+        let registry = test_api_app().await;
+        let account = make_account("Route Member", None);
+        let account_id = account.id;
+        registry.accounts().create(account).await.unwrap();
+        let pool = make_pool(account_id);
+        let pool_id = pool.id;
+        registry.pools().create(pool).await.unwrap();
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (create_status, create_json) = send_json(
+            app.clone(),
+            axum::http::Method::POST,
+            "/api/routes",
+            json!({
+                "logical_model": "gpt-4o",
+                "target_pool_id": pool_id,
+                "fallback_route_id": null,
+                "capability_constraints": ["chat"]
+            }),
+        )
+        .await;
+        assert_eq!(create_status, StatusCode::CREATED);
+        let route_id = create_json["id"].as_str().unwrap().to_string();
+
+        let (duplicate_status, duplicate_json) = send_json(
+            app.clone(),
+            axum::http::Method::POST,
+            "/api/routes",
+            json!({
+                "logical_model": "gpt-4o",
+                "target_pool_id": pool_id,
+                "fallback_route_id": null,
+                "capability_constraints": ["chat"]
+            }),
+        )
+        .await;
+        assert_eq!(duplicate_status, StatusCode::CONFLICT);
+        assert_eq!(duplicate_json["error"]["code"], json!("conflict"));
+
+        let (update_status, update_json) = send_json(
+            app.clone(),
+            axum::http::Method::PUT,
+            &format!("/api/routes/{route_id}"),
+            json!({
+                "logical_model": "gpt-4o-mini",
+                "target_pool_id": pool_id,
+                "fallback_route_id": null,
+                "capability_constraints": ["chat", "vision"]
+            }),
+        )
+        .await;
+        assert_eq!(update_status, StatusCode::OK);
+        assert_eq!(update_json["logical_model"], json!("gpt-4o-mini"));
+
+        let (delete_status, _) = send_json(
+            app,
+            axum::http::Method::DELETE,
+            &format!("/api/routes/{route_id}"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(delete_status, StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn admin_router_put_settings_persists_and_round_trips() {
+        let registry = test_api_app().await;
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (put_status, put_json) = send_json(
+            app.clone(),
+            axum::http::Method::PUT,
+            "/api/settings",
+            json!({
+                "gateway_port": 5151,
+                "default_routing_policy": {
+                    "strategy": "priority",
+                    "max_retries": 9,
+                    "cooldown_seconds": 180
+                },
+                "log_json": true,
+                "log_level": "debug"
+            }),
+        )
+        .await;
+        assert_eq!(put_status, StatusCode::OK);
+        assert_eq!(put_json["gateway_port"], json!(5151));
+
+        let (get_status, get_json) = request_json(app, "/api/settings").await;
+        assert_eq!(get_status, StatusCode::OK);
+        assert_eq!(get_json["gateway_port"], json!(5151));
+        assert_eq!(get_json["default_routing_policy"]["max_retries"], json!(9));
+    }
+
+    #[tokio::test]
+    async fn admin_router_adds_pool_member_and_is_idempotent() {
+        let registry = test_api_app().await;
+        let existing = make_account("Existing", None);
+        let existing_id = existing.id;
+        registry.accounts().create(existing).await.unwrap();
+        let added = make_account("Added", None);
+        let added_id = added.id;
+        registry.accounts().create(added).await.unwrap();
+        let pool = make_pool(existing_id);
+        let pool_id = pool.id;
+        registry.pools().create(pool).await.unwrap();
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (add_status, add_json) = send_json(
+            app.clone(),
+            axum::http::Method::POST,
+            &format!("/api/pools/{pool_id}/accounts"),
+            json!({ "account_id": added_id }),
+        )
+        .await;
+        assert_eq!(add_status, StatusCode::OK);
+        let added_members = add_json["members"].as_array().unwrap();
+        assert_eq!(added_members.len(), 2);
+        assert!(added_members.contains(&json!(existing_id.to_string())));
+        assert!(added_members.contains(&json!(added_id.to_string())));
+
+        let (repeat_status, repeat_json) = send_json(
+            app,
+            axum::http::Method::POST,
+            &format!("/api/pools/{pool_id}/accounts"),
+            json!({ "account_id": added_id }),
+        )
+        .await;
+        assert_eq!(repeat_status, StatusCode::OK);
+        let repeat_members = repeat_json["members"].as_array().unwrap();
+        assert_eq!(repeat_members.len(), 2);
+        let added_occurrences = repeat_members
+            .iter()
+            .filter(|member| *member == &json!(added_id.to_string()))
+            .count();
+        assert_eq!(added_occurrences, 1);
+    }
+
+    #[tokio::test]
+    async fn admin_router_add_member_missing_account_or_pool_uses_structured_errors() {
+        let registry = test_api_app().await;
+        let existing = make_account("Existing", None);
+        let existing_id = existing.id;
+        registry.accounts().create(existing).await.unwrap();
+        let pool = make_pool(existing_id);
+        let pool_id = pool.id;
+        registry.pools().create(pool).await.unwrap();
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let missing_account = crate::domain::AccountId::generate();
+        let (missing_account_status, missing_account_json) = send_json(
+            app.clone(),
+            axum::http::Method::POST,
+            &format!("/api/pools/{pool_id}/accounts"),
+            json!({ "account_id": missing_account }),
+        )
+        .await;
+        assert_eq!(missing_account_status, StatusCode::NOT_FOUND);
+        assert_eq!(missing_account_json["error"]["code"], json!("not_found"));
+
+        let missing_pool = crate::domain::PoolId::generate();
+        let (missing_pool_status, missing_pool_json) = send_json(
+            app,
+            axum::http::Method::POST,
+            &format!("/api/pools/{missing_pool}/accounts"),
+            json!({ "account_id": existing_id }),
+        )
+        .await;
+        assert_eq!(missing_pool_status, StatusCode::NOT_FOUND);
+        assert_eq!(missing_pool_json["error"]["code"], json!("not_found"));
+    }
+
+    #[tokio::test]
+    async fn admin_router_removes_pool_member_and_non_member_is_conflict() {
+        let registry = test_api_app().await;
+        let existing = make_account("Existing", None);
+        let existing_id = existing.id;
+        registry.accounts().create(existing).await.unwrap();
+        let removable = make_account("Removable", None);
+        let removable_id = removable.id;
+        registry.accounts().create(removable).await.unwrap();
+        let pool = ProviderPool {
+            id: PoolId::generate(),
+            name: "primary".to_string(),
+            strategy: SelectionStrategy::RoundRobin,
+            members: vec![existing_id, removable_id],
+            fallback_pool_id: None,
+        };
+        let pool_id = pool.id;
+        registry.pools().create(pool).await.unwrap();
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (remove_status, remove_json) = send_json(
+            app.clone(),
+            axum::http::Method::DELETE,
+            &format!("/api/pools/{pool_id}/accounts/{removable_id}"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(remove_status, StatusCode::OK);
+        assert_eq!(remove_json["members"], json!([existing_id.to_string()]));
+
+        let (conflict_status, conflict_json) = send_json(
+            app,
+            axum::http::Method::DELETE,
+            &format!("/api/pools/{pool_id}/accounts/{removable_id}"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(conflict_status, StatusCode::CONFLICT);
+        assert_eq!(conflict_json["error"]["code"], json!("conflict"));
+    }
+
+    #[tokio::test]
+    async fn admin_router_delete_account_referenced_by_pool_is_conflict() {
+        let registry = test_api_app().await;
+        let account = make_account("Referenced", None);
+        let account_id = account.id;
+        registry.accounts().create(account).await.unwrap();
+        let pool = make_pool(account_id);
+        registry.pools().create(pool).await.unwrap();
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (status, json) = send_json(
+            app.clone(),
+            axum::http::Method::DELETE,
+            &format!("/api/accounts/{account_id}"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(json["error"]["code"], json!("reference_conflict"));
+
+        let (get_status, _) = request_json(app, &format!("/api/accounts/{account_id}")).await;
+        assert_eq!(get_status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn admin_router_delete_pool_referenced_by_route_is_conflict() {
+        let registry = test_api_app().await;
+        let account = make_account("Member", None);
+        let account_id = account.id;
+        registry.accounts().create(account).await.unwrap();
+        let pool = make_pool(account_id);
+        let pool_id = pool.id;
+        registry.pools().create(pool).await.unwrap();
+        registry.routes().create(make_route(pool_id)).await.unwrap();
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (status, json) = send_json(
+            app,
+            axum::http::Method::DELETE,
+            &format!("/api/pools/{pool_id}"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(json["error"]["code"], json!("reference_conflict"));
+    }
+
+    #[tokio::test]
+    async fn admin_router_delete_pool_referenced_as_fallback_is_conflict() {
+        let registry = test_api_app().await;
+        let account = make_account("Member", None);
+        let account_id = account.id;
+        registry.accounts().create(account).await.unwrap();
+        let fallback_pool = make_pool(account_id);
+        let fallback_pool_id = fallback_pool.id;
+        registry.pools().create(fallback_pool).await.unwrap();
+        let primary_pool = ProviderPool {
+            id: PoolId::generate(),
+            name: "primary-with-fallback".to_string(),
+            strategy: SelectionStrategy::RoundRobin,
+            members: vec![account_id],
+            fallback_pool_id: Some(fallback_pool_id),
+        };
+        registry.pools().create(primary_pool).await.unwrap();
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (status, json) = send_json(
+            app,
+            axum::http::Method::DELETE,
+            &format!("/api/pools/{fallback_pool_id}"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(json["error"]["code"], json!("reference_conflict"));
+    }
+
+    #[tokio::test]
+    async fn admin_router_delete_route_referenced_as_fallback_is_conflict() {
+        let registry = test_api_app().await;
+        let account = make_account("Member", None);
+        let account_id = account.id;
+        registry.accounts().create(account).await.unwrap();
+        let pool = make_pool(account_id);
+        let pool_id = pool.id;
+        registry.pools().create(pool).await.unwrap();
+
+        let fallback_route = crate::domain::ModelRoute {
+            id: crate::domain::RouteId::generate(),
+            logical_model: "gpt-4o-fallback".to_string(),
+            target_pool_id: pool_id,
+            fallback_route_id: None,
+            capability_constraints: vec![],
+        };
+        let fallback_route_id = fallback_route.id;
+        registry.routes().create(fallback_route).await.unwrap();
+        let primary_route = crate::domain::ModelRoute {
+            id: crate::domain::RouteId::generate(),
+            logical_model: "gpt-4o-primary".to_string(),
+            target_pool_id: pool_id,
+            fallback_route_id: Some(fallback_route_id),
+            capability_constraints: vec![],
+        };
+        registry.routes().create(primary_route).await.unwrap();
+        let app = axum::Router::new().nest("/api", build_router(registry));
+
+        let (status, json) = send_json(
+            app,
+            axum::http::Method::DELETE,
+            &format!("/api/routes/{fallback_route_id}"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(json["error"]["code"], json!("reference_conflict"));
+    }
+
+    #[tokio::test]
+    async fn admin_router_returns_not_found_for_missing_pool_and_route_mutations() {
+        let registry = test_api_app().await;
+        let app = axum::Router::new().nest("/api", build_router(registry));
+        let missing_pool = crate::domain::PoolId::generate();
+        let missing_route = crate::domain::RouteId::generate();
+        let missing_account = crate::domain::AccountId::generate();
+
+        let (pool_update_status, pool_update_json) = send_json(
+            app.clone(),
+            axum::http::Method::PUT,
+            &format!("/api/pools/{missing_pool}"),
+            json!({
+                "name": "missing",
+                "strategy": "round_robin",
+                "members": [],
+                "fallback_pool_id": null
+            }),
+        )
+        .await;
+        assert_eq!(pool_update_status, StatusCode::NOT_FOUND);
+        assert_eq!(pool_update_json["error"]["code"], json!("not_found"));
+
+        let (pool_delete_status, pool_delete_json) = send_json(
+            app.clone(),
+            axum::http::Method::DELETE,
+            &format!("/api/pools/{missing_pool}"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(pool_delete_status, StatusCode::NOT_FOUND);
+        assert_eq!(pool_delete_json["error"]["code"], json!("not_found"));
+
+        let (route_update_status, route_update_json) = send_json(
+            app.clone(),
+            axum::http::Method::PUT,
+            &format!("/api/routes/{missing_route}"),
+            json!({
+                "logical_model": "missing",
+                "target_pool_id": missing_pool,
+                "fallback_route_id": null,
+                "capability_constraints": []
+            }),
+        )
+        .await;
+        assert_eq!(route_update_status, StatusCode::NOT_FOUND);
+        assert_eq!(route_update_json["error"]["code"], json!("not_found"));
+
+        let (route_delete_status, route_delete_json) = send_json(
+            app.clone(),
+            axum::http::Method::DELETE,
+            &format!("/api/routes/{missing_route}"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(route_delete_status, StatusCode::NOT_FOUND);
+        assert_eq!(route_delete_json["error"]["code"], json!("not_found"));
+
+        let (membership_remove_status, membership_remove_json) = send_json(
+            app,
+            axum::http::Method::DELETE,
+            &format!("/api/pools/{missing_pool}/accounts/{missing_account}"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(membership_remove_status, StatusCode::NOT_FOUND);
+        assert_eq!(membership_remove_json["error"]["code"], json!("not_found"));
+    }
+}

--- a/clients/rook/src/admin/types.rs
+++ b/clients/rook/src/admin/types.rs
@@ -1,0 +1,475 @@
+use crate::domain::{
+    AccountId, ModelRoute, PoolId, ProviderAccount, ProviderPool, ProviderVendor, RookSettings,
+    RouteId, RoutingPolicy, SelectionStrategy,
+};
+use crate::services::health::{AccountHealth, HealthStatus};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+fn default_enabled() -> bool {
+    true
+}
+
+fn default_weight() -> u32 {
+    1
+}
+
+fn default_priority() -> u32 {
+    0
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AccountView {
+    pub id: AccountId,
+    pub vendor: ProviderVendor,
+    pub display_name: String,
+    pub api_base_override: Option<String>,
+    pub has_api_key: bool,
+    pub enabled: bool,
+    pub weight: u32,
+    pub priority: u32,
+    pub tags: Vec<String>,
+    pub capabilities: Vec<String>,
+}
+
+impl From<ProviderAccount> for AccountView {
+    fn from(account: ProviderAccount) -> Self {
+        Self {
+            id: account.id,
+            vendor: account.vendor,
+            display_name: account.display_name,
+            api_base_override: account.api_base_override,
+            has_api_key: account.api_key.is_some(),
+            enabled: account.enabled,
+            weight: account.weight,
+            priority: account.priority,
+            tags: account.tags,
+            capabilities: account.capabilities,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PoolView {
+    pub id: PoolId,
+    pub name: String,
+    pub strategy: SelectionStrategy,
+    pub members: Vec<AccountId>,
+    pub fallback_pool_id: Option<PoolId>,
+}
+
+impl From<ProviderPool> for PoolView {
+    fn from(pool: ProviderPool) -> Self {
+        Self {
+            id: pool.id,
+            name: pool.name,
+            strategy: pool.strategy,
+            members: pool.members,
+            fallback_pool_id: pool.fallback_pool_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RouteView {
+    pub id: RouteId,
+    pub logical_model: String,
+    pub target_pool_id: PoolId,
+    pub fallback_route_id: Option<RouteId>,
+    pub capability_constraints: Vec<String>,
+}
+
+impl From<ModelRoute> for RouteView {
+    fn from(route: ModelRoute) -> Self {
+        Self {
+            id: route.id,
+            logical_model: route.logical_model,
+            target_pool_id: route.target_pool_id,
+            fallback_route_id: route.fallback_route_id,
+            capability_constraints: route.capability_constraints,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HealthAccountView {
+    pub account_id: AccountId,
+    pub display_name: String,
+    pub vendor: ProviderVendor,
+    pub enabled: bool,
+    pub status: String,
+    pub last_checked: Option<chrono::DateTime<chrono::Utc>>,
+    pub consecutive_failures: u32,
+    pub cooldown_until: Option<chrono::DateTime<chrono::Utc>>,
+    pub is_available: bool,
+}
+
+fn health_status_name(status: &HealthStatus) -> &'static str {
+    match status {
+        HealthStatus::Healthy => "healthy",
+        HealthStatus::Degraded => "degraded",
+        HealthStatus::Unhealthy => "unhealthy",
+        HealthStatus::Unknown => "unknown",
+    }
+}
+
+impl HealthAccountView {
+    pub fn new(account: &ProviderAccount, health: AccountHealth, is_available: bool) -> Self {
+        Self {
+            account_id: health.account_id,
+            display_name: account.display_name.clone(),
+            vendor: account.vendor.clone(),
+            enabled: account.enabled,
+            status: health_status_name(&health.status).to_string(),
+            last_checked: health.last_checked,
+            consecutive_failures: health.consecutive_failures,
+            cooldown_until: health.cooldown_until,
+            is_available,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HealthSummaryView {
+    pub total: usize,
+    pub healthy: usize,
+    pub degraded: usize,
+    pub unhealthy: usize,
+    pub unknown: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RoutingPolicyView {
+    pub strategy: SelectionStrategy,
+    pub max_retries: u32,
+    pub cooldown_seconds: u64,
+}
+
+impl From<RoutingPolicy> for RoutingPolicyView {
+    fn from(policy: RoutingPolicy) -> Self {
+        Self {
+            strategy: policy.strategy,
+            max_retries: policy.max_retries,
+            cooldown_seconds: policy.cooldown_seconds,
+        }
+    }
+}
+
+impl From<RoutingPolicyView> for RoutingPolicy {
+    fn from(policy: RoutingPolicyView) -> Self {
+        Self {
+            strategy: policy.strategy,
+            max_retries: policy.max_retries,
+            cooldown_seconds: policy.cooldown_seconds,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SettingsView {
+    pub gateway_port: u16,
+    pub default_routing_policy: RoutingPolicyView,
+    pub log_json: bool,
+    pub log_level: String,
+}
+
+impl From<RookSettings> for SettingsView {
+    fn from(settings: RookSettings) -> Self {
+        Self {
+            gateway_port: settings.gateway_port,
+            default_routing_policy: settings.default_routing_policy.into(),
+            log_json: settings.log_json,
+            log_level: settings.log_level,
+        }
+    }
+}
+
+impl From<SettingsView> for RookSettings {
+    fn from(view: SettingsView) -> Self {
+        Self {
+            gateway_port: view.gateway_port,
+            default_routing_policy: view.default_routing_policy.into(),
+            log_json: view.log_json,
+            log_level: view.log_level,
+        }
+    }
+}
+
+pub type UpdateSettingsRequest = SettingsView;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UsageStatusView {
+    pub available: bool,
+    pub reason: &'static str,
+}
+
+impl UsageStatusView {
+    pub fn placeholder() -> Self {
+        Self {
+            available: false,
+            reason: "usage accounting is not implemented in M1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateAccountRequest {
+    pub vendor: ProviderVendor,
+    pub display_name: String,
+    pub api_base_override: Option<String>,
+    pub api_key: Option<String>,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_weight")]
+    pub weight: u32,
+    #[serde(default = "default_priority")]
+    pub priority: u32,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+}
+
+pub type UpdateAccountRequest = CreateAccountRequest;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreatePoolRequest {
+    pub name: String,
+    pub strategy: SelectionStrategy,
+    #[serde(default)]
+    pub members: Vec<AccountId>,
+    pub fallback_pool_id: Option<PoolId>,
+}
+
+pub type UpdatePoolRequest = CreatePoolRequest;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AddPoolMemberRequest {
+    pub account_id: AccountId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateRouteRequest {
+    pub logical_model: String,
+    pub target_pool_id: PoolId,
+    pub fallback_route_id: Option<RouteId>,
+    #[serde(default)]
+    pub capability_constraints: Vec<String>,
+}
+
+pub type UpdateRouteRequest = CreateRouteRequest;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct AdminErrorResponse {
+    pub error: AdminErrorBody,
+}
+
+impl AdminErrorResponse {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            error: AdminErrorBody {
+                code: code.into(),
+                message: message.into(),
+                details: None,
+            },
+        }
+    }
+
+    pub fn with_details(mut self, details: Map<String, Value>) -> Self {
+        self.error.details = Some(details);
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct AdminErrorBody {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<Map<String, Value>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        AccountId, PoolId, ProviderAccount, ProviderPool, ProviderVendor, RookSettings, RouteId,
+        RoutingPolicy, SelectionStrategy,
+    };
+    use crate::services::health::{AccountHealth, HealthStatus};
+    use chrono::Utc;
+    use serde_json::json;
+
+    fn sample_account() -> ProviderAccount {
+        ProviderAccount {
+            id: AccountId::generate(),
+            vendor: ProviderVendor::OpenAi,
+            display_name: "Primary OpenAI".to_string(),
+            api_base_override: Some("http://localhost:4000/v1".to_string()),
+            api_key: Some("sk-secret".to_string()),
+            enabled: true,
+            weight: 1,
+            priority: 0,
+            tags: vec!["prod".to_string()],
+            capabilities: vec!["chat".to_string(), "vision".to_string()],
+        }
+    }
+
+    #[test]
+    fn account_view_redacts_api_key_and_sets_has_api_key() {
+        let account = sample_account();
+
+        let view = AccountView::from(account.clone());
+        let json = serde_json::to_value(&view).unwrap();
+
+        assert_eq!(view.id, account.id);
+        assert_eq!(view.vendor, account.vendor);
+        assert!(view.has_api_key);
+        assert!(json.get("api_key").is_none());
+        assert_eq!(json["has_api_key"], json!(true));
+    }
+
+    #[test]
+    fn create_account_request_defaults_optional_fields() {
+        let request: CreateAccountRequest = serde_json::from_value(json!({
+            "vendor": "open_ai",
+            "display_name": "Primary OpenAI"
+        }))
+        .unwrap();
+
+        assert_eq!(request.vendor, ProviderVendor::OpenAi);
+        assert_eq!(request.display_name, "Primary OpenAI");
+        assert_eq!(request.api_base_override, None);
+        assert_eq!(request.api_key, None);
+        assert!(request.enabled);
+        assert_eq!(request.weight, 1);
+        assert_eq!(request.priority, 0);
+        assert!(request.tags.is_empty());
+        assert!(request.capabilities.is_empty());
+    }
+
+    #[test]
+    fn pool_and_route_views_round_trip_expected_fields() {
+        let account_id = AccountId::generate();
+        let pool = ProviderPool {
+            id: PoolId::generate(),
+            name: "primary".to_string(),
+            strategy: SelectionStrategy::RoundRobin,
+            members: vec![account_id],
+            fallback_pool_id: None,
+        };
+        let route = crate::domain::ModelRoute {
+            id: RouteId::generate(),
+            logical_model: "gpt-4o".to_string(),
+            target_pool_id: pool.id,
+            fallback_route_id: None,
+            capability_constraints: vec!["chat".to_string()],
+        };
+
+        let pool_json = serde_json::to_value(PoolView::from(pool)).unwrap();
+        let route_json = serde_json::to_value(RouteView::from(route)).unwrap();
+
+        assert_eq!(pool_json["name"], json!("primary"));
+        assert_eq!(pool_json["strategy"], json!("round_robin"));
+        assert_eq!(route_json["logical_model"], json!("gpt-4o"));
+        assert_eq!(route_json["capability_constraints"], json!(["chat"]));
+    }
+
+    #[test]
+    fn health_account_view_serializes_snake_case_status() {
+        let account = ProviderAccount {
+            id: AccountId::generate(),
+            vendor: ProviderVendor::OpenAi,
+            display_name: "Health Checked".to_string(),
+            api_base_override: None,
+            api_key: None,
+            enabled: true,
+            weight: 1,
+            priority: 0,
+            tags: vec![],
+            capabilities: vec![],
+        };
+        let health = AccountHealth {
+            account_id: account.id,
+            status: HealthStatus::Unhealthy,
+            last_checked: Some(Utc::now()),
+            consecutive_failures: 2,
+            cooldown_until: None,
+        };
+
+        let json = serde_json::to_value(HealthAccountView::new(&account, health, false)).unwrap();
+
+        assert_eq!(json["status"], json!("unhealthy"));
+        assert_eq!(json["consecutive_failures"], json!(2));
+        assert_eq!(json["display_name"], json!("Health Checked"));
+        assert_eq!(json["enabled"], json!(true));
+        assert_eq!(json["is_available"], json!(false));
+    }
+
+    #[test]
+    fn settings_view_and_update_request_match_rook_settings_shape() {
+        let settings = RookSettings {
+            gateway_port: 4141,
+            default_routing_policy: RoutingPolicy {
+                strategy: SelectionStrategy::RoundRobin,
+                max_retries: 5,
+                cooldown_seconds: 120,
+            },
+            log_json: true,
+            log_level: "debug".to_string(),
+        };
+
+        let view = SettingsView::from(settings.clone());
+        let request = UpdateSettingsRequest::from(settings.clone());
+
+        let from_view = RookSettings::from(view);
+        let from_request = RookSettings::from(request);
+
+        assert_eq!(from_view.gateway_port, settings.gateway_port);
+        assert_eq!(from_view.log_json, settings.log_json);
+        assert_eq!(from_view.log_level, settings.log_level);
+        assert_eq!(
+            from_view.default_routing_policy.max_retries,
+            settings.default_routing_policy.max_retries
+        );
+        assert_eq!(from_request.gateway_port, settings.gateway_port);
+        assert_eq!(from_request.log_json, settings.log_json);
+        assert_eq!(from_request.log_level, settings.log_level);
+        assert_eq!(
+            from_request.default_routing_policy.cooldown_seconds,
+            settings.default_routing_policy.cooldown_seconds
+        );
+    }
+
+    #[test]
+    fn usage_status_placeholder_matches_spec() {
+        let json = serde_json::to_value(UsageStatusView::placeholder()).unwrap();
+
+        assert_eq!(
+            json,
+            json!({
+                "available": false,
+                "reason": "usage accounting is not implemented in M1"
+            })
+        );
+    }
+
+    #[test]
+    fn admin_error_response_helper_builds_expected_shape() {
+        let response = AdminErrorResponse::new("not_found", "account missing").with_details(
+            serde_json::Map::from_iter([(String::from("resource"), json!("account"))]),
+        );
+
+        let json = serde_json::to_value(response).unwrap();
+
+        assert_eq!(json["error"]["code"], json!("not_found"));
+        assert_eq!(json["error"]["message"], json!("account missing"));
+        assert_eq!(json["error"]["details"]["resource"], json!("account"));
+    }
+}

--- a/clients/rook/src/dashboard/mod.rs
+++ b/clients/rook/src/dashboard/mod.rs
@@ -9,11 +9,11 @@
 //! - Everything else     → 404
 
 use axum::{
-    Router,
     body::Body,
-    http::{Response, StatusCode, header},
+    http::{header, Response, StatusCode},
     response::IntoResponse,
     routing::get,
+    Router,
 };
 use rust_embed::RustEmbed;
 
@@ -89,7 +89,10 @@ mod tests {
     #[test]
     fn index_html_is_embedded() {
         let file = DashboardAssets::get("index.html");
-        assert!(file.is_some(), "index.html must be embedded in DashboardAssets");
+        assert!(
+            file.is_some(),
+            "index.html must be embedded in DashboardAssets"
+        );
         let asset = file.unwrap();
         let content = std::str::from_utf8(&asset.data).expect("valid UTF-8");
         assert!(

--- a/clients/rook/src/db/account.rs
+++ b/clients/rook/src/db/account.rs
@@ -7,6 +7,12 @@ use chrono::Utc;
 use sqlx::Row;
 use uuid::Uuid;
 
+pub enum DeleteAccountResult {
+    Deleted,
+    Referenced,
+    NotFound,
+}
+
 // ── Vendor serialization helpers ──────────────────────────────────────────────
 
 /// Convert a `ProviderVendor` to its canonical database string representation.
@@ -172,9 +178,47 @@ impl SqliteDb {
         rows.iter().map(row_to_account).collect()
     }
 
-    /// Delete a [`ProviderAccount`] by ID.
+    pub async fn delete_account_if_not_referenced(
+        &self,
+        id: &AccountId,
+    ) -> Result<DeleteAccountResult, RookError> {
+        let id_str = id.to_string();
+        let result = sqlx::query(
+            "DELETE FROM provider_accounts \
+             WHERE id = ? \
+               AND NOT EXISTS (SELECT 1 FROM pool_members WHERE account_id = ?)",
+        )
+        .bind(&id_str)
+        .bind(&id_str)
+        .execute(self.pool())
+        .await
+        .map_err(|e| {
+            RookError::Registry(format!("delete_account_if_not_referenced failed: {e}"))
+        })?;
+
+        if result.rows_affected() > 0 {
+            return Ok(DeleteAccountResult::Deleted);
+        }
+
+        let exists: Option<(i64,)> =
+            sqlx::query_as("SELECT 1 FROM provider_accounts WHERE id = ? LIMIT 1")
+                .bind(&id_str)
+                .fetch_optional(self.pool())
+                .await
+                .map_err(|e| {
+                    RookError::Registry(format!("failed to check account existence: {e}"))
+                })?;
+
+        if exists.is_none() {
+            return Ok(DeleteAccountResult::NotFound);
+        }
+
+        Ok(DeleteAccountResult::Referenced)
+    }
+
+    /// Delete a [`ProviderAccount`] by ID without reference protection.
     ///
-    /// Returns `true` if a row was deleted, `false` if the ID was not found.
+    /// Used by update flows that intentionally replace an already-verified row.
     pub async fn delete_account(&self, id: &AccountId) -> Result<bool, RookError> {
         let id_str = id.to_string();
         let result = sqlx::query("DELETE FROM provider_accounts WHERE id = ?")
@@ -184,21 +228,6 @@ impl SqliteDb {
             .map_err(|e| RookError::Registry(format!("delete_account failed: {e}")))?;
 
         Ok(result.rows_affected() > 0)
-    }
-
-    /// Returns true if the account participates in any pool membership.
-    pub async fn is_account_referenced_by_pool(&self, id: &AccountId) -> Result<bool, RookError> {
-        let id_str = id.to_string();
-        let row: Option<(i64,)> =
-            sqlx::query_as("SELECT 1 FROM pool_members WHERE account_id = ? LIMIT 1")
-                .bind(&id_str)
-                .fetch_optional(self.pool())
-                .await
-                .map_err(|e| {
-                    RookError::Registry(format!("failed to check account pool references: {e}"))
-                })?;
-
-        Ok(row.is_some())
     }
 }
 

--- a/clients/rook/src/db/account.rs
+++ b/clients/rook/src/db/account.rs
@@ -185,6 +185,21 @@ impl SqliteDb {
 
         Ok(result.rows_affected() > 0)
     }
+
+    /// Returns true if the account participates in any pool membership.
+    pub async fn is_account_referenced_by_pool(&self, id: &AccountId) -> Result<bool, RookError> {
+        let id_str = id.to_string();
+        let row: Option<(i64,)> =
+            sqlx::query_as("SELECT 1 FROM pool_members WHERE account_id = ? LIMIT 1")
+                .bind(&id_str)
+                .fetch_optional(self.pool())
+                .await
+                .map_err(|e| {
+                    RookError::Registry(format!("failed to check account pool references: {e}"))
+                })?;
+
+        Ok(row.is_some())
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -347,6 +362,9 @@ mod tests {
         };
         db.insert_account(&account).await.unwrap();
         let fetched = db.get_account(&account.id).await.unwrap().unwrap();
-        assert_eq!(fetched.vendor, ProviderVendor::Other("weird\"name".to_string()));
+        assert_eq!(
+            fetched.vendor,
+            ProviderVendor::Other("weird\"name".to_string())
+        );
     }
 }

--- a/clients/rook/src/db/mod.rs
+++ b/clients/rook/src/db/mod.rs
@@ -49,16 +49,12 @@ impl SqliteDb {
     pub async fn open(path: &str) -> Result<Self, RookError> {
         let url = format!("sqlite:{path}?mode=rwc");
         let options = SqliteConnectOptions::from_str(&url)
-            .map_err(|e| {
-                RookError::Registry(format!("failed to parse database URL {path}: {e}"))
-            })?
+            .map_err(|e| RookError::Registry(format!("failed to parse database URL {path}: {e}")))?
             .foreign_keys(true);
 
         let pool = SqlitePool::connect_with(options)
             .await
-            .map_err(|e| {
-                RookError::Registry(format!("failed to open database at {path}: {e}"))
-            })?;
+            .map_err(|e| RookError::Registry(format!("failed to open database at {path}: {e}")))?;
 
         #[cfg(unix)]
         tighten_db_permissions(path)?;
@@ -74,18 +70,14 @@ impl SqliteDb {
         // max_connections(1) ensures a single connection so the in-memory
         // database is not dropped between pool checkouts.
         let options = SqliteConnectOptions::from_str("sqlite::memory:")
-            .map_err(|e| {
-                RookError::Registry(format!("failed to parse in-memory URL: {e}"))
-            })?
+            .map_err(|e| RookError::Registry(format!("failed to parse in-memory URL: {e}")))?
             .foreign_keys(true);
 
         let pool = sqlx::pool::PoolOptions::<sqlx::Sqlite>::new()
             .max_connections(1)
             .connect_with(options)
             .await
-            .map_err(|e| {
-                RookError::Registry(format!("failed to open in-memory database: {e}"))
-            })?;
+            .map_err(|e| RookError::Registry(format!("failed to open in-memory database: {e}")))?;
 
         Self::run_migrations(&pool).await?;
         Ok(Self { pool })
@@ -105,21 +97,24 @@ impl SqliteDb {
             "CREATE TABLE IF NOT EXISTS schema_migrations (
                 version TEXT PRIMARY KEY,
                 applied_at TEXT NOT NULL
-            )"
+            )",
         )
         .execute(pool)
         .await
-        .map_err(|e| RookError::Registry(format!("failed to create schema_migrations table: {e}")))?;
+        .map_err(|e| {
+            RookError::Registry(format!("failed to create schema_migrations table: {e}"))
+        })?;
 
         // Check if migration 0001_initial has already been applied
         let version = "0001_initial";
-        let row: Option<(String,)> = sqlx::query_as(
-            "SELECT version FROM schema_migrations WHERE version = ?"
-        )
-        .bind(version)
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| RookError::Registry(format!("failed to check migration status: {e}")))?;
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT version FROM schema_migrations WHERE version = ?")
+                .bind(version)
+                .fetch_optional(pool)
+                .await
+                .map_err(|e| {
+                    RookError::Registry(format!("failed to check migration status: {e}"))
+                })?;
 
         if row.is_none() {
             apply_migration(pool, version, MIGRATION_SQL).await?;
@@ -127,13 +122,14 @@ impl SqliteDb {
 
         // ── Migration 0002: settings ──────────────────────────────────────────
         let version_0002 = "0002_settings";
-        let row_0002: Option<(String,)> = sqlx::query_as(
-            "SELECT version FROM schema_migrations WHERE version = ?"
-        )
-        .bind(version_0002)
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| RookError::Registry(format!("failed to check migration 0002 status: {e}")))?;
+        let row_0002: Option<(String,)> =
+            sqlx::query_as("SELECT version FROM schema_migrations WHERE version = ?")
+                .bind(version_0002)
+                .fetch_optional(pool)
+                .await
+                .map_err(|e| {
+                    RookError::Registry(format!("failed to check migration 0002 status: {e}"))
+                })?;
 
         if row_0002.is_none() {
             apply_migration(pool, version_0002, MIGRATION_SQL_0002).await?;
@@ -141,15 +137,14 @@ impl SqliteDb {
 
         // ── Migration 0003: account_api_key ───────────────────────────────────
         let version_0003 = "0003_account_api_key";
-        let row_0003: Option<(String,)> = sqlx::query_as(
-            "SELECT version FROM schema_migrations WHERE version = ?",
-        )
-        .bind(version_0003)
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| {
-            RookError::Registry(format!("failed to check migration 0003 status: {e}"))
-        })?;
+        let row_0003: Option<(String,)> =
+            sqlx::query_as("SELECT version FROM schema_migrations WHERE version = ?")
+                .bind(version_0003)
+                .fetch_optional(pool)
+                .await
+                .map_err(|e| {
+                    RookError::Registry(format!("failed to check migration 0003 status: {e}"))
+                })?;
 
         if row_0003.is_none() {
             apply_migration(pool, version_0003, MIGRATION_SQL_0003).await?;
@@ -192,8 +187,9 @@ fn tighten_db_permissions(path: &str) -> Result<(), RookError> {
     }
 
     let permissions = fs::Permissions::from_mode(0o600);
-    fs::set_permissions(path, permissions)
-        .map_err(|e| RookError::Registry(format!("failed to set database permissions on {path}: {e}")))
+    fs::set_permissions(path, permissions).map_err(|e| {
+        RookError::Registry(format!("failed to set database permissions on {path}: {e}"))
+    })
 }
 
 #[cfg(test)]
@@ -216,21 +212,26 @@ mod tests {
                 .unwrap_or(false)
         });
 
-        assert!(has_api_key, "provider_accounts should include api_key column");
+        assert!(
+            has_api_key,
+            "provider_accounts should include api_key column"
+        );
     }
 
     #[tokio::test]
     async fn open_in_memory_records_account_api_key_migration_version() {
         let db = SqliteDb::open_in_memory().await.unwrap();
 
-        let row: Option<(String,)> = sqlx::query_as(
-            "SELECT version FROM schema_migrations WHERE version = ?",
-        )
-        .bind("0003_account_api_key")
-        .fetch_optional(db.pool())
-        .await
-        .unwrap();
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT version FROM schema_migrations WHERE version = ?")
+                .bind("0003_account_api_key")
+                .fetch_optional(db.pool())
+                .await
+                .unwrap();
 
-        assert_eq!(row.map(|(version,)| version), Some("0003_account_api_key".to_string()));
+        assert_eq!(
+            row.map(|(version,)| version),
+            Some("0003_account_api_key".to_string())
+        );
     }
 }

--- a/clients/rook/src/db/pool.rs
+++ b/clients/rook/src/db/pool.rs
@@ -88,6 +88,27 @@ impl SqliteDb {
             .await
             .map_err(|e| RookError::Registry(format!("failed to begin transaction: {e}")))?;
 
+        if let Some(fallback_id) = &pool.fallback_pool_id {
+            let fallback_str = fallback_id.to_string();
+            let exists: Option<(i64,)> =
+                sqlx::query_as("SELECT 1 FROM provider_pools WHERE id = ? LIMIT 1")
+                    .bind(&fallback_str)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| {
+                        RookError::Registry(format!(
+                            "failed to validate fallback_pool_id existence: {e}"
+                        ))
+                    })?;
+
+            if exists.is_none() {
+                return Err(RookError::Registry(format!(
+                    "fallback pool {} does not exist",
+                    fallback_id
+                )));
+            }
+        }
+
         // Insert pool
         sqlx::query(
             "INSERT INTO provider_pools \
@@ -116,6 +137,90 @@ impl SqliteDb {
         }
 
         // Commit transaction
+        tx.commit()
+            .await
+            .map_err(|e| RookError::Registry(format!("failed to commit transaction: {e}")))?;
+
+        Ok(())
+    }
+
+    pub async fn replace_pool(&self, pool: &ProviderPool) -> Result<(), RookError> {
+        let pool_id = pool.id.to_string();
+        let mut tx = self
+            .pool()
+            .begin()
+            .await
+            .map_err(|e| RookError::Registry(format!("failed to begin transaction: {e}")))?;
+
+        let exists: Option<(i64,)> =
+            sqlx::query_as("SELECT 1 FROM provider_pools WHERE id = ? LIMIT 1")
+                .bind(&pool_id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| {
+                    RookError::Registry(format!("failed to verify pool existence: {e}"))
+                })?;
+
+        if exists.is_none() {
+            return Err(RookError::Registry(format!("pool {} not found", pool.id)));
+        }
+
+        if let Some(fallback_id) = &pool.fallback_pool_id {
+            let fallback_str = fallback_id.to_string();
+            let fallback_exists: Option<(i64,)> =
+                sqlx::query_as("SELECT 1 FROM provider_pools WHERE id = ? LIMIT 1")
+                    .bind(&fallback_str)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| {
+                        RookError::Registry(format!(
+                            "failed to validate fallback_pool_id existence: {e}"
+                        ))
+                    })?;
+
+            if fallback_exists.is_none() {
+                return Err(RookError::Registry(format!(
+                    "fallback pool {} does not exist",
+                    fallback_id
+                )));
+            }
+        }
+
+        sqlx::query("DELETE FROM provider_pools WHERE id = ?")
+            .bind(&pool_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| RookError::Registry(format!("delete_pool failed: {e}")))?;
+
+        let strategy_str = strategy_to_db_str(&pool.strategy)?;
+        let fallback = pool.fallback_pool_id.as_ref().map(|p| p.to_string());
+        let now = Utc::now().to_rfc3339();
+
+        sqlx::query(
+            "INSERT INTO provider_pools \
+             (id, name, strategy, fallback_pool_id, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&pool_id)
+        .bind(&pool.name)
+        .bind(&strategy_str)
+        .bind(&fallback)
+        .bind(&now)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RookError::Registry(format!("insert_pool failed: {e}")))?;
+
+        for account_id in &pool.members {
+            let acct_str = account_id.to_string();
+            sqlx::query("INSERT OR IGNORE INTO pool_members (pool_id, account_id) VALUES (?, ?)")
+                .bind(&pool_id)
+                .bind(&acct_str)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| RookError::Registry(format!("insert pool member failed: {e}")))?;
+        }
+
         tx.commit()
             .await
             .map_err(|e| RookError::Registry(format!("failed to commit transaction: {e}")))?;

--- a/clients/rook/src/db/pool.rs
+++ b/clients/rook/src/db/pool.rs
@@ -56,9 +56,7 @@ fn row_to_pool(
         .map(|s| {
             Uuid::parse_str(&s)
                 .map(PoolId::new)
-                .map_err(|e| {
-                    RookError::Registry(format!("invalid fallback_pool_id UUID: {e}"))
-                })
+                .map_err(|e| RookError::Registry(format!("invalid fallback_pool_id UUID: {e}")))
         })
         .transpose()?;
 
@@ -84,7 +82,8 @@ impl SqliteDb {
         let now = Utc::now().to_rfc3339();
 
         // Start transaction to make pool + members insertion atomic
-        let mut tx = self.pool()
+        let mut tx = self
+            .pool()
             .begin()
             .await
             .map_err(|e| RookError::Registry(format!("failed to begin transaction: {e}")))?;
@@ -108,14 +107,12 @@ impl SqliteDb {
         // Insert members
         for account_id in &pool.members {
             let acct_str = account_id.to_string();
-            sqlx::query(
-                "INSERT OR IGNORE INTO pool_members (pool_id, account_id) VALUES (?, ?)",
-            )
-            .bind(&id)
-            .bind(&acct_str)
-            .execute(&mut *tx)
-            .await
-            .map_err(|e| RookError::Registry(format!("add_pool_member failed: {e}")))?;
+            sqlx::query("INSERT OR IGNORE INTO pool_members (pool_id, account_id) VALUES (?, ?)")
+                .bind(&id)
+                .bind(&acct_str)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| RookError::Registry(format!("add_pool_member failed: {e}")))?;
         }
 
         // Commit transaction
@@ -176,7 +173,11 @@ impl SqliteDb {
 
         // Query all members in one go
         let pool_id_strings: Vec<String> = pool_ids.iter().map(|id| id.to_string()).collect();
-        let placeholders = pool_id_strings.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let placeholders = pool_id_strings
+            .iter()
+            .map(|_| "?")
+            .collect::<Vec<_>>()
+            .join(", ");
         let query_str = format!(
             "SELECT pool_id, account_id FROM pool_members WHERE pool_id IN ({}) ORDER BY pool_id, account_id",
             placeholders
@@ -236,14 +237,12 @@ impl SqliteDb {
         let pool_str = pool_id.to_string();
         let acct_str = account_id.to_string();
 
-        sqlx::query(
-            "INSERT OR IGNORE INTO pool_members (pool_id, account_id) VALUES (?, ?)",
-        )
-        .bind(&pool_str)
-        .bind(&acct_str)
-        .execute(self.pool())
-        .await
-        .map_err(|e| RookError::Registry(format!("add_pool_member failed: {e}")))?;
+        sqlx::query("INSERT OR IGNORE INTO pool_members (pool_id, account_id) VALUES (?, ?)")
+            .bind(&pool_str)
+            .bind(&acct_str)
+            .execute(self.pool())
+            .await
+            .map_err(|e| RookError::Registry(format!("add_pool_member failed: {e}")))?;
 
         Ok(())
     }
@@ -257,14 +256,12 @@ impl SqliteDb {
         let pool_str = pool_id.to_string();
         let acct_str = account_id.to_string();
 
-        sqlx::query(
-            "DELETE FROM pool_members WHERE pool_id = ? AND account_id = ?",
-        )
-        .bind(&pool_str)
-        .bind(&acct_str)
-        .execute(self.pool())
-        .await
-        .map_err(|e| RookError::Registry(format!("remove_pool_member failed: {e}")))?;
+        sqlx::query("DELETE FROM pool_members WHERE pool_id = ? AND account_id = ?")
+            .bind(&pool_str)
+            .bind(&acct_str)
+            .execute(self.pool())
+            .await
+            .map_err(|e| RookError::Registry(format!("remove_pool_member failed: {e}")))?;
 
         Ok(())
     }
@@ -291,6 +288,21 @@ impl SqliteDb {
                     .map_err(|e| RookError::Registry(format!("invalid member UUID: {e}")))
             })
             .collect()
+    }
+
+    /// Returns true if another pool references this pool as its fallback.
+    pub async fn is_pool_referenced_as_fallback(&self, id: &PoolId) -> Result<bool, RookError> {
+        let id_str = id.to_string();
+        let row: Option<(i64,)> =
+            sqlx::query_as("SELECT 1 FROM provider_pools WHERE fallback_pool_id = ? LIMIT 1")
+                .bind(&id_str)
+                .fetch_optional(self.pool())
+                .await
+                .map_err(|e| {
+                    RookError::Registry(format!("failed to check fallback pool references: {e}"))
+                })?;
+
+        Ok(row.is_some())
     }
 }
 

--- a/clients/rook/src/db/route.rs
+++ b/clients/rook/src/db/route.rs
@@ -1,7 +1,7 @@
 //! CRUD operations for [`ModelRoute`] backed by the `model_routes` table.
 
 use crate::db::SqliteDb;
-use crate::domain::{ModelRoute, PoolId, RouteId, RookError};
+use crate::domain::{ModelRoute, PoolId, RookError, RouteId};
 use chrono::Utc;
 use sqlx::Row;
 use uuid::Uuid;
@@ -37,9 +37,7 @@ fn row_to_route(row: &sqlx::sqlite::SqliteRow) -> Result<ModelRoute, RookError> 
         .map_err(|e| RookError::Registry(format!("missing target_pool_id: {e}")))?;
     let target_pool_id = PoolId::new(
         Uuid::parse_str(&target_str)
-            .map_err(|e| {
-                RookError::Registry(format!("invalid target_pool_id UUID: {e}"))
-            })?,
+            .map_err(|e| RookError::Registry(format!("invalid target_pool_id UUID: {e}")))?,
     );
 
     let fallback_str: Option<String> = row
@@ -49,17 +47,18 @@ fn row_to_route(row: &sqlx::sqlite::SqliteRow) -> Result<ModelRoute, RookError> 
         .map(|s| {
             Uuid::parse_str(&s)
                 .map(RouteId::new)
-                .map_err(|e| {
-                    RookError::Registry(format!("invalid fallback_route_id UUID: {e}"))
-                })
+                .map_err(|e| RookError::Registry(format!("invalid fallback_route_id UUID: {e}")))
         })
         .transpose()?;
 
     let policy_json: String = row
         .try_get("policy")
         .map_err(|e| RookError::Registry(format!("missing policy: {e}")))?;
-    let policy: StoredPolicy = serde_json::from_str(&policy_json)
-        .map_err(|e| RookError::Registry(format!("invalid policy JSON: {e}; policy_json={policy_json}")))?;
+    let policy: StoredPolicy = serde_json::from_str(&policy_json).map_err(|e| {
+        RookError::Registry(format!(
+            "invalid policy JSON: {e}; policy_json={policy_json}"
+        ))
+    })?;
 
     Ok(ModelRoute {
         id,
@@ -85,7 +84,9 @@ impl SqliteDb {
                 .bind(fallback_id.to_string())
                 .fetch_optional(self.pool())
                 .await
-                .map_err(|e| RookError::Registry(format!("failed to validate fallback_route_id: {e}")))?;
+                .map_err(|e| {
+                    RookError::Registry(format!("failed to validate fallback_route_id: {e}"))
+                })?;
 
             if exists.is_none() {
                 return Err(RookError::Registry(format!(
@@ -177,13 +178,14 @@ impl SqliteDb {
         let id_str = id.to_string();
 
         // Check if any routes reference this one as a fallback
-        let referencing: Option<(String,)> = sqlx::query_as(
-            "SELECT id FROM model_routes WHERE fallback_route_id = ? LIMIT 1"
-        )
-        .bind(&id_str)
-        .fetch_optional(self.pool())
-        .await
-        .map_err(|e| RookError::Registry(format!("failed to check route references: {e}")))?;
+        let referencing: Option<(String,)> =
+            sqlx::query_as("SELECT id FROM model_routes WHERE fallback_route_id = ? LIMIT 1")
+                .bind(&id_str)
+                .fetch_optional(self.pool())
+                .await
+                .map_err(|e| {
+                    RookError::Registry(format!("failed to check route references: {e}"))
+                })?;
 
         if let Some((referring_id,)) = referencing {
             return Err(RookError::Registry(format!(

--- a/clients/rook/src/db/route.rs
+++ b/clients/rook/src/db/route.rs
@@ -177,7 +177,34 @@ impl SqliteDb {
     pub async fn delete_route(&self, id: &RouteId) -> Result<bool, RookError> {
         let id_str = id.to_string();
 
-        // Check if any routes reference this one as a fallback
+        let result = sqlx::query(
+            "DELETE FROM model_routes \
+             WHERE id = ? \
+               AND NOT EXISTS (SELECT 1 FROM model_routes WHERE fallback_route_id = ?)",
+        )
+        .bind(&id_str)
+        .bind(&id_str)
+        .execute(self.pool())
+        .await
+        .map_err(|e| RookError::Registry(format!("delete_route failed: {e}")))?;
+
+        if result.rows_affected() > 0 {
+            return Ok(true);
+        }
+
+        let exists: Option<(String,)> =
+            sqlx::query_as("SELECT id FROM model_routes WHERE id = ? LIMIT 1")
+                .bind(&id_str)
+                .fetch_optional(self.pool())
+                .await
+                .map_err(|e| {
+                    RookError::Registry(format!("failed to verify route existence: {e}"))
+                })?;
+
+        if exists.is_none() {
+            return Ok(false);
+        }
+
         let referencing: Option<(String,)> =
             sqlx::query_as("SELECT id FROM model_routes WHERE fallback_route_id = ? LIMIT 1")
                 .bind(&id_str)
@@ -194,13 +221,7 @@ impl SqliteDb {
             )));
         }
 
-        let result = sqlx::query("DELETE FROM model_routes WHERE id = ?")
-            .bind(&id_str)
-            .execute(self.pool())
-            .await
-            .map_err(|e| RookError::Registry(format!("delete_route failed: {e}")))?;
-
-        Ok(result.rows_affected() > 0)
+        Ok(false)
     }
 }
 

--- a/clients/rook/src/db/settings.rs
+++ b/clients/rook/src/db/settings.rs
@@ -144,11 +144,15 @@ mod tests {
     async fn save_and_load_round_trip() {
         let db = SqliteDb::open_in_memory().await.unwrap();
 
-        let mut s = RookSettings::default();
-        s.gateway_port = 9090;
-        s.log_json = true;
-        s.log_level = "debug".to_owned();
-        s.default_routing_policy.max_retries = 5;
+        let s = RookSettings {
+            gateway_port: 9090,
+            default_routing_policy: crate::domain::RoutingPolicy {
+                max_retries: 5,
+                ..RookSettings::default().default_routing_policy
+            },
+            log_json: true,
+            log_level: "debug".to_owned(),
+        };
 
         db.save_settings(s).await.unwrap();
 
@@ -163,12 +167,16 @@ mod tests {
     async fn save_twice_upserts() {
         let db = SqliteDb::open_in_memory().await.unwrap();
 
-        let mut s1 = RookSettings::default();
-        s1.gateway_port = 8080;
+        let s1 = RookSettings {
+            gateway_port: 8080,
+            ..RookSettings::default()
+        };
         db.save_settings(s1).await.unwrap();
 
-        let mut s2 = RookSettings::default();
-        s2.gateway_port = 9999;
+        let s2 = RookSettings {
+            gateway_port: 9999,
+            ..RookSettings::default()
+        };
         db.save_settings(s2).await.unwrap();
 
         let loaded = db.load_settings().await.unwrap();

--- a/clients/rook/src/domain/mod.rs
+++ b/clients/rook/src/domain/mod.rs
@@ -368,14 +368,26 @@ mod tests {
     /// Unit variants must serialize as snake_case strings.
     #[test]
     fn provider_vendor_unit_variants_serialize_as_snake_case() {
-        assert_eq!(serde_json::to_string(&ProviderVendor::OpenAi).unwrap(), r#""open_ai""#);
-        assert_eq!(serde_json::to_string(&ProviderVendor::Anthropic).unwrap(), r#""anthropic""#);
-        assert_eq!(serde_json::to_string(&ProviderVendor::Google).unwrap(), r#""google""#);
+        assert_eq!(
+            serde_json::to_string(&ProviderVendor::OpenAi).unwrap(),
+            r#""open_ai""#
+        );
+        assert_eq!(
+            serde_json::to_string(&ProviderVendor::Anthropic).unwrap(),
+            r#""anthropic""#
+        );
+        assert_eq!(
+            serde_json::to_string(&ProviderVendor::Google).unwrap(),
+            r#""google""#
+        );
         assert_eq!(
             serde_json::to_string(&ProviderVendor::OpenRouter).unwrap(),
             r#""open_router""#
         );
-        assert_eq!(serde_json::to_string(&ProviderVendor::DeepSeek).unwrap(), r#""deep_seek""#);
+        assert_eq!(
+            serde_json::to_string(&ProviderVendor::DeepSeek).unwrap(),
+            r#""deep_seek""#
+        );
     }
 
     /// `Other` must serialize as a bare string, NOT as `{"other":"…"}`.
@@ -421,8 +433,8 @@ mod tests {
             "OPENAI",    // all-caps
             "Anthropic", // wrong casing
             "ANTHROPIC",
-            "deepseek",  // missing underscore
-            "DeepSeek",  // wrong casing
+            "deepseek", // missing underscore
+            "DeepSeek", // wrong casing
             "deep-seek",
             "openrouter",
             "OpenRouter",

--- a/clients/rook/src/gateway/handlers.rs
+++ b/clients/rook/src/gateway/handlers.rs
@@ -13,10 +13,7 @@ use crate::services::{health::HealthService as _, route::RouteService as _};
 
 const FAILURE_COOLDOWN_SECS: u64 = 60;
 
-pub async fn handle_chat_completions(
-    State(state): State<GatewayState>,
-    body: Bytes,
-) -> Response {
+pub async fn handle_chat_completions(State(state): State<GatewayState>, body: Bytes) -> Response {
     let request: ChatCompletionRequest = match serde_json::from_slice(&body) {
         Ok(request) => request,
         Err(_) => {
@@ -315,7 +312,10 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        assert_eq!(serde_json::from_slice::<Value>(&body).unwrap(), json!({"id":"chatcmpl-123"}));
+        assert_eq!(
+            serde_json::from_slice::<Value>(&body).unwrap(),
+            json!({"id":"chatcmpl-123"})
+        );
         let health = tokio::time::timeout(std::time::Duration::from_secs(1), async {
             loop {
                 let health = registry.health().get(account_id).await;
@@ -327,7 +327,10 @@ mod tests {
         })
         .await
         .unwrap();
-        assert_eq!(health.status, crate::services::health::HealthStatus::Healthy);
+        assert_eq!(
+            health.status,
+            crate::services::health::HealthStatus::Healthy
+        );
     }
 
     #[tokio::test]
@@ -354,7 +357,8 @@ mod tests {
 
     #[tokio::test]
     async fn chat_completions_missing_api_key_still_proxies_upstream() {
-        let (_server, upstream) = mock_upstream(StatusCode::OK, json!({"id":"chatcmpl-no-auth"})).await;
+        let (_server, upstream) =
+            mock_upstream(StatusCode::OK, json!({"id":"chatcmpl-no-auth"})).await;
         let (app, registry) = test_app().await;
         seed_route(
             &registry,

--- a/clients/rook/src/gateway/mod.rs
+++ b/clients/rook/src/gateway/mod.rs
@@ -10,8 +10,8 @@
 //! Gateway authentication is deferred to #591. Until then, the server must keep
 //! the listener bound to loopback by default before any external exposure.
 
-pub mod types;
 pub mod handlers;
+pub mod types;
 pub mod upstream;
 pub mod vendor;
 

--- a/clients/rook/src/gateway/types.rs
+++ b/clients/rook/src/gateway/types.rs
@@ -278,7 +278,10 @@ mod tests {
 
         let json = serde_json::to_value(&response).unwrap();
 
-        assert_eq!(json["error"]["message"], json!("no route configured for model 'unknown-model'"));
+        assert_eq!(
+            json["error"]["message"],
+            json!("no route configured for model 'unknown-model'")
+        );
         assert_eq!(json["error"]["type"], json!("server_error"));
         assert_eq!(json["error"]["code"], json!("model_not_found"));
     }

--- a/clients/rook/src/gateway/upstream.rs
+++ b/clients/rook/src/gateway/upstream.rs
@@ -14,16 +14,27 @@ pub struct UpstreamResponse {
 
 #[derive(Debug)]
 pub enum UpstreamError {
-    MissingBaseUrl { account_id: String, vendor: String },
-    MissingAuthHeader { vendor: String },
+    MissingBaseUrl {
+        account_id: String,
+        vendor: String,
+    },
+    MissingAuthHeader {
+        vendor: String,
+    },
     UpstreamStatus {
         status: StatusCode,
         body: Bytes,
         content_type: Option<String>,
     },
-    Timeout { message: String },
-    Transport { message: String },
-    ReadBody { message: String },
+    Timeout {
+        message: String,
+    },
+    Transport {
+        message: String,
+    },
+    ReadBody {
+        message: String,
+    },
 }
 
 pub async fn proxy_chat_completion(
@@ -31,10 +42,11 @@ pub async fn proxy_chat_completion(
     account: &ProviderAccount,
     raw_body: Bytes,
 ) -> Result<UpstreamResponse, UpstreamError> {
-    let base = vendor::effective_base_url(account).ok_or_else(|| UpstreamError::MissingBaseUrl {
-        account_id: account.id.to_string(),
-        vendor: format!("{:?}", account.vendor),
-    })?;
+    let base =
+        vendor::effective_base_url(account).ok_or_else(|| UpstreamError::MissingBaseUrl {
+            account_id: account.id.to_string(),
+            vendor: format!("{:?}", account.vendor),
+        })?;
     let url = format!("{base}/v1/chat/completions");
 
     let mut request = client
@@ -75,9 +87,12 @@ pub async fn proxy_chat_completion(
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
 
-    let body = response.bytes().await.map_err(|error| UpstreamError::ReadBody {
-        message: format!("failed to read upstream response body: {error}"),
-    })?;
+    let body = response
+        .bytes()
+        .await
+        .map_err(|error| UpstreamError::ReadBody {
+            message: format!("failed to read upstream response body: {error}"),
+        })?;
 
     if !status.is_success() {
         return Err(UpstreamError::UpstreamStatus {
@@ -117,6 +132,8 @@ mod tests {
         body: Value,
     }
 
+    type MockState = (StatusCode, Value, Arc<Mutex<Vec<CapturedRequest>>>);
+
     fn make_account(vendor: ProviderVendor) -> ProviderAccount {
         ProviderAccount {
             id: AccountId::generate(),
@@ -138,15 +155,15 @@ mod tests {
         captured: Arc<Mutex<Vec<CapturedRequest>>>,
     ) -> (String, tokio::task::JoinHandle<()>) {
         async fn handler(
-            State((status, body, captured)): State<(StatusCode, Value, Arc<Mutex<Vec<CapturedRequest>>>)>,
+            State((status, body, captured)): State<MockState>,
             headers: HeaderMap,
             raw_body: AxumBytes,
         ) -> (StatusCode, Json<Value>) {
             let parsed: Value = serde_json::from_slice(&raw_body).unwrap();
-            captured
-                .lock()
-                .unwrap()
-                .push(CapturedRequest { headers, body: parsed });
+            captured.lock().unwrap().push(CapturedRequest {
+                headers,
+                body: parsed,
+            });
             (status, Json(body))
         }
 
@@ -176,17 +193,30 @@ mod tests {
         let mut account = make_account(ProviderVendor::OpenAi);
         account.api_base_override = Some(base_url);
 
-        let client = reqwest::Client::builder().timeout(Duration::from_secs(2)).build().unwrap();
-        let body = Bytes::from_static(br#"{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}"#);
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap();
+        let body = Bytes::from_static(
+            br#"{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}"#,
+        );
 
-        let response = proxy_chat_completion(&client, &account, body.clone()).await.unwrap();
+        let response = proxy_chat_completion(&client, &account, body.clone())
+            .await
+            .unwrap();
 
         assert_eq!(response.status, reqwest::StatusCode::OK);
-        assert_eq!(response.body, Bytes::from_static(br#"{"id":"chatcmpl-123","object":"chat.completion"}"#));
+        assert_eq!(
+            response.body,
+            Bytes::from_static(br#"{"id":"chatcmpl-123","object":"chat.completion"}"#)
+        );
 
         let requests = captured.lock().unwrap();
         assert_eq!(requests.len(), 1);
-        assert_eq!(requests[0].body, json!({"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}));
+        assert_eq!(
+            requests[0].body,
+            json!({"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]})
+        );
         assert_eq!(
             requests[0]
                 .headers
@@ -199,21 +229,24 @@ mod tests {
     #[tokio::test]
     async fn proxy_chat_completion_uses_override_base_url_and_anthropic_auth() {
         let captured = Arc::new(Mutex::new(Vec::new()));
-        let (base_url, _handle) = mock_upstream(
-            StatusCode::OK,
-            json!({"ok":true}),
-            captured.clone(),
-        )
-        .await;
+        let (base_url, _handle) =
+            mock_upstream(StatusCode::OK, json!({"ok":true}), captured.clone()).await;
 
         let mut account = make_account(ProviderVendor::Anthropic);
         account.api_base_override = Some(format!("{base_url}/"));
         account.api_key = Some("sk-ant-123".to_string());
 
-        let client = reqwest::Client::builder().timeout(Duration::from_secs(2)).build().unwrap();
-        let body = Bytes::from_static(br#"{"model":"claude-proxy","messages":[{"role":"user","content":"Hi"}]}"#);
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap();
+        let body = Bytes::from_static(
+            br#"{"model":"claude-proxy","messages":[{"role":"user","content":"Hi"}]}"#,
+        );
 
-        let response = proxy_chat_completion(&client, &account, body).await.unwrap();
+        let response = proxy_chat_completion(&client, &account, body)
+            .await
+            .unwrap();
         assert_eq!(response.status, reqwest::StatusCode::OK);
 
         let requests = captured.lock().unwrap();
@@ -230,18 +263,17 @@ mod tests {
     #[tokio::test]
     async fn proxy_chat_completion_without_api_key_still_forwards_request() {
         let captured = Arc::new(Mutex::new(Vec::new()));
-        let (base_url, _handle) = mock_upstream(
-            StatusCode::OK,
-            json!({"ok":true}),
-            captured.clone(),
-        )
-        .await;
+        let (base_url, _handle) =
+            mock_upstream(StatusCode::OK, json!({"ok":true}), captured.clone()).await;
 
         let mut account = make_account(ProviderVendor::OpenAi);
         account.api_base_override = Some(base_url);
         account.api_key = None;
 
-        let client = reqwest::Client::builder().timeout(Duration::from_secs(2)).build().unwrap();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap();
 
         let response = proxy_chat_completion(&client, &account, Bytes::from_static(br#"{}"#))
             .await
@@ -257,7 +289,10 @@ mod tests {
 
     #[tokio::test]
     async fn proxy_chat_completion_returns_local_error_for_missing_base_url() {
-        let client = reqwest::Client::builder().timeout(Duration::from_secs(2)).build().unwrap();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap();
         let account = make_account(ProviderVendor::Other("mistral".to_string()));
 
         let error = proxy_chat_completion(&client, &account, Bytes::from_static(br#"{}"#))
@@ -279,7 +314,10 @@ mod tests {
 
         let mut account = make_account(ProviderVendor::OpenAi);
         account.api_base_override = Some(base_url);
-        let client = reqwest::Client::builder().timeout(Duration::from_secs(2)).build().unwrap();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap();
 
         let error = proxy_chat_completion(&client, &account, Bytes::from_static(br#"{}"#))
             .await
@@ -296,7 +334,10 @@ mod tests {
 
     #[tokio::test]
     async fn proxy_chat_completion_maps_transport_failures() {
-        let client = reqwest::Client::builder().timeout(Duration::from_millis(200)).build().unwrap();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(200))
+            .build()
+            .unwrap();
         let mut account = make_account(ProviderVendor::OpenAi);
         account.api_base_override = Some("http://127.0.0.1:9".to_string());
 
@@ -304,6 +345,9 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(matches!(error, UpstreamError::Transport { .. } | UpstreamError::Timeout { .. }));
+        assert!(matches!(
+            error,
+            UpstreamError::Transport { .. } | UpstreamError::Timeout { .. }
+        ));
     }
 }

--- a/clients/rook/src/gateway/vendor.rs
+++ b/clients/rook/src/gateway/vendor.rs
@@ -48,19 +48,28 @@ mod tests {
 
     #[test]
     fn default_base_url_maps_known_vendors() {
-        assert_eq!(default_base_url(&ProviderVendor::OpenAi), Some("https://api.openai.com"));
+        assert_eq!(
+            default_base_url(&ProviderVendor::OpenAi),
+            Some("https://api.openai.com")
+        );
         assert_eq!(default_base_url(&ProviderVendor::Anthropic), None);
         assert_eq!(default_base_url(&ProviderVendor::Google), None);
         assert_eq!(
             default_base_url(&ProviderVendor::OpenRouter),
             Some("https://openrouter.ai/api")
         );
-        assert_eq!(default_base_url(&ProviderVendor::DeepSeek), Some("https://api.deepseek.com"));
+        assert_eq!(
+            default_base_url(&ProviderVendor::DeepSeek),
+            Some("https://api.deepseek.com")
+        );
     }
 
     #[test]
     fn default_base_url_returns_none_for_other_vendor() {
-        assert_eq!(default_base_url(&ProviderVendor::Other("mistral".to_string())), None);
+        assert_eq!(
+            default_base_url(&ProviderVendor::Other("mistral".to_string())),
+            None
+        );
     }
 
     #[test]

--- a/clients/rook/src/lib.rs
+++ b/clients/rook/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Exposes the public module tree for the gateway, TUI, and operator surfaces.
 
+pub mod admin;
 pub mod config;
 pub mod dashboard;
 pub mod db;

--- a/clients/rook/src/registry/mod.rs
+++ b/clients/rook/src/registry/mod.rs
@@ -23,11 +23,8 @@
 use crate::db::SqliteDb;
 use crate::domain::RookError;
 use crate::services::{
-    account::SqliteAccountService,
-    health::InMemoryHealthService,
-    pool::SqlitePoolService,
-    route::SqliteRouteService,
-    settings::SqliteSettingsService,
+    account::SqliteAccountService, health::InMemoryHealthService, pool::SqlitePoolService,
+    route::SqliteRouteService, settings::SqliteSettingsService,
 };
 
 /// Composition root — holds all service singletons for a Rook instance.
@@ -114,9 +111,7 @@ mod tests {
     use super::*;
     use crate::domain::RookSettings;
     use crate::services::{
-        account::AccountService as _,
-        pool::PoolService as _,
-        route::RouteService as _,
+        account::AccountService as _, pool::PoolService as _, route::RouteService as _,
         settings::SettingsService as _,
     };
 
@@ -155,8 +150,10 @@ mod tests {
     #[tokio::test]
     async fn registry_settings_round_trip() {
         let r = registry().await;
-        let mut s = RookSettings::default();
-        s.gateway_port = 7777;
+        let s = RookSettings {
+            gateway_port: 7777,
+            ..RookSettings::default()
+        };
         r.settings().save(s).await.unwrap();
         assert_eq!(r.settings().load().await.gateway_port, 7777);
     }

--- a/clients/rook/src/routing/mod.rs
+++ b/clients/rook/src/routing/mod.rs
@@ -42,13 +42,12 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use crate::domain::{
-    AccountId, ModelRoute, PoolId, ProviderAccount, ProviderPool, RouteId, RookError, SelectionStrategy,
+    AccountId, ModelRoute, PoolId, ProviderAccount, ProviderPool, RookError, RouteId,
+    SelectionStrategy,
 };
 use crate::registry::RookRegistry;
 use crate::services::{
-    account::AccountService as _,
-    health::HealthService as _,
-    pool::PoolService as _,
+    account::AccountService as _, health::HealthService as _, pool::PoolService as _,
     route::RouteService as _,
 };
 
@@ -205,9 +204,15 @@ impl RoutingEngine {
                     .await;
             }
 
-            let account = self.select_from_pool(pool_id, &pool.strategy, &candidates).await?;
+            let account = self
+                .select_from_pool(pool_id, &pool.strategy, &candidates)
+                .await?;
 
-            Ok(RoutingDecision { account, pool_id, route_id })
+            Ok(RoutingDecision {
+                account,
+                pool_id,
+                route_id,
+            })
         })
     }
 
@@ -225,13 +230,7 @@ impl RoutingEngine {
             // Pool-level fallback: the pool itself names another pool.
             if let Some(fallback_pool_id) = pool.fallback_pool_id {
                 return self
-                    .resolve_pool(
-                        fallback_pool_id,
-                        route_id,
-                        route,
-                        depth + 1,
-                        visited_pools,
-                    )
+                    .resolve_pool(fallback_pool_id, route_id, route, depth + 1, visited_pools)
                     .await;
             }
 
@@ -271,7 +270,10 @@ impl RoutingEngine {
         strategy: &SelectionStrategy,
         candidates: &[ProviderAccount],
     ) -> Result<ProviderAccount, RookError> {
-        debug_assert!(!candidates.is_empty(), "select_from_pool called with empty candidates");
+        debug_assert!(
+            !candidates.is_empty(),
+            "select_from_pool called with empty candidates"
+        );
 
         let account = match strategy {
             SelectionStrategy::Priority => self.select_priority(candidates)?,
@@ -286,7 +288,10 @@ impl RoutingEngine {
     // ── Strategy implementations ──────────────────────────────────────────────
 
     /// Pick the candidate with the lowest `priority` value (highest priority).
-    fn select_priority(&self, candidates: &[ProviderAccount]) -> Result<ProviderAccount, RookError> {
+    fn select_priority(
+        &self,
+        candidates: &[ProviderAccount],
+    ) -> Result<ProviderAccount, RookError> {
         candidates
             .iter()
             .min_by_key(|a| a.priority)
@@ -298,7 +303,10 @@ impl RoutingEngine {
     ///
     /// The pool-level fallback chain handles the actual failover; here we
     /// simply return the best available candidate after health filtering.
-    fn select_failover(&self, candidates: &[ProviderAccount]) -> Result<ProviderAccount, RookError> {
+    fn select_failover(
+        &self,
+        candidates: &[ProviderAccount],
+    ) -> Result<ProviderAccount, RookError> {
         // Pick the account with the lowest priority value (highest urgency).
         // This mirrors Priority semantics: if all are healthy, the top-priority
         // account acts as primary; if it fails, the caller marks it unhealthy
@@ -363,9 +371,9 @@ impl RoutingEngine {
         pool_state.retain(|id, _| candidates_ids.contains(id));
 
         let mut total_weight: i64 = 0;
-        let best_account = candidates.first().ok_or_else(|| {
-            RookError::Routing("no candidates for weighted selection".into())
-        })?;
+        let best_account = candidates
+            .first()
+            .ok_or_else(|| RookError::Routing("no candidates for weighted selection".into()))?;
         let mut best_id = best_account.id;
         let mut best_score: i64 = i64::MIN;
 
@@ -574,7 +582,10 @@ mod tests {
         registry.routes().create(route).await.unwrap();
 
         let decision = engine.resolve("claude-3").await.unwrap();
-        assert_eq!(decision.account.id, primary_id, "primary should be selected");
+        assert_eq!(
+            decision.account.id, primary_id,
+            "primary should be selected"
+        );
     }
 
     #[tokio::test]
@@ -606,7 +617,10 @@ mod tests {
         registry.routes().create(route).await.unwrap();
 
         let decision = engine.resolve("gpt-4o-mini").await.unwrap();
-        assert_eq!(decision.account.id, enabled_id, "disabled account must be skipped");
+        assert_eq!(
+            decision.account.id, enabled_id,
+            "disabled account must be skipped"
+        );
     }
 
     #[tokio::test]
@@ -636,7 +650,10 @@ mod tests {
         registry.routes().create(route).await.unwrap();
 
         let decision = engine.resolve("deep-seek-r1").await.unwrap();
-        assert_eq!(decision.account.id, good_id, "unhealthy account must be skipped");
+        assert_eq!(
+            decision.account.id, good_id,
+            "unhealthy account must be skipped"
+        );
     }
 
     #[tokio::test]
@@ -680,7 +697,11 @@ mod tests {
         registry.accounts().create(text_only).await.unwrap();
 
         let all = registry.accounts().list().await;
-        let text_only_id = all.iter().find(|a| a.capabilities == vec!["text".to_owned()]).unwrap().id;
+        let text_only_id = all
+            .iter()
+            .find(|a| a.capabilities == vec!["text".to_owned()])
+            .unwrap()
+            .id;
 
         let pool = ProviderPool {
             id: PoolId::generate(),
@@ -697,7 +718,10 @@ mod tests {
         registry.routes().create(route).await.unwrap();
 
         let decision = engine.resolve("vision-model").await.unwrap();
-        assert_eq!(decision.account.id, vision_id, "must select the vision-capable account");
+        assert_eq!(
+            decision.account.id, vision_id,
+            "must select the vision-capable account"
+        );
     }
 
     // ── Round-robin ───────────────────────────────────────────────────────────
@@ -786,7 +810,7 @@ mod tests {
         // With weights 3:1 over 40 requests we expect ~30 heavy (75%) and ~10 light (25%).
         // Tight bounds: heavy should get 24-32 (60-80%), light must be > 0 and 8-16.
         assert!(
-            heavy_count >= 24 && heavy_count <= 32,
+            (24..=32).contains(&heavy_count),
             "heavy account should get ~75% (60-80%) of traffic, got {heavy_count}/40"
         );
         assert!(
@@ -838,7 +862,10 @@ mod tests {
         registry.routes().create(route).await.unwrap();
 
         let decision = engine.resolve("fallback-model").await.unwrap();
-        assert_eq!(decision.account.id, good_id, "must fall back to healthy account");
+        assert_eq!(
+            decision.account.id, good_id,
+            "must fall back to healthy account"
+        );
     }
 
     #[tokio::test]
@@ -894,7 +921,10 @@ mod tests {
         registry.routes().create(primary_route).await.unwrap();
 
         let decision = engine.resolve("primary-model").await.unwrap();
-        assert_eq!(decision.account.id, good_id, "must use route-level fallback");
+        assert_eq!(
+            decision.account.id, good_id,
+            "must use route-level fallback"
+        );
     }
 
     #[tokio::test]

--- a/clients/rook/src/server/mod.rs
+++ b/clients/rook/src/server/mod.rs
@@ -3,12 +3,13 @@
 //! [`run`] binds the unified axum [`Router`] (API + dashboard assets) to the
 //! configured address and blocks until a graceful shutdown signal is received.
 
+use crate::admin;
 use crate::dashboard;
 use crate::domain::RookError;
 use crate::gateway::{self, GatewayState};
 use crate::registry::RookRegistry;
 use crate::routing::RoutingEngine;
-use axum::{Router, routing::get};
+use axum::Router;
 use std::net::SocketAddr;
 use tracing::info;
 
@@ -52,15 +53,6 @@ impl ServerConfig {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Admin stub router
-// ---------------------------------------------------------------------------
-
-/// Minimal `/api` router — a placeholder for the full admin API (M2+).
-fn api_stub_router() -> Router {
-    Router::new().route("/health", get(|| async { "ok" }))
-}
-
 async fn build_app(config: ServerConfig) -> Result<Router, RookError> {
     let registry = RookRegistry::open(config.effective_db_path()).await?;
     build_app_with_registry(config, registry).await
@@ -77,13 +69,13 @@ async fn build_app_with_registry(
         .map_err(|e| RookError::Gateway(format!("failed to build HTTP client: {e}")))?;
 
     let gateway_state = GatewayState {
-        registry,
+        registry: registry.clone(),
         engine,
         client,
     };
 
     Ok(Router::new()
-        .nest("/api", api_stub_router())
+        .nest("/api", admin::build_router(registry))
         .nest("/v1", gateway::build_router(gateway_state))
         .merge(dashboard::router()))
 }
@@ -181,8 +173,8 @@ mod tests {
     async fn composed_server_router_keeps_api_health_route() {
         let registry = RookRegistry::open_in_memory().await.unwrap();
         let app = build_app_with_registry(ServerConfig::default(), registry)
-        .await
-        .unwrap();
+            .await
+            .unwrap();
 
         let response = app
             .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
@@ -192,6 +184,30 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         assert_eq!(&body[..], b"ok");
+    }
+
+    #[tokio::test]
+    async fn composed_server_router_mounts_real_admin_usage_endpoint() {
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let app = build_app_with_registry(ServerConfig::default(), registry)
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(Request::get("/api/usage").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json_body,
+            json!({
+                "available": false,
+                "reason": "usage accounting is not implemented in M1"
+            })
+        );
     }
 
     #[tokio::test]
@@ -210,5 +226,23 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let json_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json_body, json!({"object":"list","data":[]}));
+    }
+
+    #[tokio::test]
+    async fn composed_server_router_preserves_dashboard_root_route() {
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let app = build_app_with_registry(ServerConfig::default(), registry)
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(Request::get("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body_text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body_text.contains("Corvus Rook"));
     }
 }

--- a/clients/rook/src/server/mod.rs
+++ b/clients/rook/src/server/mod.rs
@@ -133,6 +133,27 @@ mod tests {
     use serde_json::json;
     use tower::util::ServiceExt;
 
+    async fn request_json(app: axum::Router, path: &str) -> (StatusCode, serde_json::Value) {
+        let response = app
+            .oneshot(Request::get(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        (status, json)
+    }
+
+    async fn request_text(app: axum::Router, path: &str) -> (StatusCode, Vec<u8>) {
+        let response = app
+            .oneshot(Request::get(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (status, body.to_vec())
+    }
+
     #[test]
     fn server_config_default_values() {
         let cfg = ServerConfig::default();
@@ -244,5 +265,29 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let body_text = String::from_utf8(body.to_vec()).unwrap();
         assert!(body_text.contains("Corvus Rook"));
+    }
+
+    #[tokio::test]
+    async fn composed_server_router_preserves_api_gateway_root_and_assets() {
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let app = build_app_with_registry(ServerConfig::default(), registry)
+            .await
+            .unwrap();
+
+        let (health_status, health_body) = request_text(app.clone(), "/api/health").await;
+        assert_eq!(health_status, StatusCode::OK);
+        assert_eq!(health_body, b"ok");
+
+        let (models_status, models_json) = request_json(app.clone(), "/v1/models").await;
+        assert_eq!(models_status, StatusCode::OK);
+        assert_eq!(models_json, json!({"object":"list","data":[]}));
+
+        let (root_status, root_body) = request_text(app.clone(), "/").await;
+        assert_eq!(root_status, StatusCode::OK);
+        assert!(String::from_utf8_lossy(&root_body).contains("Corvus Rook"));
+
+        let (asset_status, asset_body) = request_text(app, "/assets/index.html").await;
+        assert_eq!(asset_status, StatusCode::OK);
+        assert!(String::from_utf8_lossy(&asset_body).contains("Corvus Rook"));
     }
 }

--- a/clients/rook/src/services/account.rs
+++ b/clients/rook/src/services/account.rs
@@ -147,18 +147,18 @@ impl AccountService for SqliteAccountService {
     }
 
     async fn delete(&self, id: AccountId) -> Result<(), RookError> {
-        if self.db.is_account_referenced_by_pool(&id).await? {
-            return Err(RookError::Registry(format!(
-                "cannot delete account {}: referenced by one or more pools",
-                id
-            )));
+        match self.db.delete_account_if_not_referenced(&id).await? {
+            crate::db::account::DeleteAccountResult::Deleted => Ok(()),
+            crate::db::account::DeleteAccountResult::Referenced => {
+                Err(RookError::Registry(format!(
+                    "cannot delete account {}: referenced by one or more pools",
+                    id
+                )))
+            }
+            crate::db::account::DeleteAccountResult::NotFound => {
+                Err(RookError::Registry(format!("account {id} not found")))
+            }
         }
-
-        if !self.db.delete_account(&id).await? {
-            return Err(RookError::Registry(format!("account {id} not found")));
-        }
-
-        Ok(())
     }
 }
 

--- a/clients/rook/src/services/account.rs
+++ b/clients/rook/src/services/account.rs
@@ -82,8 +82,10 @@ impl AccountService for InMemoryAccountService {
     }
 
     async fn update(&self, account: ProviderAccount) -> Result<(), RookError> {
-        let mut guard =
-            self.store.lock().map_err(|e| RookError::Registry(e.to_string()))?;
+        let mut guard = self
+            .store
+            .lock()
+            .map_err(|e| RookError::Registry(e.to_string()))?;
         if !guard.contains_key(&account.id) {
             return Err(RookError::Registry(format!(
                 "account {} not found",
@@ -95,8 +97,10 @@ impl AccountService for InMemoryAccountService {
     }
 
     async fn delete(&self, id: AccountId) -> Result<(), RookError> {
-        let mut guard =
-            self.store.lock().map_err(|e| RookError::Registry(e.to_string()))?;
+        let mut guard = self
+            .store
+            .lock()
+            .map_err(|e| RookError::Registry(e.to_string()))?;
         if guard.remove(&id).is_none() {
             return Err(RookError::Registry(format!("account {id} not found")));
         }
@@ -143,7 +147,18 @@ impl AccountService for SqliteAccountService {
     }
 
     async fn delete(&self, id: AccountId) -> Result<(), RookError> {
-        self.db.delete_account(&id).await.map(|_| ())
+        if self.db.is_account_referenced_by_pool(&id).await? {
+            return Err(RookError::Registry(format!(
+                "cannot delete account {}: referenced by one or more pools",
+                id
+            )));
+        }
+
+        if !self.db.delete_account(&id).await? {
+            return Err(RookError::Registry(format!("account {id} not found")));
+        }
+
+        Ok(())
     }
 }
 

--- a/clients/rook/src/services/health.rs
+++ b/clients/rook/src/services/health.rs
@@ -104,7 +104,9 @@ impl InMemoryHealthService {
     fn lock(
         &self,
     ) -> Result<std::sync::MutexGuard<'_, HashMap<AccountId, AccountHealth>>, RookError> {
-        self.store.lock().map_err(|e| RookError::Registry(e.to_string()))
+        self.store
+            .lock()
+            .map_err(|e| RookError::Registry(e.to_string()))
     }
 }
 
@@ -123,8 +125,9 @@ impl HealthService for InMemoryHealthService {
     async fn mark_success(&self, account_id: AccountId) {
         match self.lock() {
             Ok(mut guard) => {
-                let entry =
-                    guard.entry(account_id).or_insert_with(|| AccountHealth::new(account_id));
+                let entry = guard
+                    .entry(account_id)
+                    .or_insert_with(|| AccountHealth::new(account_id));
                 entry.status = HealthStatus::Healthy;
                 entry.last_checked = Some(Utc::now());
                 entry.consecutive_failures = 0;
@@ -143,14 +146,14 @@ impl HealthService for InMemoryHealthService {
     async fn mark_failure(&self, account_id: AccountId, cooldown_seconds: u64) {
         match self.lock() {
             Ok(mut guard) => {
-                let entry =
-                    guard.entry(account_id).or_insert_with(|| AccountHealth::new(account_id));
+                let entry = guard
+                    .entry(account_id)
+                    .or_insert_with(|| AccountHealth::new(account_id));
                 entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
                 entry.last_checked = Some(Utc::now());
                 entry.status = HealthStatus::Unhealthy;
                 let cooldown_secs = i64::try_from(cooldown_seconds).unwrap_or(i64::MAX);
-                entry.cooldown_until =
-                    Some(Utc::now() + chrono::Duration::seconds(cooldown_secs));
+                entry.cooldown_until = Some(Utc::now() + chrono::Duration::seconds(cooldown_secs));
             }
             Err(e) => {
                 tracing::warn!(

--- a/clients/rook/src/services/pool.rs
+++ b/clients/rook/src/services/pool.rs
@@ -186,14 +186,7 @@ impl PoolService for SqlitePoolService {
     }
 
     async fn update(&self, pool: ProviderPool) -> Result<(), RookError> {
-        // No update_pool in db layer — implement as delete + re-insert.
-        let pool_id_str = pool.id.to_string();
-        sqlx::query("DELETE FROM provider_pools WHERE id = ?")
-            .bind(&pool_id_str)
-            .execute(self.db.pool())
-            .await
-            .map_err(|e| RookError::Registry(format!("delete_pool failed: {e}")))?;
-        self.db.insert_pool(&pool).await
+        self.db.replace_pool(&pool).await
     }
 
     async fn delete(&self, id: PoolId) -> Result<(), RookError> {

--- a/clients/rook/src/services/pool.rs
+++ b/clients/rook/src/services/pool.rs
@@ -18,10 +18,7 @@ pub trait PoolService: Send + Sync {
     fn get(&self, id: PoolId) -> impl Future<Output = Option<ProviderPool>> + Send;
 
     /// Persist a new pool and return its assigned [`PoolId`].
-    fn create(
-        &self,
-        pool: ProviderPool,
-    ) -> impl Future<Output = Result<PoolId, RookError>> + Send;
+    fn create(&self, pool: ProviderPool) -> impl Future<Output = Result<PoolId, RookError>> + Send;
 
     /// Overwrite an existing pool.
     ///
@@ -98,8 +95,10 @@ impl PoolService for InMemoryPoolService {
     }
 
     async fn update(&self, pool: ProviderPool) -> Result<(), RookError> {
-        let mut guard =
-            self.store.lock().map_err(|e| RookError::Registry(e.to_string()))?;
+        let mut guard = self
+            .store
+            .lock()
+            .map_err(|e| RookError::Registry(e.to_string()))?;
         if !guard.contains_key(&pool.id) {
             return Err(RookError::Registry(format!("pool {} not found", pool.id)));
         }
@@ -108,8 +107,10 @@ impl PoolService for InMemoryPoolService {
     }
 
     async fn delete(&self, id: PoolId) -> Result<(), RookError> {
-        let mut guard =
-            self.store.lock().map_err(|e| RookError::Registry(e.to_string()))?;
+        let mut guard = self
+            .store
+            .lock()
+            .map_err(|e| RookError::Registry(e.to_string()))?;
         if guard.remove(&id).is_none() {
             return Err(RookError::Registry(format!("pool {id} not found")));
         }
@@ -117,8 +118,10 @@ impl PoolService for InMemoryPoolService {
     }
 
     async fn add_member(&self, pool_id: PoolId, account_id: AccountId) -> Result<(), RookError> {
-        let mut guard =
-            self.store.lock().map_err(|e| RookError::Registry(e.to_string()))?;
+        let mut guard = self
+            .store
+            .lock()
+            .map_err(|e| RookError::Registry(e.to_string()))?;
         let pool = guard
             .get_mut(&pool_id)
             .ok_or_else(|| RookError::Registry(format!("pool {pool_id} not found")))?;
@@ -128,18 +131,19 @@ impl PoolService for InMemoryPoolService {
         Ok(())
     }
 
-    async fn remove_member(
-        &self,
-        pool_id: PoolId,
-        account_id: AccountId,
-    ) -> Result<(), RookError> {
-        let mut guard =
-            self.store.lock().map_err(|e| RookError::Registry(e.to_string()))?;
+    async fn remove_member(&self, pool_id: PoolId, account_id: AccountId) -> Result<(), RookError> {
+        let mut guard = self
+            .store
+            .lock()
+            .map_err(|e| RookError::Registry(e.to_string()))?;
         let pool = guard
             .get_mut(&pool_id)
             .ok_or_else(|| RookError::Registry(format!("pool {pool_id} not found")))?;
-        let pos =
-            pool.members.iter().position(|m| m == &account_id).ok_or_else(|| {
+        let pos = pool
+            .members
+            .iter()
+            .position(|m| m == &account_id)
+            .ok_or_else(|| {
                 RookError::Registry(format!(
                     "account {account_id} is not a member of pool {pool_id}"
                 ))
@@ -193,12 +197,25 @@ impl PoolService for SqlitePoolService {
     }
 
     async fn delete(&self, id: PoolId) -> Result<(), RookError> {
+        if self.db.is_pool_referenced_as_fallback(&id).await? {
+            return Err(RookError::Registry(format!(
+                "cannot delete pool {}: referenced by one or more fallback pools",
+                id
+            )));
+        }
+
         let id_str = id.to_string();
         sqlx::query("DELETE FROM provider_pools WHERE id = ?")
             .bind(&id_str)
             .execute(self.db.pool())
             .await
-            .map(|_| ())
+            .and_then(|result| {
+                if result.rows_affected() == 0 {
+                    Err(sqlx::Error::RowNotFound)
+                } else {
+                    Ok(())
+                }
+            })
             .map_err(|e| RookError::Registry(format!("delete_pool failed: {e}")))
     }
 
@@ -206,11 +223,7 @@ impl PoolService for SqlitePoolService {
         self.db.add_pool_member(&pool_id, &account_id).await
     }
 
-    async fn remove_member(
-        &self,
-        pool_id: PoolId,
-        account_id: AccountId,
-    ) -> Result<(), RookError> {
+    async fn remove_member(&self, pool_id: PoolId, account_id: AccountId) -> Result<(), RookError> {
         self.db.remove_pool_member(&pool_id, &account_id).await
     }
 }
@@ -315,8 +328,10 @@ mod tests {
     #[tokio::test]
     async fn add_member_to_nonexistent_pool_errors() {
         let svc = InMemoryPoolService::new();
-        let err =
-            svc.add_member(PoolId::generate(), AccountId::generate()).await.unwrap_err();
+        let err = svc
+            .add_member(PoolId::generate(), AccountId::generate())
+            .await
+            .unwrap_err();
         assert!(err.to_string().contains("not found"));
     }
 

--- a/clients/rook/src/services/route.rs
+++ b/clients/rook/src/services/route.rs
@@ -19,16 +19,10 @@ pub trait RouteService: Send + Sync {
 
     /// Resolve a logical model name to its active route, or `None` if no route
     /// is configured for that model.
-    fn resolve(
-        &self,
-        logical_model: &str,
-    ) -> impl Future<Output = Option<ModelRoute>> + Send;
+    fn resolve(&self, logical_model: &str) -> impl Future<Output = Option<ModelRoute>> + Send;
 
     /// Persist a new route and return its assigned [`RouteId`].
-    fn create(
-        &self,
-        route: ModelRoute,
-    ) -> impl Future<Output = Result<RouteId, RookError>> + Send;
+    fn create(&self, route: ModelRoute) -> impl Future<Output = Result<RouteId, RookError>> + Send;
 
     /// Overwrite an existing route.
     ///
@@ -79,7 +73,11 @@ impl RouteService for InMemoryRouteService {
             .collect();
 
         // Only return a route if exactly one is found
-        if matches.len() == 1 { Some(matches[0].clone()) } else { None }
+        if matches.len() == 1 {
+            Some(matches[0].clone())
+        } else {
+            None
+        }
     }
 
     async fn create(&self, route: ModelRoute) -> Result<RouteId, RookError> {
@@ -109,8 +107,10 @@ impl RouteService for InMemoryRouteService {
     }
 
     async fn update(&self, route: ModelRoute) -> Result<(), RookError> {
-        let mut guard =
-            self.store.lock().map_err(|e| RookError::Registry(e.to_string()))?;
+        let mut guard = self
+            .store
+            .lock()
+            .map_err(|e| RookError::Registry(e.to_string()))?;
 
         // Verify route exists
         if !guard.contains_key(&route.id) {
@@ -132,8 +132,10 @@ impl RouteService for InMemoryRouteService {
     }
 
     async fn delete(&self, id: RouteId) -> Result<(), RookError> {
-        let mut guard =
-            self.store.lock().map_err(|e| RookError::Registry(e.to_string()))?;
+        let mut guard = self
+            .store
+            .lock()
+            .map_err(|e| RookError::Registry(e.to_string()))?;
         if guard.remove(&id).is_none() {
             return Err(RookError::Registry(format!("route {id} not found")));
         }
@@ -168,7 +170,11 @@ impl RouteService for SqliteRouteService {
     }
 
     async fn resolve(&self, logical_model: &str) -> Option<ModelRoute> {
-        self.db.find_route_by_model(logical_model).await.ok().flatten()
+        self.db
+            .find_route_by_model(logical_model)
+            .await
+            .ok()
+            .flatten()
     }
 
     async fn create(&self, route: ModelRoute) -> Result<RouteId, RookError> {

--- a/clients/rook/src/services/settings.rs
+++ b/clients/rook/src/services/settings.rs
@@ -45,8 +45,10 @@ impl SettingsService for InMemorySettingsService {
     }
 
     async fn save(&self, settings: RookSettings) -> Result<(), RookError> {
-        let mut guard =
-            self.store.lock().map_err(|e| RookError::Registry(e.to_string()))?;
+        let mut guard = self
+            .store
+            .lock()
+            .map_err(|e| RookError::Registry(e.to_string()))?;
         *guard = Some(settings);
         Ok(())
     }
@@ -98,10 +100,12 @@ mod tests {
     #[tokio::test]
     async fn save_and_load_round_trip() {
         let svc = InMemorySettingsService::new();
-        let mut s = RookSettings::default();
-        s.gateway_port = 9090;
-        s.log_json = true;
-        s.log_level = "debug".to_owned();
+        let s = RookSettings {
+            gateway_port: 9090,
+            log_json: true,
+            log_level: "debug".to_owned(),
+            ..RookSettings::default()
+        };
 
         svc.save(s.clone()).await.unwrap();
 
@@ -115,12 +119,16 @@ mod tests {
     async fn save_overwrites_previous() {
         let svc = InMemorySettingsService::new();
 
-        let mut s1 = RookSettings::default();
-        s1.gateway_port = 8080;
+        let s1 = RookSettings {
+            gateway_port: 8080,
+            ..RookSettings::default()
+        };
         svc.save(s1).await.unwrap();
 
-        let mut s2 = RookSettings::default();
-        s2.gateway_port = 9999;
+        let s2 = RookSettings {
+            gateway_port: 9999,
+            ..RookSettings::default()
+        };
         svc.save(s2).await.unwrap();
 
         assert_eq!(svc.load().await.gateway_port, 9999);

--- a/openspec/changes/rook-590-admin-api/design.md
+++ b/openspec/changes/rook-590-admin-api/design.md
@@ -1,0 +1,1024 @@
+# Design: Expose the Rook Admin API for Accounts, Pools, Routes, Health, Settings, and Usage Status
+
+## Technical Approach
+
+Rook will add a thin axum admin surface under `/api` inside `clients/rook`, backed directly by
+existing `RookRegistry` services rather than new business-logic layers. The server will continue to
+compose three concerns in one process:
+
+- `/api/*` → admin API for operator/dashboard management
+- `/v1/*` → existing OpenAI-compatible gateway
+- `/*` → dashboard assets
+
+The admin API will introduce transport DTOs that are intentionally separate from domain models.
+This is required because `ProviderAccount` contains sensitive `api_key` state that must never be
+serialized back to callers, while the admin surface needs stable JSON contracts and error shapes.
+
+The resulting implementation stays local to `clients/rook/src/admin/` plus server wiring and test
+coverage. Existing services in `clients/rook/src/services/` remain the source of truth for CRUD and
+reference behavior.
+
+## Architecture Overview
+
+### Admin router placement
+
+The admin router will be mounted as a nested router under `/api` from `server/mod.rs`, replacing the
+current `api_stub_router()` placeholder. The admin router owns all admin endpoints, including the
+preserved `GET /api/health` route.
+
+### Relationship to `/v1` gateway and server composition
+
+Server composition remains:
+
+```text
+Router::new()
+  ├─ nest("/api", admin::build_router(registry.clone()))
+  ├─ nest("/v1", gateway::build_router(gateway_state))
+  └─ merge(dashboard::router())
+```
+
+This keeps the transport boundary explicit:
+
+- `/api` is for operator CRUD and runtime inspection.
+- `/v1` remains the public OpenAI-compatible inference surface.
+- Dashboard assets stay independent from both API surfaces.
+
+No admin handler should call gateway handlers or route through `/v1`; both surfaces share the same
+registry-backed state, but each keeps its own transport contract.
+
+### State sharing via `RookRegistry`
+
+`RookRegistry` is already the composition root for accounts, pools, routes, settings, and health.
+The admin layer should use it as its only application state:
+
+```text
+HTTP Request
+   │
+   ▼
+Admin axum handler
+   │
+   ▼
+RookRegistry
+   ├─ accounts()
+   ├─ pools()
+   ├─ routes()
+   ├─ settings()
+   └─ health()
+   │
+   ▼
+SQLite services / in-memory health service
+```
+
+This avoids introducing an admin-specific service layer that would only duplicate existing logic.
+
+## Architecture Decisions
+
+### Decision: Keep admin transport models separate from domain structs
+
+**Choice**: Create dedicated DTO/view types in `clients/rook/src/admin/types.rs`.
+
+**Alternatives considered**:
+
+- Serialize domain structs directly.
+- Add serde annotations to domain structs to fit admin JSON.
+
+**Rationale**: The domain model is not a safe public contract. `ProviderAccount` already hides
+`api_key` from serde output, but the admin API also needs explicit `has_api_key`, stable JSON
+naming, request validation boundaries, and future-proofing for client compatibility.
+
+### Decision: Use `RookRegistry` directly as handler state
+
+**Choice**: `admin::build_router(registry: RookRegistry) -> Router` and `State<RookRegistry>` in
+handlers.
+
+**Alternatives considered**:
+
+- Wrap registry in an `AdminState` newtype.
+- Add `admin/state.rs` to hold helper methods.
+
+**Rationale**: `RookRegistry` is already cloneable and is the correct composition root. A separate
+`state.rs` adds indirection without solving a current problem. If helper logic grows later, it can
+still be introduced without breaking route signatures.
+
+### Decision: Keep the admin layer thin and service-backed
+
+**Choice**: Handlers will translate HTTP DTOs to domain models, call existing services, then map
+results back to views.
+
+**Alternatives considered**:
+
+- Build an admin application service layer that wraps every existing service.
+- Re-implement reference checks in handlers with raw SQL.
+
+**Rationale**: The change goal is a transport slice, not domain redesign. Existing services and DB
+constraints already own most lifecycle behavior. The admin layer should only add transport-specific
+validation, error mapping, and response shaping.
+
+### Decision: Canonical settings update is `PUT`
+
+**Choice**: Treat `PUT /api/settings` as the canonical mutation contract. `PATCH /api/settings`
+remains an explicit product decision for M1 rather than a distinct implementation requirement.
+
+**Alternatives considered**:
+
+- Support full `PATCH` partial-update semantics now.
+- Implement `PATCH` as an alias to `PUT`.
+
+**Rationale**: The existing settings service only supports load/save of the full singleton, which
+maps naturally to `PUT`. A true `PATCH` contract requires field-level merge semantics and stronger
+validation rules. Alias-to-`PUT` behavior is easy, but semantically muddy. For M1, `PUT` is honest
+and sufficient.
+
+### Decision: Health summary is derived at read time
+
+**Choice**: `GET /api/health/accounts` and `GET /api/health/summary` will combine account records
+from `accounts().list()` with per-account snapshots from `health().get(account_id)`.
+
+**Alternatives considered**:
+
+- Persist a separate materialized health table.
+- Expose only the in-memory health store without account metadata.
+
+**Rationale**: The current health service is in-memory and keyed by `AccountId`. Operators need
+account context such as display name, vendor, and enabled status. Deriving views at read time is
+cheap at current scale and matches M1 behavior honestly.
+
+## Data Flow
+
+### Admin CRUD flow
+
+```text
+Client
+  │  JSON request
+  ▼
+admin::handlers::{create_*, update_*, delete_*}
+  │  validate DTO / parse IDs
+  ▼
+domain model construction
+  │
+  ▼
+registry.{accounts|pools|routes|settings}()
+  │
+  ▼
+SQLite-backed service
+  │
+  ▼
+domain result / RookError
+  │
+  ├─ success → admin view DTO → JSON response
+  └─ error   → admin error mapper → JSON error response
+```
+
+### Health read flow
+
+```text
+GET /api/health/accounts or /api/health/summary
+  │
+  ▼
+list accounts from registry.accounts()
+  │
+  ├─ for each account_id → registry.health().get(account_id)
+  │
+  ▼
+derive account health views + aggregate counts
+  │
+  ▼
+JSON response
+```
+
+### Sequence diagram: account read with redaction
+
+```text
+Client -> Admin Router: GET /api/accounts/:account_id
+Admin Router -> Handler: handle_get_account(Path<AccountId>, State<RookRegistry>)
+Handler -> AccountService: get(account_id)
+AccountService -> Handler: Option<ProviderAccount>
+Handler -> Types mapper: AccountView::from_domain(account)
+Types mapper -> Handler: AccountView { has_api_key: true/false, api_key omitted }
+Handler -> Client: 200 JSON or 404 JSON error
+```
+
+## Module / File Structure
+
+Recommended files under `clients/rook/src/admin/`:
+
+- `mod.rs`
+- `types.rs`
+- `handlers.rs`
+
+`state.rs` is **not** justified for M1 because `RookRegistry` already serves as the handler state.
+If shared helper logic later becomes complex, it can be added then.
+
+### File responsibilities
+
+#### `clients/rook/src/admin/mod.rs`
+
+- Declare `pub mod handlers; pub mod types;`
+- Export `pub fn build_router(registry: RookRegistry) -> Router`
+- Define the full route table for `/api`
+- Optionally keep private route wiring helpers for readability
+
+#### `clients/rook/src/admin/types.rs`
+
+- Request DTOs (`CreateAccountRequest`, `UpdatePoolRequest`, etc.)
+- Response DTOs/views (`AccountView`, `PoolView`, `HealthSummaryView`, `UsageView`)
+- Admin error payload type (`AdminErrorBody`)
+- Mapping helpers from domain → transport and transport → domain pieces
+
+#### `clients/rook/src/admin/handlers.rs`
+
+- Axum handlers only
+- Request parsing, validation, service calls, response construction
+- Error mapping helpers such as `map_rook_error(...)`
+- Small helper functions for parsing path IDs and building derived health responses
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `clients/rook/src/admin/mod.rs` | Create | Admin router module and route registration under `/api`. |
+| `clients/rook/src/admin/types.rs` | Create | Request/response DTOs, redacted views, and JSON error types. |
+| `clients/rook/src/admin/handlers.rs` | Create | Handler implementations for accounts, pools, routes, health, settings, and usage. |
+| `clients/rook/src/lib.rs` | Modify | Export the new `admin` module. |
+| `clients/rook/src/server/mod.rs` | Modify | Replace `api_stub_router()` usage with real admin router composition while preserving `/v1` and dashboard routes. |
+| `clients/rook/src/services/account.rs` | Maybe modify | Only if needed to normalize “not found” behavior on update/delete for cleaner HTTP mapping. |
+| `clients/rook/src/services/pool.rs` | Maybe modify | Only if needed to tighten not-found/reference semantics and member removal behavior. |
+| `clients/rook/src/services/route.rs` | Maybe modify | Only if needed to preserve stable not-found/conflict mapping on update/delete. |
+| `clients/rook/src/server/mod.rs` tests and/or new admin tests | Modify/Create | Add router composition and handler coverage. |
+
+## Route List
+
+### Health
+
+- `GET /api/health`
+- `GET /api/health/accounts`
+- `GET /api/health/summary`
+
+### Accounts
+
+- `GET /api/accounts`
+- `POST /api/accounts`
+- `GET /api/accounts/:account_id`
+- `PUT /api/accounts/:account_id`
+- `DELETE /api/accounts/:account_id`
+
+### Pools
+
+- `GET /api/pools`
+- `POST /api/pools`
+- `GET /api/pools/:pool_id`
+- `PUT /api/pools/:pool_id`
+- `DELETE /api/pools/:pool_id`
+- `POST /api/pools/:pool_id/accounts`
+- `DELETE /api/pools/:pool_id/accounts/:account_id`
+
+### Routes
+
+- `GET /api/routes`
+- `POST /api/routes`
+- `GET /api/routes/:route_id`
+- `PUT /api/routes/:route_id`
+- `DELETE /api/routes/:route_id`
+
+### Settings
+
+- `GET /api/settings`
+- `PUT /api/settings`
+- `PATCH /api/settings` (open product/contract decision for M1)
+
+### Usage
+
+- `GET /api/usage`
+
+## Interfaces / Contracts
+
+### Shared error shape
+
+All admin failures should use one JSON envelope:
+
+```rust
+#[derive(Serialize)]
+struct AdminErrorBody {
+    error: AdminErrorDetail,
+}
+
+#[derive(Serialize)]
+struct AdminErrorDetail {
+    code: &'static str,
+    message: String,
+    details: Option<serde_json::Value>,
+}
+```
+
+Example:
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "account 8f6d... not found",
+    "details": null
+  }
+}
+```
+
+### Account transport contracts
+
+#### Redacted response view
+
+```rust
+#[derive(Serialize)]
+struct AccountView {
+    id: AccountId,
+    vendor: ProviderVendor,
+    display_name: String,
+    api_base_override: Option<String>,
+    has_api_key: bool,
+    enabled: bool,
+    weight: u32,
+    priority: u32,
+    tags: Vec<String>,
+    capabilities: Vec<String>,
+}
+```
+
+Mapping rule:
+
+```rust
+impl From<ProviderAccount> for AccountView {
+    fn from(account: ProviderAccount) -> Self {
+        Self {
+            id: account.id,
+            vendor: account.vendor,
+            display_name: account.display_name,
+            api_base_override: account.api_base_override,
+            has_api_key: account.api_key.is_some(),
+            enabled: account.enabled,
+            weight: account.weight,
+            priority: account.priority,
+            tags: account.tags,
+            capabilities: account.capabilities,
+        }
+    }
+}
+```
+
+`api_key` is never returned. The admin surface exposes only `has_api_key: bool`.
+
+#### Create/update requests
+
+```rust
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreateAccountRequest {
+    vendor: ProviderVendor,
+    display_name: String,
+    api_base_override: Option<String>,
+    api_key: Option<String>,
+    enabled: bool,
+    weight: u32,
+    priority: u32,
+    tags: Vec<String>,
+    capabilities: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UpdateAccountRequest {
+    vendor: ProviderVendor,
+    display_name: String,
+    api_base_override: Option<String>,
+    api_key: Option<String>,
+    enabled: bool,
+    weight: u32,
+    priority: u32,
+    tags: Vec<String>,
+    capabilities: Vec<String>,
+}
+```
+
+M1 behavior for account updates should be full replacement. The simplest honest rule is:
+
+- if `api_key` is present, replace stored key with that value
+- if `api_key` is `null`, clear the stored key
+
+This is explicit and avoids inventing sentinel semantics.
+
+### Pool transport contracts
+
+```rust
+#[derive(Serialize)]
+struct PoolView {
+    id: PoolId,
+    name: String,
+    strategy: SelectionStrategy,
+    members: Vec<AccountId>,
+    fallback_pool_id: Option<PoolId>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreatePoolRequest {
+    name: String,
+    strategy: SelectionStrategy,
+    members: Vec<AccountId>,
+    fallback_pool_id: Option<PoolId>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UpdatePoolRequest {
+    name: String,
+    strategy: SelectionStrategy,
+    members: Vec<AccountId>,
+    fallback_pool_id: Option<PoolId>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AddPoolMemberRequest {
+    account_id: AccountId,
+}
+```
+
+### Route transport contracts
+
+```rust
+#[derive(Serialize)]
+struct RouteView {
+    id: RouteId,
+    logical_model: String,
+    target_pool_id: PoolId,
+    fallback_route_id: Option<RouteId>,
+    capability_constraints: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreateRouteRequest {
+    logical_model: String,
+    target_pool_id: PoolId,
+    fallback_route_id: Option<RouteId>,
+    capability_constraints: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UpdateRouteRequest {
+    logical_model: String,
+    target_pool_id: PoolId,
+    fallback_route_id: Option<RouteId>,
+    capability_constraints: Vec<String>,
+}
+```
+
+### Settings transport contracts
+
+```rust
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SettingsView {
+    gateway_port: u16,
+    default_routing_policy: RoutingPolicyView,
+    log_json: bool,
+    log_level: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RoutingPolicyView {
+    strategy: SelectionStrategy,
+    max_retries: u32,
+    cooldown_seconds: u64,
+}
+```
+
+`PUT /api/settings` should accept the same shape as `GET /api/settings` returns.
+
+### Health transport contracts
+
+Health is derived from accounts + health snapshots.
+
+```rust
+#[derive(Serialize)]
+struct AccountHealthView {
+    account_id: AccountId,
+    display_name: String,
+    vendor: ProviderVendor,
+    enabled: bool,
+    status: HealthStatus,
+    last_checked: Option<chrono::DateTime<chrono::Utc>>,
+    consecutive_failures: u32,
+    cooldown_until: Option<chrono::DateTime<chrono::Utc>>,
+    is_available: bool,
+}
+
+#[derive(Serialize)]
+struct HealthSummaryView {
+    total_accounts: usize,
+    healthy: usize,
+    degraded: usize,
+    unhealthy: usize,
+    unknown: usize,
+    available_now: usize,
+}
+```
+
+The summary should be computed from the derived account health list in the handler, not stored.
+
+### Usage placeholder contract
+
+The usage endpoint should be intentionally minimal and honest:
+
+```rust
+#[derive(Serialize)]
+struct UsageView {
+    available: bool,
+    reason: &'static str,
+}
+```
+
+Example response:
+
+```json
+{
+  "available": false,
+  "reason": "usage accounting is not implemented in M1"
+}
+```
+
+Do not fabricate quota, spend, token, or cost fields with zero values; that would imply a real
+subsystem exists when it does not.
+
+## Handler Design
+
+### Common state and result helpers
+
+All handlers should receive `State<RookRegistry>`. A small internal alias is acceptable:
+
+```rust
+type AdminResult<T> = Result<Json<T>, AdminHttpError>;
+```
+
+ID parsing from path segments should fail with `400 bad_request` if the UUID/newtype cannot be
+deserialized.
+
+### Health handlers
+
+#### `handle_health`
+
+```rust
+pub async fn handle_health() -> &'static str
+```
+
+- Inputs: none
+- Calls: none
+- Output: plain text `"ok"` to preserve current behavior
+- Errors: none expected
+
+#### `handle_list_account_health`
+
+```rust
+pub async fn handle_list_account_health(State(registry): State<RookRegistry>)
+    -> AdminResult<Vec<AccountHealthView>>
+```
+
+- Inputs: shared registry
+- Calls:
+  - `registry.accounts().list().await`
+  - for each account: `registry.health().get(account.id).await`
+  - `registry.health().is_available(account.id).await`
+- Output: derived per-account health views
+- Validation/error cases:
+  - if account list retrieval falls back to empty due to service behavior, response is empty list
+  - internal derivation errors are not expected; unexpected failures map to 500
+
+#### `handle_health_summary`
+
+```rust
+pub async fn handle_health_summary(State(registry): State<RookRegistry>)
+    -> AdminResult<HealthSummaryView>
+```
+
+- Inputs: shared registry
+- Calls: same account + health derivation as above
+- Output: aggregate counts
+- Validation/error cases: same as account health list
+
+### Account handlers
+
+#### `handle_list_accounts`
+
+```rust
+pub async fn handle_list_accounts(State(registry): State<RookRegistry>)
+    -> AdminResult<Vec<AccountView>>
+```
+
+- Calls: `registry.accounts().list().await`
+- Output: redacted `AccountView[]`
+
+#### `handle_create_account`
+
+```rust
+pub async fn handle_create_account(
+    State(registry): State<RookRegistry>,
+    Json(req): Json<CreateAccountRequest>,
+) -> Result<(StatusCode, Json<AccountView>), AdminHttpError>
+```
+
+- Validation:
+  - `display_name` should not be blank after trim
+  - `weight` should be > 0 if weighted routing is expected later; at minimum reject clearly invalid
+    zero if the team wants stricter semantics
+- Calls:
+  - build `ProviderAccount { id: AccountId::generate(), ... }`
+  - `registry.accounts().create(account.clone()).await?`
+- Output: `201 Created` with redacted view
+- Errors:
+  - duplicate ID or registry conflict → 409 conflict
+  - malformed JSON/validation → 400 bad_request
+  - internal persistence failure → 500 internal_error
+
+#### `handle_get_account`
+
+```rust
+pub async fn handle_get_account(
+    Path(account_id): Path<AccountId>,
+    State(registry): State<RookRegistry>,
+) -> AdminResult<AccountView>
+```
+
+- Calls: `registry.accounts().get(account_id).await`
+- Output: `200` with redacted view
+- Errors: missing account → `404 not_found`
+
+#### `handle_update_account`
+
+```rust
+pub async fn handle_update_account(
+    Path(account_id): Path<AccountId>,
+    State(registry): State<RookRegistry>,
+    Json(req): Json<UpdateAccountRequest>,
+) -> AdminResult<AccountView>
+```
+
+- Validation: same as create
+- Calls:
+  - construct full `ProviderAccount` with path ID
+  - `registry.accounts().update(account.clone()).await?`
+  - optionally `registry.accounts().get(account_id).await` for final read-back if desired
+- Output: `200` with updated redacted view
+- Errors:
+  - unknown ID → `404 not_found`
+  - validation → `400 bad_request`
+  - registry conflict → `409 conflict`
+  - internal error → `500`
+
+#### `handle_delete_account`
+
+```rust
+pub async fn handle_delete_account(
+    Path(account_id): Path<AccountId>,
+    State(registry): State<RookRegistry>,
+) -> Result<StatusCode, AdminHttpError>
+```
+
+- Calls: `registry.accounts().delete(account_id).await?`
+- Output: `204 No Content`
+- Errors:
+  - if account is referenced by pool membership and DB rejects deletion → `409 conflict` or
+    `409 reference_conflict`
+  - if account missing → `404`
+
+### Pool handlers
+
+#### `handle_list_pools`
+
+```rust
+pub async fn handle_list_pools(State(registry): State<RookRegistry>)
+    -> AdminResult<Vec<PoolView>>
+```
+
+#### `handle_create_pool`
+
+```rust
+pub async fn handle_create_pool(
+    State(registry): State<RookRegistry>,
+    Json(req): Json<CreatePoolRequest>,
+) -> Result<(StatusCode, Json<PoolView>), AdminHttpError>
+```
+
+- Validation:
+  - `name` not blank
+  - if `fallback_pool_id` is present, it must not equal the new pool's ID
+  - members are trusted to be validated by DB/service, but pre-validation may improve 400 vs 409
+- Calls: `registry.pools().create(pool).await?`
+- Errors:
+  - missing referenced member/fallback pool from DB constraints → `409 reference_conflict`
+
+#### `handle_get_pool`
+
+```rust
+pub async fn handle_get_pool(
+    Path(pool_id): Path<PoolId>,
+    State(registry): State<RookRegistry>,
+) -> AdminResult<PoolView>
+```
+
+#### `handle_update_pool`
+
+```rust
+pub async fn handle_update_pool(
+    Path(pool_id): Path<PoolId>,
+    State(registry): State<RookRegistry>,
+    Json(req): Json<UpdatePoolRequest>,
+) -> AdminResult<PoolView>
+```
+
+- Calls: full replacement update via `registry.pools().update(pool).await?`
+- Key caution: current SQLite implementation deletes then reinserts. That means reference failures can
+  surface during reinsert, so the handler should map them clearly.
+
+#### `handle_delete_pool`
+
+```rust
+pub async fn handle_delete_pool(
+    Path(pool_id): Path<PoolId>,
+    State(registry): State<RookRegistry>,
+) -> Result<StatusCode, AdminHttpError>
+```
+
+- Errors:
+  - if routes or other pools reference the pool → `409 reference_conflict`
+  - missing pool → `404`
+
+#### `handle_add_pool_member`
+
+```rust
+pub async fn handle_add_pool_member(
+    Path(pool_id): Path<PoolId>,
+    State(registry): State<RookRegistry>,
+    Json(req): Json<AddPoolMemberRequest>,
+) -> AdminResult<PoolView>
+```
+
+- Calls:
+  - `registry.pools().add_member(pool_id, req.account_id).await?`
+  - `registry.pools().get(pool_id).await` to return updated pool
+- Output: `200` with pool view
+- Errors:
+  - unknown pool → `404`
+  - unknown account / FK violation → `409 reference_conflict`
+
+#### `handle_remove_pool_member`
+
+```rust
+pub async fn handle_remove_pool_member(
+    Path((pool_id, account_id)): Path<(PoolId, AccountId)>,
+    State(registry): State<RookRegistry>,
+) -> AdminResult<PoolView>
+```
+
+- Calls:
+  - `registry.pools().remove_member(pool_id, account_id).await?`
+  - `registry.pools().get(pool_id).await`
+- Errors:
+  - unknown pool → `404`
+  - unknown membership → `404` or `409` depending on final service behavior; M1 should prefer `404`
+    because the target membership resource does not exist
+
+### Route handlers
+
+#### `handle_list_routes`
+
+```rust
+pub async fn handle_list_routes(State(registry): State<RookRegistry>)
+    -> AdminResult<Vec<RouteView>>
+```
+
+#### `handle_create_route`
+
+```rust
+pub async fn handle_create_route(
+    State(registry): State<RookRegistry>,
+    Json(req): Json<CreateRouteRequest>,
+) -> Result<(StatusCode, Json<RouteView>), AdminHttpError>
+```
+
+- Validation:
+  - `logical_model` not blank
+- Calls: `registry.routes().create(route).await?`
+- Errors:
+  - duplicate logical model → `409 conflict`
+  - unknown target pool or fallback route → `409 reference_conflict`
+
+#### `handle_get_route`
+
+```rust
+pub async fn handle_get_route(
+    Path(route_id): Path<RouteId>,
+    State(registry): State<RookRegistry>,
+) -> AdminResult<RouteView>
+```
+
+#### `handle_update_route`
+
+```rust
+pub async fn handle_update_route(
+    Path(route_id): Path<RouteId>,
+    State(registry): State<RookRegistry>,
+    Json(req): Json<UpdateRouteRequest>,
+) -> AdminResult<RouteView>
+```
+
+- Calls: `registry.routes().update(route).await?`
+- Errors:
+  - route not found → `404`
+  - duplicate logical model / bad reference → `409`
+
+#### `handle_delete_route`
+
+```rust
+pub async fn handle_delete_route(
+    Path(route_id): Path<RouteId>,
+    State(registry): State<RookRegistry>,
+) -> Result<StatusCode, AdminHttpError>
+```
+
+- Calls: `registry.routes().delete(route_id).await?`
+- Errors:
+  - referenced as fallback by another route → `409 reference_conflict`
+  - missing route → `404`
+
+### Settings handlers
+
+#### `handle_get_settings`
+
+```rust
+pub async fn handle_get_settings(State(registry): State<RookRegistry>)
+    -> AdminResult<SettingsView>
+```
+
+- Calls: `registry.settings().load().await`
+- Output: current settings singleton
+
+#### `handle_put_settings`
+
+```rust
+pub async fn handle_put_settings(
+    State(registry): State<RookRegistry>,
+    Json(req): Json<SettingsView>,
+) -> AdminResult<SettingsView>
+```
+
+- Validation:
+  - `gateway_port > 0`
+  - `log_level` not blank
+- Calls:
+  - map to `RookSettings`
+  - `registry.settings().save(settings.clone()).await?`
+- Output: updated settings view
+- Errors: validation → `400`, save failure → `500`
+
+#### `handle_patch_settings`
+
+Open decision. If kept in M1, it should either:
+
+- be intentionally unsupported with `405/501`, or
+- accept a dedicated partial DTO and merge with `load()` result before `save()`.
+
+The design recommendation is to avoid distinct PATCH semantics in M1.
+
+### Usage handler
+
+#### `handle_get_usage`
+
+```rust
+pub async fn handle_get_usage() -> AdminResult<UsageView>
+```
+
+- Calls: none
+- Output: placeholder contract only
+- Errors: none expected
+
+## Error Handling Strategy
+
+### Status mapping
+
+The admin layer should centralize mapping from service/domain failures to HTTP responses.
+
+| Condition | HTTP | `error.code` | Notes |
+|---|---:|---|---|
+| Invalid JSON body / invalid path UUID / local validation failure | 400 | `bad_request` | Used for malformed input and explicit validation rules. |
+| Resource missing | 404 | `not_found` | Applies to unknown account/pool/route and missing membership resource. |
+| Duplicate logical resource or integrity conflict | 409 | `conflict` | Example: duplicate logical model. |
+| Reference integrity failure | 409 | `reference_conflict` | Example: delete blocked by route fallback reference or FK-protected membership. |
+| Unexpected persistence/runtime failure | 500 | `internal_error` | Message should be useful but not leak secrets. |
+
+### Mapping approach
+
+Because current services mostly return `RookError::Registry(String)`, the admin layer will need a
+small classifier based on known message patterns until richer typed errors exist. That classifier
+should live in `handlers.rs` and remain tightly scoped to the admin transport layer.
+
+Recommended heuristics:
+
+- contains `"not found"` → 404
+- contains `"duplicate"` or `"already exists"` → 409 conflict
+- contains `"referenced by"`, `"FOREIGN KEY"`, `"fallback_"`, or similar FK violations → 409
+  reference_conflict
+- otherwise → 500
+
+This is not ideal long-term, but it is the smallest compatible design for M1.
+
+## Server Integration
+
+### Replace the stub router
+
+`server/mod.rs` should stop composing `api_stub_router()` and instead compose the admin router:
+
+```rust
+Ok(Router::new()
+    .nest("/api", crate::admin::build_router(registry.clone()))
+    .nest("/v1", gateway::build_router(gateway_state))
+    .merge(dashboard::router()))
+```
+
+### Preserve `GET /api/health`
+
+The admin router itself must define:
+
+```rust
+.route("/health", get(handlers::handle_health))
+```
+
+`handle_health` should preserve the existing plain-text `"ok"` response so current behavior and
+tests remain stable.
+
+### Keep `/v1` and dashboard intact
+
+Important integration constraints:
+
+- `GatewayState` stays unchanged.
+- `/v1/models` and other gateway behavior are unaffected.
+- Dashboard static routing remains merged after `/api` and `/v1` nesting.
+- No admin route should shadow `/v1` or asset paths.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|--------------|----------|
+| Unit | DTO redaction and domain→view mapping | Direct tests in `admin/types.rs` for `AccountView::from(ProviderAccount)` and placeholder usage shape. |
+| Unit | Error classification | Tests in `admin/handlers.rs` for message-to-status mapping. |
+| Handler/router | CRUD happy paths | Axum router tests using `RookRegistry::open_in_memory()` and `tower::ServiceExt::oneshot`. |
+| Handler/router | Validation failures | Bad UUIDs, blank names, malformed JSON, invalid settings payloads. |
+| Handler/router | Redaction | Assert no response JSON ever includes `api_key`, and `has_api_key` is correct. |
+| Handler/router | Reference integrity | Delete account in pool, delete pool referenced by route/fallback, delete route referenced as fallback, add member with missing account. |
+| Handler/router | Health derivation | Account list + in-memory health snapshots produce correct per-account view and summary counts. |
+| Server composition | `/api`, `/v1`, and dashboard coexist | Extend `server/mod.rs` tests to verify `GET /api/health`, one admin CRUD/list route, and existing `/v1/models` all work together. |
+
+### Recommended test organization
+
+- Keep pure mapping tests near `admin/types.rs`
+- Keep handler tests near `admin/handlers.rs` or as nested module tests under `admin/mod.rs`
+- Keep server composition tests in `clients/rook/src/server/mod.rs`
+
+### Specific required scenarios
+
+1. **Redaction tests**
+   - create or seed an account with `api_key = Some(...)`
+   - assert `GET /api/accounts` and `GET /api/accounts/:id` omit `api_key`
+   - assert `has_api_key == true`
+
+2. **Reference-integrity tests**
+   - deleting a route that is referenced as `fallback_route_id` returns `409`
+   - deleting an account still used by a pool returns `409`
+   - deleting a pool still targeted by a route returns `409`
+
+3. **Router composition tests**
+   - `GET /api/health` still returns `ok`
+   - `GET /api/usage` returns placeholder JSON
+   - `GET /v1/models` remains unchanged
+
+## Migration / Rollout
+
+No data migration required.
+
+This is a transport-layer rollout over already-existing storage and services. The change is
+local-first and loopback-first by default, matching the current security posture until #591 lands.
+
+## Open Questions / Decisions
+
+- [ ] **PATCH for settings in M1**: recommendation is to ship `PUT /api/settings` only. If product
+      requires `PATCH`, decide whether to support true partial updates or reject it explicitly.
+- [ ] **Delete semantics for referenced resources**: current services rely on DB/service behavior and
+      string-based errors. Confirm whether M1 should always return `409 reference_conflict` for any
+      blocked delete, even if the underlying message varies.
+- [ ] **Membership removal semantics**: decide whether removing a non-member account from a pool is a
+      `404 not_found` or `409 conflict`. This design recommends `404` because the membership resource
+      does not exist.
+- [ ] **Usage placeholder minimality**: this design recommends only `{ available, reason }`. Confirm
+      whether clients need an optional `updated_at` or similar metadata, but avoid fake accounting
+      numbers.
+- [ ] **Validation strictness for weights and blank strings**: decide whether M1 should reject
+      zero-weight accounts or simply pass through to existing domain behavior.

--- a/openspec/changes/rook-590-admin-api/design.md
+++ b/openspec/changes/rook-590-admin-api/design.md
@@ -784,8 +784,7 @@ pub async fn handle_remove_pool_member(
   - `registry.pools().get(pool_id).await`
 - Errors:
   - unknown pool → `404`
-  - unknown membership → `404` or `409` depending on final service behavior; M1 should prefer `404`
-    because the target membership resource does not exist
+  - unknown membership → `409`
 
 ### Route handlers
 

--- a/openspec/changes/rook-590-admin-api/proposal.md
+++ b/openspec/changes/rook-590-admin-api/proposal.md
@@ -52,9 +52,9 @@ the already-shipped `/v1` gateway router and dashboard asset routes. The admin l
 expose domain structs directly. Instead, it should translate between transport DTOs and existing
 service/domain models through dedicated modules:
 
-- `clients/agent-runtime/src/gateway/admin/mod.rs`
-- `clients/agent-runtime/src/gateway/admin/types.rs`
-- `clients/agent-runtime/src/gateway/admin/handlers.rs`
+- `clients/rook/src/admin/mod.rs`
+- `clients/rook/src/admin/types.rs`
+- `clients/rook/src/admin/handlers.rs`
 
 The admin handlers should share application state through `RookRegistry`, treating the registry as
 the boundary to existing account, pool, route, health, and settings services. This keeps the new

--- a/openspec/changes/rook-590-admin-api/proposal.md
+++ b/openspec/changes/rook-590-admin-api/proposal.md
@@ -1,0 +1,194 @@
+# Proposal: Expose the Rook Admin API for Accounts, Pools, Routes, Health, Settings, and Usage Status
+
+## Intent
+
+Issue #590 is the next required slice to make Rook operable as a product surface instead of a
+runtime with internal-only management state. The OpenAI-compatible `/v1` gateway already exists and
+the domain/services for accounts, pools, routes, health, and settings already exist, but operators
+and the dashboard still lack a stable administrative contract for reading and mutating that state.
+
+This change establishes a thin, explicit admin API under `/api` so the dashboard and future
+automation can manage Rook through supported HTTP contracts rather than by reaching into internal
+runtime state. It also preserves the current M1 safety posture: loopback-first binding remains
+unchanged, auth/pairing work stays deferred to #591, and provider credentials remain redacted from
+all admin responses.
+
+> Note: the referenced PRD file `tmp/2026-04-19-local-first-provider-gateway-prd-rfc.md` is not
+> present in the repository, so this proposal uses issue context and verified exploration findings
+> as the source of truth.
+
+## Scope
+
+### In Scope
+
+- Add a real admin API namespace under `/api` backed by existing `RookRegistry` services.
+- Preserve the existing `GET /api/health` endpoint.
+- Expose account management endpoints for create, list, get, update, and delete operations.
+- Expose pool management endpoints for create, list, get, update, and delete operations.
+- Expose pool membership endpoints for adding and removing provider accounts from pools.
+- Expose route management endpoints for create, list, get, update, and delete operations.
+- Expose health read endpoints for account-level health records and aggregate summary views.
+- Expose settings read and update endpoints.
+- Add stable admin DTOs/views that redact secrets and return `has_api_key: bool` instead of raw
+  `api_key` values.
+- Add a placeholder read-only usage endpoint: `GET /api/usage` returning `available: false` and a
+  clear reason that real usage/cost accounting is not implemented yet.
+- Document the resulting admin contract where operators and developers can discover it.
+
+### Out of Scope
+
+- Admin auth, pairing, bearer token enforcement, or scope enforcement changes from #591.
+- Any change to loopback/default bind posture.
+- Real usage or cost accounting subsystem implementation.
+- Rate limiting, idempotency policy, or admin mutation conflict semantics beyond existing service
+  behavior.
+- Dashboard UI, TUI, or other client-surface implementation work.
+- Encryption-at-rest or secret storage redesign for provider API keys.
+
+## Approach
+
+Implement a thin admin router under `/api` that composes with the existing Rook server alongside
+the already-shipped `/v1` gateway router and dashboard asset routes. The admin layer should not
+expose domain structs directly. Instead, it should translate between transport DTOs and existing
+service/domain models through dedicated modules:
+
+- `clients/agent-runtime/src/gateway/admin/mod.rs`
+- `clients/agent-runtime/src/gateway/admin/types.rs`
+- `clients/agent-runtime/src/gateway/admin/handlers.rs`
+
+The admin handlers should share application state through `RookRegistry`, treating the registry as
+the boundary to existing account, pool, route, health, and settings services. This keeps the new
+HTTP surface thin, avoids duplicating business logic, and preserves internal service ownership.
+
+All outward-facing account and pool views must use stable redacted representations. In particular,
+provider credentials must never be serialized back to clients. Responses should expose capability
+signals such as `has_api_key: bool` and other non-sensitive metadata, while request DTOs may accept
+credential input only where needed for create/update flows.
+
+For usage, this proposal intentionally includes a placeholder `GET /api/usage` endpoint rather than
+deferring the path entirely. The acceptance criteria call out usage explicitly, but exploration
+confirmed there is no real usage/cost tracking subsystem in M1. Returning a stable read-only shape
+with `available: false` lets dashboard and automation clients integrate against a documented
+endpoint now without inventing fake accounting or overreaching into #591 or later usage work.
+
+## API Shape (High Level)
+
+The proposed admin API routes are:
+
+### Health
+
+- `GET /api/health`
+- `GET /api/health/accounts`
+- `GET /api/health/summary`
+
+### Accounts
+
+- `GET /api/accounts`
+- `POST /api/accounts`
+- `GET /api/accounts/:account_id`
+- `PUT /api/accounts/:account_id`
+- `DELETE /api/accounts/:account_id`
+
+### Pools
+
+- `GET /api/pools`
+- `POST /api/pools`
+- `GET /api/pools/:pool_id`
+- `PUT /api/pools/:pool_id`
+- `DELETE /api/pools/:pool_id`
+- `POST /api/pools/:pool_id/accounts`
+- `DELETE /api/pools/:pool_id/accounts/:account_id`
+
+### Routes
+
+- `GET /api/routes`
+- `POST /api/routes`
+- `GET /api/routes/:route_id`
+- `PUT /api/routes/:route_id`
+- `DELETE /api/routes/:route_id`
+
+### Settings
+
+- `GET /api/settings`
+- `PUT /api/settings`
+- `PATCH /api/settings`
+
+### Usage
+
+- `GET /api/usage`
+
+The usage response should be a documented placeholder contract, for example:
+
+```json
+{
+  "available": false,
+  "reason": "usage accounting is not implemented in M1"
+}
+```
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `clients/agent-runtime/src/gateway/mod.rs` | Modified | Compose the new `/api` admin router into the existing server alongside `/v1` and existing health/admin routes. |
+| `clients/agent-runtime/src/gateway/admin/` | New | Define admin module boundaries, request/response DTOs, and HTTP handlers for accounts, pools, routes, health, settings, and usage placeholder. |
+| `clients/agent-runtime/src/gateway/admin.rs` | Modified or reduced | Preserve any reusable admin serialization logic already present, while avoiding duplicate transport contracts. |
+| `clients/agent-runtime/src/...rook registry/services...` | Modified (targeted) | Reuse existing `RookRegistry` service accessors and add only the minimal glue needed for HTTP-backed admin operations. |
+| `openspec/changes/rook-590-admin-api/` | New | Proposal, specs, design, tasks, and verification artifacts for this change. |
+| Operator/developer docs | Modified | Document the stable admin API contract and explicitly note the placeholder usage endpoint. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Admin API is exposed before auth/pairing protections land | Medium | Keep auth explicitly deferred to #591, preserve loopback-only posture, and document that this is local-admin M1 behavior only. |
+| `api_key` leaks through serialization/debug output | Medium | Use dedicated admin DTOs only, never serialize raw account domain structs, and add targeted redaction tests. |
+| Usage endpoint implies real accounting exists | Medium | Make the endpoint explicitly read-only with `available: false` and a reason field; document it as a placeholder contract. |
+| Health data may be misread as durable historical truth | Medium | Document that health summaries reflect current in-memory/runtime-backed state only in M1. |
+| Delete operations may break references between accounts, pools, and routes | High | Define and test deterministic service-backed behavior for referenced deletions, and surface clear API errors for integrity violations. |
+| Router changes may accidentally disturb existing `/v1` or dashboard composition | Low | Add router composition tests that preserve `/api`, `/v1`, and existing health/dashboard behavior together. |
+
+## Testing Strategy
+
+- Add targeted read-only endpoint coverage for list/get flows on accounts, pools, routes, health,
+  settings, and the usage placeholder.
+- Add targeted mutation endpoint coverage for account, pool, membership, route, and settings
+  create/update/delete flows.
+- Add explicit redaction coverage proving admin responses never return raw `api_key` values and
+  instead surface `has_api_key`-style flags.
+- Add deletion/reference integrity coverage for expected failure cases when accounts, pools, or
+  routes are still referenced by related entities.
+- Add router composition coverage proving `/api/*` admin routes coexist correctly with preserved
+  `GET /api/health`, existing `/v1/*` gateway routes, and dashboard asset routing.
+- If full end-to-end coverage is too expensive for every handler, prioritize targeted handler/router
+  tests around the new admin contract and document any remaining validation gaps explicitly.
+
+## Rollback Plan
+
+If the admin API causes regressions, remove the new `/api` admin router composition and revert the
+added admin handler/types modules, restoring the prior state where only the stub `GET /api/health`
+is exposed. Because this proposal keeps the change thin and localized to the gateway/admin surface,
+rollback should not require reverting the `/v1` gateway or unrelated dashboard asset serving.
+
+## Dependencies
+
+- Existing `RookRegistry` account, pool, route, health, and settings services must remain the
+  source of truth.
+- Existing server composition in `clients/agent-runtime/src/gateway/mod.rs` must continue to host
+  `/api`, `/v1`, and dashboard assets in one process.
+- Follow-on auth/pairing hardening in #591 remains a dependency for broader exposure beyond current
+  local-admin assumptions.
+
+## Success Criteria
+
+- [ ] Rook exposes a stable `/api` admin surface for accounts, pools, pool membership, routes,
+      health, and settings while preserving `GET /api/health`.
+- [ ] Admin responses never return raw `api_key` values and use redacted views such as
+      `has_api_key: bool`.
+- [ ] `GET /api/usage` is either implemented as the documented placeholder contract in this change
+      and clearly marked unavailable, with no fake accounting behavior.
+- [ ] The admin API is backed by existing domain/services through `RookRegistry`, not duplicated
+      business logic.
+- [ ] Targeted tests cover read paths, mutation paths, redaction behavior, and router composition.
+- [ ] Operator/developer-facing documentation describes the resulting admin contract and the M1
+      limitations that remain deferred.

--- a/openspec/changes/rook-590-admin-api/spec.md
+++ b/openspec/changes/rook-590-admin-api/spec.md
@@ -1,0 +1,908 @@
+# Rook Admin API Specification
+
+**Change**: rook-590-admin-api  
+**Issue**: #590  
+**Phase**: M1 (MVP)  
+**Target Area**: `clients/rook`  
+**Domain**: gateway / admin API
+
+---
+
+## Purpose
+
+Define the HTTP admin contract exposed by Rook under `/api` for operators and the dashboard.
+
+This specification covers CRUD management for accounts, pools, pool membership, routes, health,
+settings, and a placeholder usage endpoint. It also defines redacted admin response views,
+preservation of the existing `GET /api/health` route, and required coexistence with the existing
+OpenAI-compatible `/v1/*` gateway routes and dashboard asset routes.
+
+This spec is aligned to `clients/rook/...` as the implementation target. Any earlier references to
+`clients/agent-runtime/...` are superseded for this change.
+
+---
+
+## Requirements
+
+### Requirement: Admin router composition under `/api`
+
+The system MUST compose a dedicated admin router under the `/api` prefix in the Rook server hosted
+from `clients/rook`.
+
+The composed server MUST preserve all of the following at the same time:
+
+- `GET /api/health`
+- all newly defined `/api/*` admin routes in this spec
+- existing `/v1/*` gateway routes
+- dashboard routes served from `/` and `/assets/*`
+
+The admin router MUST NOT shadow or break existing `/v1/*` behavior.
+
+#### Scenario: router composition preserves existing health and gateway routes
+
+- GIVEN a running Rook server with the composed application router
+- WHEN a client requests `GET /api/health`
+- THEN the response MUST succeed
+- AND the route MUST remain mounted under `/api`
+- WHEN a client requests `GET /v1/models`
+- THEN the response MUST also succeed
+- AND the `/v1/models` behavior MUST remain available alongside `/api/*`
+
+#### Scenario: dashboard routes still coexist with admin routes
+
+- GIVEN a running Rook server with dashboard assets enabled
+- WHEN a client requests `GET /`
+- THEN the dashboard response MUST still be served
+- AND admin router composition MUST NOT replace or intercept the dashboard root route
+
+---
+
+### Requirement: Preserve `GET /api/health`
+
+The system MUST preserve `GET /api/health` as a valid health endpoint for the admin surface.
+
+For M1, `GET /api/health` SHALL remain a lightweight server-health endpoint and MUST NOT be
+redefined to require account-level aggregation semantics.
+
+#### Scenario: base health endpoint remains available
+
+- GIVEN a running Rook server
+- WHEN a client requests `GET /api/health`
+- THEN the server MUST return a successful response
+- AND the route MUST remain available even if no accounts, pools, or routes exist
+
+---
+
+### Requirement: Account admin endpoints
+
+The system MUST expose the following account endpoints:
+
+- `GET /api/accounts`
+- `POST /api/accounts`
+- `GET /api/accounts/{account_id}`
+- `PUT /api/accounts/{account_id}`
+- `DELETE /api/accounts/{account_id}`
+
+These endpoints MUST operate on the existing Rook account service via `RookRegistry` and MUST use
+the redacted `AccountView` response shape defined in this spec.
+
+The service MUST support create, list, fetch, replace-update, and delete semantics.
+
+#### Scenario: listing accounts returns an empty collection
+
+- GIVEN no accounts have been created
+- WHEN a client requests `GET /api/accounts`
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST equal `[]`
+
+#### Scenario: create account happy path
+
+- GIVEN a valid `CreateAccountRequest`
+- WHEN a client submits `POST /api/accounts`
+- THEN the response status MUST be `201 Created`
+- AND the response body MUST be an `AccountView`
+- AND the returned `id` MUST be a server-assigned stable identifier
+- AND the returned `has_api_key` MUST reflect whether the request included `api_key`
+
+#### Scenario: get account happy path
+
+- GIVEN an existing account id
+- WHEN a client requests `GET /api/accounts/{account_id}`
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST be the matching `AccountView`
+
+#### Scenario: update account happy path
+
+- GIVEN an existing account id
+- AND a valid `UpdateAccountRequest`
+- WHEN a client submits `PUT /api/accounts/{account_id}`
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST be the updated `AccountView`
+
+#### Scenario: delete account happy path
+
+- GIVEN an existing account id that is not referenced by any pool
+- WHEN a client submits `DELETE /api/accounts/{account_id}`
+- THEN the response status MUST be `204 No Content`
+- AND subsequent `GET /api/accounts/{account_id}` MUST return `404 Not Found`
+
+#### Scenario: account fetch for unknown id
+
+- GIVEN no account exists for a requested id
+- WHEN a client requests `GET /api/accounts/{account_id}`
+- THEN the response status MUST be `404 Not Found`
+- AND the response body MUST match the admin error response shape
+
+---
+
+### Requirement: Account responses MUST redact credentials
+
+The system MUST accept `api_key` in create and update requests as a write-only field.
+
+The system MUST NOT return raw `api_key` values in any admin response body.
+
+Every account response MUST expose `has_api_key: boolean` instead of `api_key`.
+
+This redaction rule MUST apply to list responses, get responses, create responses, update
+responses, nested pool member views if any are ever returned, and any error payload metadata.
+
+#### Scenario: account create response redacts api_key
+
+- GIVEN a `CreateAccountRequest` with `api_key = "sk-secret"`
+- WHEN the request succeeds
+- THEN the response body MUST include `has_api_key: true`
+- AND the response body MUST NOT include an `api_key` field
+- AND the raw submitted credential MUST NOT be echoed back
+
+#### Scenario: account update response redacts api_key
+
+- GIVEN an existing account without a key
+- WHEN a client submits `PUT /api/accounts/{account_id}` with a new `api_key`
+- THEN the response body MUST include `has_api_key: true`
+- AND the response body MUST NOT include an `api_key` field
+
+#### Scenario: account list response remains redacted
+
+- GIVEN one or more stored accounts with API keys
+- WHEN a client requests `GET /api/accounts`
+- THEN every item in the response MUST include `has_api_key`
+- AND no item in the response MUST expose raw credential material
+
+---
+
+### Requirement: Pool admin endpoints
+
+The system MUST expose the following pool endpoints:
+
+- `GET /api/pools`
+- `POST /api/pools`
+- `GET /api/pools/{pool_id}`
+- `PUT /api/pools/{pool_id}`
+- `DELETE /api/pools/{pool_id}`
+
+These endpoints MUST operate on the existing Rook pool service via `RookRegistry`.
+
+Pool responses MUST use the `PoolView` contract defined in this spec.
+
+#### Scenario: listing pools returns an empty collection
+
+- GIVEN no pools have been created
+- WHEN a client requests `GET /api/pools`
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST equal `[]`
+
+#### Scenario: create pool happy path
+
+- GIVEN a valid `CreatePoolRequest`
+- WHEN a client submits `POST /api/pools`
+- THEN the response status MUST be `201 Created`
+- AND the response body MUST be a `PoolView`
+- AND the new pool MUST initially contain the members specified by the request, if any
+
+#### Scenario: update pool happy path
+
+- GIVEN an existing pool id
+- WHEN a client submits `PUT /api/pools/{pool_id}` with updated metadata
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST reflect the updated pool values
+
+#### Scenario: delete pool happy path
+
+- GIVEN an existing pool id that is not referenced by any route and is not referenced as another
+  pool's fallback pool
+- WHEN a client submits `DELETE /api/pools/{pool_id}`
+- THEN the response status MUST be `204 No Content`
+
+#### Scenario: delete referenced pool fails
+
+- GIVEN a pool is referenced by at least one route or fallback pool reference
+- WHEN a client submits `DELETE /api/pools/{pool_id}`
+- THEN the response status MUST be `409 Conflict`
+- AND the response body MUST match the admin error response shape
+- AND the error code MUST identify the resource as still referenced
+
+---
+
+### Requirement: Pool membership endpoints
+
+The system MUST expose pool membership mutation endpoints:
+
+- `POST /api/pools/{pool_id}/accounts`
+- `DELETE /api/pools/{pool_id}/accounts/{account_id}`
+
+`POST /api/pools/{pool_id}/accounts` MUST accept `AddPoolMemberRequest`.
+
+Adding an account to a pool MUST be idempotent: if the account is already a member, the operation
+MUST still succeed without creating a duplicate membership.
+
+Removing a member MUST fail when the account is not currently a member of the pool.
+
+Adding a member MUST fail when the account does not exist.
+
+#### Scenario: add member happy path
+
+- GIVEN an existing pool and an existing account that is not yet a member
+- WHEN a client submits `POST /api/pools/{pool_id}/accounts`
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST be the updated `PoolView`
+- AND the `members` list MUST now include that account id exactly once
+
+#### Scenario: add member is idempotent
+
+- GIVEN an existing pool that already contains the requested account id
+- WHEN a client submits `POST /api/pools/{pool_id}/accounts` for the same account again
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST contain the account id exactly once in `members`
+
+#### Scenario: remove member happy path
+
+- GIVEN an existing pool that contains an account id
+- WHEN a client submits `DELETE /api/pools/{pool_id}/accounts/{account_id}`
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST be the updated `PoolView`
+- AND the removed account id MUST no longer appear in `members`
+
+#### Scenario: remove non-member fails
+
+- GIVEN an existing pool that does not contain the requested account id
+- WHEN a client submits `DELETE /api/pools/{pool_id}/accounts/{account_id}`
+- THEN the response status MUST be `409 Conflict`
+- AND the response body MUST match the admin error response shape
+
+#### Scenario: add nonexistent account to pool fails
+
+- GIVEN an existing pool
+- AND no account exists for the requested account id
+- WHEN a client submits `POST /api/pools/{pool_id}/accounts`
+- THEN the response status MUST be `404 Not Found`
+- AND the response body MUST match the admin error response shape
+
+---
+
+### Requirement: Route admin endpoints
+
+The system MUST expose the following route endpoints:
+
+- `GET /api/routes`
+- `POST /api/routes`
+- `GET /api/routes/{route_id}`
+- `PUT /api/routes/{route_id}`
+- `DELETE /api/routes/{route_id}`
+
+These endpoints MUST operate on the existing Rook route service via `RookRegistry`.
+
+Route responses MUST use the `RouteView` contract defined in this spec.
+
+#### Scenario: listing routes returns an empty collection
+
+- GIVEN no routes have been created
+- WHEN a client requests `GET /api/routes`
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST equal `[]`
+
+#### Scenario: create route happy path
+
+- GIVEN a valid `CreateRouteRequest` referencing an existing pool
+- WHEN a client submits `POST /api/routes`
+- THEN the response status MUST be `201 Created`
+- AND the response body MUST be a `RouteView`
+
+#### Scenario: update route happy path
+
+- GIVEN an existing route id
+- AND a valid `UpdateRouteRequest`
+- WHEN a client submits `PUT /api/routes/{route_id}`
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST reflect the updated route
+
+#### Scenario: delete route happy path
+
+- GIVEN an existing route id that is not referenced as another route's fallback route
+- WHEN a client submits `DELETE /api/routes/{route_id}`
+- THEN the response status MUST be `204 No Content`
+
+#### Scenario: delete referenced route fails
+
+- GIVEN a route is referenced by another route's `fallback_route_id`
+- WHEN a client submits `DELETE /api/routes/{route_id}`
+- THEN the response status MUST be `409 Conflict`
+- AND the response body MUST match the admin error response shape
+- AND the error code MUST identify the route as still referenced
+
+#### Scenario: create route with duplicate logical model fails
+
+- GIVEN a route already exists for a logical model name
+- WHEN a client submits `POST /api/routes` with the same `logical_model`
+- THEN the response status MUST be `409 Conflict`
+- AND the response body MUST match the admin error response shape
+
+---
+
+### Requirement: Referenced resource deletion safeguards
+
+The system MUST fail closed when a delete operation would violate current resource references.
+
+At minimum, the following failure behavior MUST be defined:
+
+- deleting an account referenced by a pool membership MUST fail
+- deleting a pool referenced by a route target MUST fail
+- deleting a pool referenced by another pool's `fallback_pool_id` MUST fail
+- deleting a route referenced by another route's `fallback_route_id` MUST fail
+
+These failures MUST return `409 Conflict` and MUST use the standard admin error response shape.
+
+#### Scenario: delete account referenced by pool fails
+
+- GIVEN an account is a member of at least one pool
+- WHEN a client submits `DELETE /api/accounts/{account_id}`
+- THEN the response status MUST be `409 Conflict`
+- AND the account MUST remain unchanged
+
+#### Scenario: delete pool referenced by route fails
+
+- GIVEN a route targets a pool
+- WHEN a client submits `DELETE /api/pools/{pool_id}`
+- THEN the response status MUST be `409 Conflict`
+- AND the pool MUST remain unchanged
+
+#### Scenario: delete fallback route target fails
+
+- GIVEN route B references route A as `fallback_route_id`
+- WHEN a client submits `DELETE /api/routes/{route_a_id}`
+- THEN the response status MUST be `409 Conflict`
+- AND route A MUST remain unchanged
+
+---
+
+### Requirement: Health account list endpoint
+
+The system MUST expose `GET /api/health/accounts`.
+
+The response MUST be a JSON array of `HealthAccountView` records representing runtime health state
+ for known accounts.
+
+For M1, health data is runtime-scoped and in-memory only. It MUST reflect current process state and
+ MUST NOT imply durable historical health storage.
+
+When an account exists but has never been probed, its health status MUST be `"unknown"`.
+
+#### Scenario: health account list returns empty collection when no accounts exist
+
+- GIVEN no accounts exist
+- WHEN a client requests `GET /api/health/accounts`
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST equal `[]`
+
+#### Scenario: health account list reports unknown state for unprobed account
+
+- GIVEN an existing account with no health probes recorded in the current runtime
+- WHEN a client requests `GET /api/health/accounts`
+- THEN the corresponding item MUST include `status: "unknown"`
+- AND `last_checked` MUST be `null`
+
+#### Scenario: health account list reports healthy and unhealthy states
+
+- GIVEN one account has been marked healthy in runtime state
+- AND another account has been marked unhealthy in runtime state
+- WHEN a client requests `GET /api/health/accounts`
+- THEN the response MUST include one item with `status: "healthy"`
+- AND one item with `status: "unhealthy"`
+
+---
+
+### Requirement: Health summary endpoint
+
+The system MUST expose `GET /api/health/summary`.
+
+The response MUST be a `HealthSummaryView` object summarizing known account health state for the
+current runtime.
+
+The summary MUST include counts for `healthy`, `degraded`, `unhealthy`, `unknown`, and `total`.
+
+#### Scenario: health summary for empty system
+
+- GIVEN no accounts exist
+- WHEN a client requests `GET /api/health/summary`
+- THEN the response status MUST be `200 OK`
+- AND the body MUST report `total: 0`
+- AND all status counters MUST be `0`
+
+#### Scenario: health summary counts unknown and healthy states
+
+- GIVEN one existing account has never been probed
+- AND one existing account is healthy
+- WHEN a client requests `GET /api/health/summary`
+- THEN the body MUST report `unknown: 1`
+- AND `healthy: 1`
+- AND `total: 2`
+
+#### Scenario: health summary counts unhealthy states
+
+- GIVEN one existing account is unhealthy in runtime state
+- WHEN a client requests `GET /api/health/summary`
+- THEN the body MUST report `unhealthy: 1`
+- AND `total` MUST include that account
+
+---
+
+### Requirement: Settings endpoints and MVP update semantics
+
+The system MUST expose:
+
+- `GET /api/settings`
+- `PUT /api/settings`
+
+The system MUST NOT require `PATCH /api/settings` for M1.
+
+For M1, full replace-update semantics via `PUT /api/settings` are sufficient and SHALL be the only
+documented write contract. If `PATCH /api/settings` is not implemented, requests to that route MUST
+return `404 Not Found` or `405 Method Not Allowed`; it MUST NOT be part of the supported MVP
+contract.
+
+The settings endpoints MUST operate on the existing Rook settings service via `RookRegistry`.
+
+`GET /api/settings` MUST return persisted settings if present, otherwise defaults derived from the
+ current settings service.
+
+#### Scenario: settings read returns defaults before any save
+
+- GIVEN no settings have been persisted yet
+- WHEN a client requests `GET /api/settings`
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST equal the service default settings values
+
+#### Scenario: settings update persists replacement values
+
+- GIVEN the server is running
+- WHEN a client submits `PUT /api/settings` with a valid `UpdateSettingsRequest`
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST be the persisted `SettingsView`
+- AND a subsequent `GET /api/settings` MUST return the same values
+
+#### Scenario: patch settings is not part of MVP
+
+- GIVEN the M1 admin API contract
+- WHEN a client submits `PATCH /api/settings`
+- THEN the route MUST NOT be treated as a supported MVP requirement
+- AND clients MUST rely on `PUT /api/settings` for updates
+
+---
+
+### Requirement: Usage placeholder endpoint
+
+The system MUST expose `GET /api/usage`.
+
+Because no real usage or cost-accounting backend exists in M1, this endpoint MUST return a stable
+placeholder response using `UsageStatusView` with `available: false`.
+
+The endpoint MUST NOT invent fake usage totals or provider billing details.
+
+#### Scenario: usage placeholder response
+
+- GIVEN the M1 runtime with no backing usage subsystem
+- WHEN a client requests `GET /api/usage`
+- THEN the response status MUST be `200 OK`
+- AND the response body MUST equal the documented placeholder contract
+- AND `available` MUST be `false`
+
+---
+
+### Requirement: Admin error response contract
+
+All non-success admin API responses defined by this spec MUST use a consistent JSON error shape.
+
+The shape MUST distinguish at least:
+
+- not found failures
+- validation failures
+- conflict/reference failures
+- internal server failures
+
+#### Scenario: not found uses admin error response
+
+- GIVEN a request targets a nonexistent admin resource
+- WHEN the API returns an error
+- THEN the response body MUST match the admin error response shape
+- AND the HTTP status MUST be `404 Not Found`
+
+#### Scenario: conflict uses admin error response
+
+- GIVEN a delete operation fails because the resource is still referenced
+- WHEN the API returns an error
+- THEN the response body MUST match the admin error response shape
+- AND the HTTP status MUST be `409 Conflict`
+
+---
+
+### Requirement: Loopback-first and no-auth M1 safety posture
+
+This change MUST preserve the current M1 safety posture.
+
+The admin API defined here MUST NOT expand exposure beyond the existing loopback/local-admin
+assumption.
+
+Authentication and authorization are explicitly out of scope for this spec and belong to #591.
+
+The admin API contract MUST therefore be specified without bearer-token, pairing, or role-based
+authorization requirements.
+
+#### Scenario: admin API remains unauthenticated in M1 contract
+
+- GIVEN the M1 admin API defined by this spec
+- WHEN a client interacts with `/api/*`
+- THEN the contract MUST NOT require auth features from #591
+- AND the spec MUST continue to describe this surface as local-admin only
+
+---
+
+## Data Contracts
+
+### Identifier Rules
+
+- `id`, `account_id`, `pool_id`, `route_id`, `fallback_pool_id`, and `fallback_route_id` MUST be
+  serialized as UUID strings.
+- `vendor` MUST be serialized as the existing snake_case provider vendor string.
+- `strategy` MUST be serialized as the existing snake_case selection strategy string.
+- health `status` MUST be one of: `"healthy"`, `"degraded"`, `"unhealthy"`, `"unknown"`.
+
+---
+
+### `AccountView`
+
+```json
+{
+  "id": "uuid",
+  "vendor": "open_ai",
+  "display_name": "Primary OpenAI",
+  "api_base_override": null,
+  "has_api_key": true,
+  "enabled": true,
+  "weight": 1,
+  "priority": 0,
+  "tags": ["prod"],
+  "capabilities": ["chat", "vision"]
+}
+```
+
+Rules:
+
+- `api_key` MUST NOT appear.
+- `has_api_key` MUST be `true` when a key is stored and `false` otherwise.
+
+### `CreateAccountRequest`
+
+```json
+{
+  "vendor": "open_ai",
+  "display_name": "Primary OpenAI",
+  "api_base_override": null,
+  "api_key": "sk-secret",
+  "enabled": true,
+  "weight": 1,
+  "priority": 0,
+  "tags": ["prod"],
+  "capabilities": ["chat", "vision"]
+}
+```
+
+Rules:
+
+- `vendor` MUST be required.
+- `display_name` MUST be required.
+- `api_key` MAY be omitted or `null`.
+- `enabled`, `weight`, `priority`, `tags`, and `capabilities` MAY be omitted only if the service
+  defines defaults; if omitted, the returned `AccountView` MUST show the effective stored values.
+
+### `UpdateAccountRequest`
+
+```json
+{
+  "vendor": "open_ai",
+  "display_name": "Primary OpenAI Updated",
+  "api_base_override": "http://localhost:4000/v1",
+  "api_key": "sk-new-secret",
+  "enabled": true,
+  "weight": 2,
+  "priority": 1,
+  "tags": ["prod", "blue"],
+  "capabilities": ["chat"]
+}
+```
+
+Rules:
+
+- `PUT` semantics MUST be full replacement using the path `account_id` as the target identity.
+- The request body MUST NOT include `id`.
+- `api_key` remains write-only.
+
+---
+
+### `PoolView`
+
+```json
+{
+  "id": "uuid",
+  "name": "primary",
+  "strategy": "round_robin",
+  "members": ["account-uuid-1", "account-uuid-2"],
+  "fallback_pool_id": null
+}
+```
+
+### `CreatePoolRequest`
+
+```json
+{
+  "name": "primary",
+  "strategy": "round_robin",
+  "members": ["account-uuid-1"],
+  "fallback_pool_id": null
+}
+```
+
+Rules:
+
+- `name` MUST be required.
+- `strategy` MUST be required.
+- `members` MAY be omitted and default to `[]`.
+- every member id MUST refer to an existing account or the request MUST fail.
+
+### `UpdatePoolRequest`
+
+```json
+{
+  "name": "primary-updated",
+  "strategy": "priority",
+  "members": ["account-uuid-1", "account-uuid-2"],
+  "fallback_pool_id": "pool-uuid-2"
+}
+```
+
+Rules:
+
+- `PUT` semantics MUST be full replacement using the path `pool_id` as the target identity.
+- The request body MUST NOT include `id`.
+
+### `AddPoolMemberRequest`
+
+```json
+{
+  "account_id": "account-uuid-1"
+}
+```
+
+Rules:
+
+- `account_id` MUST be required.
+
+---
+
+### `RouteView`
+
+```json
+{
+  "id": "uuid",
+  "logical_model": "gpt-4o",
+  "target_pool_id": "pool-uuid-1",
+  "fallback_route_id": null,
+  "capability_constraints": ["chat"]
+}
+```
+
+### `CreateRouteRequest`
+
+```json
+{
+  "logical_model": "gpt-4o",
+  "target_pool_id": "pool-uuid-1",
+  "fallback_route_id": null,
+  "capability_constraints": ["chat"]
+}
+```
+
+Rules:
+
+- `logical_model` MUST be required.
+- `target_pool_id` MUST be required and MUST reference an existing pool.
+
+### `UpdateRouteRequest`
+
+```json
+{
+  "logical_model": "gpt-4o-mini",
+  "target_pool_id": "pool-uuid-2",
+  "fallback_route_id": "route-uuid-2",
+  "capability_constraints": ["chat", "vision"]
+}
+```
+
+Rules:
+
+- `PUT` semantics MUST be full replacement using the path `route_id` as the target identity.
+- The request body MUST NOT include `id`.
+
+---
+
+### `HealthAccountView`
+
+```json
+{
+  "account_id": "account-uuid-1",
+  "status": "unknown",
+  "last_checked": null,
+  "consecutive_failures": 0,
+  "cooldown_until": null
+}
+```
+
+Rules:
+
+- one item MUST correspond to one known account
+- `last_checked` and `cooldown_until` MUST be RFC 3339 timestamps when present
+
+### `HealthSummaryView`
+
+```json
+{
+  "total": 3,
+  "healthy": 1,
+  "degraded": 0,
+  "unhealthy": 1,
+  "unknown": 1
+}
+```
+
+Rules:
+
+- `total` MUST equal the sum of all four status counters
+
+---
+
+### `SettingsView`
+
+```json
+{
+  "gateway_port": 11434,
+  "default_routing_policy": {
+    "strategy": "priority",
+    "max_retries": 3,
+    "cooldown_seconds": 60
+  },
+  "log_json": false,
+  "log_level": "info"
+}
+```
+
+### `UpdateSettingsRequest`
+
+```json
+{
+  "gateway_port": 4141,
+  "default_routing_policy": {
+    "strategy": "round_robin",
+    "max_retries": 5,
+    "cooldown_seconds": 120
+  },
+  "log_json": true,
+  "log_level": "debug"
+}
+```
+
+Rules:
+
+- `PUT /api/settings` MUST accept the full settings object shape
+- `PATCH /api/settings` is intentionally excluded from the MVP contract
+
+---
+
+### `UsageStatusView` (placeholder)
+
+```json
+{
+  "available": false,
+  "reason": "usage accounting is not implemented in M1"
+}
+```
+
+Rules:
+
+- `available` MUST be `false` in M1
+- `reason` MUST be a human-readable explanation that usage accounting does not yet exist
+
+---
+
+### Admin error response shape
+
+```json
+{
+  "error": {
+    "code": "resource_in_use",
+    "message": "pool 123 cannot be deleted because it is referenced by one or more routes",
+    "details": {
+      "resource": "pool",
+      "id": "123"
+    }
+  }
+}
+```
+
+Rules:
+
+- top-level `error` object MUST exist
+- `error.code` MUST be a machine-readable string
+- `error.message` MUST be a human-readable string
+- `error.details` MAY be omitted; when present it MUST be a JSON object
+- error responses MUST NOT include secrets or raw `api_key` values
+
+Suggested error codes include:
+
+- `not_found`
+- `validation_error`
+- `resource_in_use`
+- `conflict`
+- `internal_error`
+
+---
+
+## Endpoint Summary
+
+### Supported in MVP
+
+- `GET /api/health`
+- `GET /api/health/accounts`
+- `GET /api/health/summary`
+- `GET /api/accounts`
+- `POST /api/accounts`
+- `GET /api/accounts/{account_id}`
+- `PUT /api/accounts/{account_id}`
+- `DELETE /api/accounts/{account_id}`
+- `GET /api/pools`
+- `POST /api/pools`
+- `GET /api/pools/{pool_id}`
+- `PUT /api/pools/{pool_id}`
+- `DELETE /api/pools/{pool_id}`
+- `POST /api/pools/{pool_id}/accounts`
+- `DELETE /api/pools/{pool_id}/accounts/{account_id}`
+- `GET /api/routes`
+- `POST /api/routes`
+- `GET /api/routes/{route_id}`
+- `PUT /api/routes/{route_id}`
+- `DELETE /api/routes/{route_id}`
+- `GET /api/settings`
+- `PUT /api/settings`
+- `GET /api/usage`
+
+### Explicitly not required for MVP
+
+- `PATCH /api/settings`
+
+---
+
+## Constraints
+
+- `api_key` MUST be write-only in requests and MUST never appear in responses.
+- Loopback/local-admin safety posture MUST remain unchanged; auth belongs to #591.
+- Usage is placeholder-only in M1 unless a real usage backend exists; it does not.
+- Health data is runtime-scoped and in-memory for M1; it MUST NOT be specified as durable history.
+- This spec defines HTTP behavior only; it MUST NOT require new business logic beyond composing the
+  existing `RookRegistry` services and enforcing transport-level contracts.

--- a/openspec/changes/rook-590-admin-api/spec.md
+++ b/openspec/changes/rook-590-admin-api/spec.md
@@ -748,17 +748,25 @@ Rules:
 ```json
 {
   "account_id": "account-uuid-1",
+  "display_name": "Primary OpenAI",
+  "vendor": "open_ai",
+  "enabled": true,
   "status": "unknown",
   "last_checked": null,
   "consecutive_failures": 0,
-  "cooldown_until": null
+  "cooldown_until": null,
+  "is_available": false
 }
 ```
 
 Rules:
 
 - one item MUST correspond to one known account
+- `display_name` MUST be a string
+- `vendor` MUST be a serialized provider vendor string
+- `enabled` MUST be a boolean
 - `last_checked` and `cooldown_until` MUST be RFC 3339 timestamps when present
+- `is_available` MUST be a boolean derived from current health/cooldown state
 
 ### `HealthSummaryView`
 
@@ -837,10 +845,10 @@ Rules:
 {
   "error": {
     "code": "resource_in_use",
-    "message": "pool 123 cannot be deleted because it is referenced by one or more routes",
+    "message": "pool 550e8400-e29b-41d4-a716-446655440000 cannot be deleted because it is referenced by one or more routes",
     "details": {
       "resource": "pool",
-      "id": "123"
+      "id": "550e8400-e29b-41d4-a716-446655440000"
     }
   }
 }

--- a/openspec/changes/rook-590-admin-api/state.yaml
+++ b/openspec/changes/rook-590-admin-api/state.yaml
@@ -1,0 +1,11 @@
+change: rook-590-admin-api
+current_phase: verify
+completed:
+  - propose
+  - spec
+  - design
+  - tasks
+  - apply
+  - verify
+next: archive
+updated: 2026-04-21

--- a/openspec/changes/rook-590-admin-api/tasks.md
+++ b/openspec/changes/rook-590-admin-api/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: Rook Admin API
+
+## Phase 1: Admin module scaffolding + shared DTO/error foundation
+
+- [x] **T1** — **Phase:** 1  **Title:** Scaffold admin module/router. **Desc:** Add `clients/rook/src/admin/{mod.rs,handlers.rs,types.rs}` and export from `clients/rook/src/lib.rs`; define `/api` route table with preserved `GET /health`, all MVP endpoints, and no supported `PATCH /settings`. **Files:** `clients/rook/src/admin/mod.rs`, `clients/rook/src/lib.rs`. **Tests first:** router mounts `/api/health`; `/api/settings` supports `GET`/`PUT`; `PATCH /api/settings` returns 404/405. **Accept:** route table exists, `/api/health` still returns `ok`, PATCH excluded explicitly. **Deps:** none.
+
+- [x] **T2** — **Phase:** 1  **Title:** Create redacted transport contracts and shared admin error shape. **Desc:** Define request/response DTOs, `AdminErrorBody`, and mapping helpers that never serialize `api_key` and always expose `has_api_key`. **Files:** `clients/rook/src/admin/types.rs`. **Tests first:** `AccountView` mapping omits `api_key`; placeholder usage JSON equals spec; error body shape matches spec. **Accept:** all DTOs compile conceptually from spec; `api_key` never appears in responses. **Deps:** T1.
+
+- [x] **T3** — **Phase:** 1  **Title:** Add shared handler error classification/validation helpers. **Desc:** Add bad-request/not-found/conflict/reference-conflict/internal-error mapping helpers for admin handlers using current `RookError::Registry` messages. **Files:** `clients/rook/src/admin/handlers.rs`. **Tests first:** known messages map to 404/409/500 and JSON error codes without leaking secrets. **Accept:** one reusable error mapper drives admin failures consistently. **Deps:** T2.
+
+## Phase 2: Read-only endpoints
+
+- [x] **T4** — **Phase:** 2  **Title:** Implement health + usage read endpoints. **Desc:** Add `GET /api/health`, `/api/health/accounts`, `/api/health/summary`, and placeholder `GET /api/usage` backed by registry health plus derived summary. **Files:** `clients/rook/src/admin/handlers.rs`, `clients/rook/src/admin/mod.rs`. **Tests first:** empty health lists/summaries, unknown/healthy/unhealthy derivation, usage returns `{available:false,...}`. **Accept:** health is runtime-derived; usage is placeholder-only. **Deps:** T3.
+
+- [x] **T5** — **Phase:** 2  **Title:** Implement accounts read endpoints. **Desc:** Add `GET /api/accounts` and `GET /api/accounts/:account_id` using redacted `AccountView`. **Files:** `clients/rook/src/admin/handlers.rs`. **Tests first:** empty list `[]`, get existing account, get unknown returns admin 404, list/get never expose `api_key`. **Accept:** read responses are redacted and spec-compliant. **Deps:** T3.
+
+- [x] **T6** — **Phase:** 2  **Title:** Implement pools/routes/settings read endpoints. **Desc:** Add `GET /api/pools`, `GET /api/pools/:pool_id`, `GET /api/routes`, `GET /api/routes/:route_id`, `GET /api/settings`. **Files:** `clients/rook/src/admin/handlers.rs`. **Tests first:** empty list cases, unknown resource 404s, settings defaults before save. **Accept:** all read-only MVP resources return spec shapes. **Deps:** T3.
+
+## Phase 3: Mutating account/pool/route/settings endpoints
+
+- [x] **T7** — **Phase:** 3  **Title:** Implement account create/update/delete. **Desc:** Add `POST/PUT/DELETE /api/accounts` handlers with write-only `api_key`, full-replacement PUT semantics, and safe delete mapping. **Files:** `clients/rook/src/admin/handlers.rs`. **Tests first:** create/update redact `api_key`; delete unreferenced account returns 204; blank/invalid payloads return 400. **Accept:** account mutations use registry and never echo credentials. **Deps:** T5.
+
+- [x] **T8** — **Phase:** 3  **Title:** Implement pool create/update/delete. **Desc:** Add `POST/PUT/DELETE /api/pools` handlers with full-replacement PUT and clear conflict mapping for FK/reference failures. **Files:** `clients/rook/src/admin/handlers.rs`. **Tests first:** create with members, update metadata, delete unreferenced pool 204, referenced pool 409. **Accept:** pool mutations are spec-compliant and service-backed. **Deps:** T6.
+
+- [x] **T9** — **Phase:** 3  **Title:** Implement route create/update/delete. **Desc:** Add `POST/PUT/DELETE /api/routes` handlers with duplicate-logical-model and bad-reference conflict mapping. **Files:** `clients/rook/src/admin/handlers.rs`. **Tests first:** create/update happy paths, duplicate logical model 409, delete unreferenced route 204. **Accept:** route mutation contract matches spec. **Deps:** T6.
+
+- [x] **T10** — **Phase:** 3  **Title:** Implement settings PUT as canonical MVP write path. **Desc:** Add `PUT /api/settings`; do not implement PATCH semantics beyond explicit unsupported behavior from T1. **Files:** `clients/rook/src/admin/handlers.rs`, `clients/rook/src/admin/mod.rs`. **Tests first:** PUT persists and round-trips via GET; invalid settings return 400; PATCH remains unsupported. **Accept:** `PUT /api/settings` is the only documented MVP mutation path. **Deps:** T6.
+
+## Phase 4: Pool membership endpoints
+
+- [x] **T11** — **Phase:** 4  **Title:** Implement add/remove pool member endpoints. **Desc:** Add `POST /api/pools/:pool_id/accounts` and `DELETE /api/pools/:pool_id/accounts/:account_id` returning updated `PoolView`. **Files:** `clients/rook/src/admin/handlers.rs`. **Tests first:** add happy path, add idempotent/no duplicates, add missing account fails, remove happy path, remove non-member returns chosen conflict/not-found semantics. **Accept:** membership endpoints are independently testable and documented. **Deps:** T8.
+
+## Phase 5: Server wiring + composition tests
+
+- [x] **T12** — **Phase:** 5  **Title:** Replace API stub with real admin router and composition coverage. **Desc:** Wire `server/mod.rs` to nest `crate::admin::build_router(registry.clone())` under `/api` while preserving `/v1` and dashboard routes. **Files:** `clients/rook/src/server/mod.rs`, `clients/rook/src/lib.rs`. **Tests first:** `/api/health` still returns `ok`, `/api/usage` placeholder works, `/v1/models` still works, dashboard root still serves. **Accept:** composed server hosts `/api`, `/v1`, and dashboard together. **Deps:** T1-T11.
+
+## Phase 6: Reference-integrity / deletion behavior hardening
+
+- [x] **T13** — **Phase:** 6  **Title:** Harden service/error semantics for stable admin deletion behavior. **Desc:** If current services blur not-found vs reference-conflict, make minimal targeted fixes in account/pool/route services so admin handlers can return deterministic 404/409 results. **Files:** `clients/rook/src/services/account.rs`, `clients/rook/src/services/pool.rs`, `clients/rook/src/services/route.rs`, `clients/rook/src/admin/handlers.rs`. **Tests first:** delete account referenced by pool 409, delete pool referenced by route/fallback pool 409, delete route referenced as fallback 409, unknown delete stays 404. **Accept:** reference integrity failures are fail-closed and stable across transport tests. **Deps:** T7-T11.

--- a/openspec/changes/rook-590-admin-api/verify-report.md
+++ b/openspec/changes/rook-590-admin-api/verify-report.md
@@ -1,0 +1,205 @@
+# Verify Report: rook-590-admin-api
+
+## status
+
+PASS WITH WARNINGS
+
+## executive_summary
+
+The Rook admin API implementation is functionally aligned with the proposal/spec/tasks for the M1
+scope: admin DTOs exist, responses redact `api_key`, read and write endpoints are implemented,
+pool membership endpoints are present, `/api/usage` returns the required placeholder contract, and
+server composition now mounts the real admin router under `/api` without breaking `/v1` or the
+dashboard routes.
+
+Behavioral verification is strong: the full `clients/rook` test suite passes, including targeted
+coverage for composition, redaction, CRUD, membership, and deletion/reference-integrity behavior.
+
+However, the verification gate is not completely clean because:
+
+- `cargo fmt --check` fails due to formatting drift in the Rook crate
+- `cargo clippy --all-targets -- -D warnings` fails on test-code lint issues
+
+So this change is not a FAIL on functional/spec correctness, but it is not a clean PASS either.
+
+## artifacts_reviewed
+
+- `openspec/changes/rook-590-admin-api/proposal.md`
+- `openspec/changes/rook-590-admin-api/spec.md`
+- `openspec/changes/rook-590-admin-api/design.md`
+- `openspec/changes/rook-590-admin-api/tasks.md`
+- `clients/rook/src/lib.rs`
+- `clients/rook/src/admin/mod.rs`
+- `clients/rook/src/admin/types.rs`
+- `clients/rook/src/admin/handlers.rs`
+- `clients/rook/src/server/mod.rs`
+- `clients/rook/src/services/account.rs`
+- `clients/rook/src/services/pool.rs`
+- `clients/rook/src/services/route.rs`
+- `clients/rook/src/db/account.rs`
+- `clients/rook/src/db/pool.rs`
+- `clients/rook/src/db/route.rs`
+- `clients/rook/src/db/mod.rs`
+- `clients/rook/src/dashboard/mod.rs`
+- `clients/rook/migrations/0001_initial.sql`
+
+## requirements_coverage
+
+### 1. admin module structure and DTOs
+
+Covered.
+
+- `clients/rook/src/admin/` contains `mod.rs`, `handlers.rs`, and `types.rs`
+- `clients/rook/src/lib.rs` exports `pub mod admin;`
+- DTOs/views present for accounts, pools, routes, health, settings, usage, requests, and admin
+  errors
+
+### 2. redaction behavior (`has_api_key`, never raw `api_key`)
+
+Covered.
+
+- `AccountView` exposes `has_api_key`
+- mapping from `ProviderAccount` never serializes raw `api_key`
+- targeted tests assert `api_key` absence in JSON
+
+### 3. read-only endpoints
+
+Covered.
+
+- `GET /api/health`
+- `GET /api/health/accounts`
+- `GET /api/health/summary`
+- `GET /api/accounts`
+- `GET /api/accounts/{account_id}`
+- `GET /api/pools`
+- `GET /api/pools/{pool_id}`
+- `GET /api/routes`
+- `GET /api/routes/{route_id}`
+- `GET /api/settings`
+- `GET /api/usage`
+
+Read endpoints are backed by `RookRegistry` and tested through the router.
+
+### 4. mutating endpoints
+
+Covered.
+
+- `POST/PUT/DELETE /api/accounts/{...}`
+- `POST/PUT/DELETE /api/pools/{...}`
+- `POST/PUT/DELETE /api/routes/{...}`
+- `PUT /api/settings`
+
+Handlers validate basics, map not-found/conflict/internal errors into admin error responses, and
+return redacted account payloads.
+
+### 5. pool membership endpoints
+
+Covered.
+
+- `POST /api/pools/{pool_id}/accounts`
+- `DELETE /api/pools/{pool_id}/accounts/{account_id}`
+
+Spec-aligned compensations were added in handlers:
+
+- missing account on add → `404 not_found`
+- remove non-member → `409 conflict`
+- add is idempotent and tested without relying on member ordering
+
+### 6. usage placeholder endpoint
+
+Covered.
+
+- returns `{ "available": false, "reason": "usage accounting is not implemented in M1" }`
+- composition test verifies it through `/api/usage`
+
+### 7. server composition under `/api` + coexistence with `/v1` and dashboard
+
+Covered.
+
+- `clients/rook/src/server/mod.rs` nests `admin::build_router(registry)` under `/api`
+- preserves `/v1` gateway router
+- preserves dashboard merge
+- tests prove `/api/health`, `/api/usage`, `/v1/models`, and `/` coexist
+
+### 8. integrity/deletion semantics
+
+Covered for the implemented M1 scope.
+
+Verified deterministic behavior for:
+
+- deleting account referenced by pool → `409 reference_conflict`
+- deleting pool referenced by route → `409 reference_conflict`
+- deleting pool referenced as fallback pool → `409 reference_conflict`
+- deleting route referenced as fallback route → `409 reference_conflict`
+- missing account/pool/route update/delete → `404 not_found`
+
+Minimal service/db hardening was added for cases that were previously permissive.
+
+### 9. testing evidence
+
+Strong behavioral evidence exists.
+
+- targeted admin DTO tests
+- targeted admin router tests for read/write/membership/integrity
+- targeted server composition tests
+- full Rook crate test suite passes
+
+## test_evidence
+
+### Executed
+
+1. `cargo test --manifest-path "clients/rook/Cargo.toml"`
+   - PASS
+   - 162 tests passed in `src/lib.rs`
+
+2. `cargo fmt --manifest-path "clients/rook/Cargo.toml" --all -- --check`
+   - FAIL
+   - formatting drift detected in Rook files
+
+3. `cargo clippy --manifest-path "clients/rook/Cargo.toml" --all-targets -- -D warnings`
+   - FAIL
+   - test-code warnings promoted to errors
+
+### Previously executed targeted evidence in apply slices
+
+- admin DTO redaction and placeholder tests
+- admin read-only router tests
+- admin mutation router tests
+- pool membership router tests
+- server composition tests
+- deletion/reference-integrity router tests
+
+## gaps_warnings
+
+1. **Formatting gate fails**
+   - `cargo fmt --check` is not clean
+
+2. **Clippy gate fails**
+   - examples from test code:
+     - `assert_eq!(..., true)` instead of `assert!(...)`
+     - field reassignment after `Default::default()` construction
+
+3. **Design-vs-implementation warning: malformed path IDs**
+   - Design says UUID parse failures should return admin `400 bad_request`
+   - Current implementation relies on axum extraction defaults for malformed path IDs
+   - This was not shown as a spec failure from the artifact reviewed here, but it is a design drift /
+     coverage gap worth noting
+
+4. **Error classification remains string-based**
+   - handler conflict/not-found mapping still depends on `RookError::Registry(String)` message
+   - acceptable for current scope, but brittle long-term
+
+## critical_issues
+
+None on functional/spec behavior.
+
+The implementation appears behaviorally complete for the scoped change, and the full Rook test
+suite passes. The remaining issues are quality-gate warnings, not evidence of broken feature
+behavior.
+
+## next_recommended
+
+1. Fix formatting drift with `cargo fmt`
+2. Fix clippy warnings in test code so `cargo clippy --all-targets -- -D warnings` passes cleanly
+3. Optionally add explicit malformed-ID admin error coverage if the team wants full design parity
+4. If those cleanup items are accepted, proceed to `sdd-archive`

--- a/openspec/changes/rook-590-admin-api/verify-report.md
+++ b/openspec/changes/rook-590-admin-api/verify-report.md
@@ -2,7 +2,7 @@
 
 ## status
 
-PASS WITH WARNINGS
+PASS
 
 ## executive_summary
 
@@ -15,12 +15,7 @@ dashboard routes.
 Behavioral verification is strong: the full `clients/rook` test suite passes, including targeted
 coverage for composition, redaction, CRUD, membership, and deletion/reference-integrity behavior.
 
-However, the verification gate is not completely clean because:
-
-- `cargo fmt --check` fails due to formatting drift in the Rook crate
-- `cargo clippy --all-targets -- -D warnings` fails on test-code lint issues
-
-So this change is not a FAIL on functional/spec correctness, but it is not a clean PASS either.
+The verification gate is now clean: formatting, clippy, and the full Rook test suite all pass.
 
 ## artifacts_reviewed
 
@@ -153,12 +148,10 @@ Strong behavioral evidence exists.
    - 162 tests passed in `src/lib.rs`
 
 2. `cargo fmt --manifest-path "clients/rook/Cargo.toml" --all -- --check`
-   - FAIL
-   - formatting drift detected in Rook files
+   - PASS
 
 3. `cargo clippy --manifest-path "clients/rook/Cargo.toml" --all-targets -- -D warnings`
-   - FAIL
-   - test-code warnings promoted to errors
+   - PASS
 
 ### Previously executed targeted evidence in apply slices
 


### PR DESCRIPTION
## Related Issues

closes #590

---

## Summary

- add a real `/api` admin surface for Rook backed by shared registry/services instead of internal-only management state
- expose read/write endpoints for accounts, pools, routes, pool membership, health summaries, settings, and a documented usage placeholder
- mount the admin router alongside the existing `/v1` gateway and dashboard routes while preserving redacted account responses (`has_api_key`, never raw `api_key`)

---

## Tested Information

- `cargo test --manifest-path "clients/rook/Cargo.toml"`
- `cargo fmt --manifest-path "clients/rook/Cargo.toml" --all -- --check`
- `cargo clippy --manifest-path "clients/rook/Cargo.toml" --all-targets -- -D warnings`
- SDD verify result for `rook-590-admin-api`: **PASS**

Reviewer focus:
- admin transport contracts and redaction behavior
- delete/reference-integrity semantics for accounts, pools, and routes
- server composition under `/api` + coexistence with `/v1` and dashboard

---

## Documentation Impact

- Docs updated in:
  - `openspec/changes/rook-590-admin-api/proposal.md`
  - `openspec/changes/rook-590-admin-api/spec.md`
  - `openspec/changes/rook-590-admin-api/design.md`
  - `openspec/changes/rook-590-admin-api/tasks.md`
  - `openspec/changes/rook-590-admin-api/verify-report.md`
- No docs update required because:
- I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
