### PR TITLE
feat(rook): harden gateway transport and chat delivery

### DIFF
--- a/clients/rook/Cargo.lock
+++ b/clients/rook/Cargo.lock
@@ -496,6 +496,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +526,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1264,6 +1276,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1283,12 +1296,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.7",
 ]
@@ -1317,12 +1332,15 @@ dependencies = [
  "chrono",
  "clap",
  "corvus-traits",
+ "futures-util",
  "http",
+ "ipnet",
  "mime_guess",
  "reqwest",
  "rust-embed",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "thiserror",
  "tokio",
@@ -2150,6 +2168,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/clients/rook/Cargo.toml
+++ b/clients/rook/Cargo.toml
@@ -24,8 +24,9 @@ tokio = { version = "1.42", default-features = false, features = ["rt-multi-thre
 
 # HTTP gateway
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio", "query"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 bytes = "1.0"
+futures-util = "0.3"
 
 # Serialization
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -47,6 +48,7 @@ sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-r
 
 # Time
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
+sha2 = "0.10"
 
 # Asset embedding
 rust-embed = { version = "8.5", features = ["mime-guess"] }
@@ -57,6 +59,7 @@ tower-http = { version = "0.6", default-features = false, features = ["fs", "tra
 
 # HTTP response helpers
 http = "1.0"
+ipnet = "2.10"
 
 # Shared runtime contracts (no internal corvus binary dependency)
 corvus-traits = { path = "../agent-runtime/crates/corvus-traits" }

--- a/clients/rook/migrations/0004_chat_completions_idempotency.sql
+++ b/clients/rook/migrations/0004_chat_completions_idempotency.sql
@@ -1,0 +1,19 @@
+CREATE TABLE chat_completion_idempotency (
+    principal_scope_id TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    http_method TEXT NOT NULL,
+    request_path TEXT NOT NULL,
+    request_hash TEXT NOT NULL,
+    canonical_request_body BLOB NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('in_progress', 'completed')),
+    response_status_code INTEGER,
+    response_content_type TEXT,
+    response_body BLOB,
+    started_at TEXT NOT NULL,
+    completed_at TEXT,
+    expires_at TEXT NOT NULL,
+    PRIMARY KEY (principal_scope_id, idempotency_key, http_method, request_path)
+);
+
+CREATE INDEX idx_chat_completion_idempotency_expires_at
+    ON chat_completion_idempotency(expires_at);

--- a/clients/rook/src/admin/types.rs
+++ b/clients/rook/src/admin/types.rs
@@ -3,6 +3,11 @@ use crate::domain::{
     RouteId, RoutingPolicy, SelectionStrategy,
 };
 use crate::services::health::{AccountHealth, HealthStatus};
+use axum::{
+    Json,
+    http::{HeaderValue, StatusCode, header::RETRY_AFTER, header::WWW_AUTHENTICATE},
+    response::{IntoResponse, Response},
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
@@ -295,9 +300,44 @@ pub struct AdminErrorBody {
     pub details: Option<Map<String, Value>>,
 }
 
+pub fn admin_unauthorized_response() -> Response {
+    let mut response = (
+        StatusCode::UNAUTHORIZED,
+        Json(AdminErrorResponse::new(
+            "unauthorized",
+            "valid inbound bearer token required",
+        )),
+    )
+        .into_response();
+    response
+        .headers_mut()
+        .insert(WWW_AUTHENTICATE, HeaderValue::from_static("Bearer"));
+    response
+}
+
+pub fn admin_rate_limited_response(retry_after_seconds: u64) -> Response {
+    let mut response = (
+        StatusCode::TOO_MANY_REQUESTS,
+        Json(AdminErrorResponse::new(
+            "rate_limited",
+            "global rate limit exceeded for /api surface",
+        )),
+    )
+        .into_response();
+    response.headers_mut().insert(
+        RETRY_AFTER,
+        HeaderValue::from_str(&retry_after_seconds.to_string())
+            .unwrap_or_else(|_| HeaderValue::from_static("1")),
+    );
+    response
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::to_bytes;
+    use axum::http::{header::WWW_AUTHENTICATE, StatusCode};
+    use axum::response::IntoResponse;
     use crate::domain::{
         AccountId, PoolId, ProviderAccount, ProviderPool, ProviderVendor, RookSettings, RouteId,
         RoutingPolicy, SelectionStrategy,
@@ -471,5 +511,34 @@ mod tests {
         assert_eq!(json["error"]["code"], json!("not_found"));
         assert_eq!(json["error"]["message"], json!("account missing"));
         assert_eq!(json["error"]["details"]["resource"], json!("account"));
+    }
+
+    #[tokio::test]
+    async fn admin_unauthorized_response_uses_admin_shape_and_bearer_header() {
+        let response = admin_unauthorized_response().into_response();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.headers()[WWW_AUTHENTICATE], "Bearer");
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"]["code"], json!("unauthorized"));
+        assert_eq!(json["error"]["message"], json!("valid inbound bearer token required"));
+    }
+
+    #[tokio::test]
+    async fn admin_rate_limited_response_uses_admin_shape_and_retry_after_header() {
+        let response = admin_rate_limited_response(17).into_response();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers()["retry-after"], "17");
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"]["code"], json!("rate_limited"));
+        assert_eq!(
+            json["error"]["message"],
+            json!("global rate limit exceeded for /api surface")
+        );
     }
 }

--- a/clients/rook/src/auth/bearer.rs
+++ b/clients/rook/src/auth/bearer.rs
@@ -1,0 +1,114 @@
+use axum::http::{header::AUTHORIZATION, HeaderMap};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BearerExtractionError {
+    Missing,
+    InvalidScheme,
+    EmptyToken,
+    Malformed,
+}
+
+pub fn extract_bearer_token(headers: &HeaderMap) -> Result<&str, BearerExtractionError> {
+    let mut values = headers.get_all(AUTHORIZATION).iter();
+    let value = values.next().ok_or(BearerExtractionError::Missing)?;
+    if values.next().is_some() {
+        return Err(BearerExtractionError::Malformed);
+    }
+
+    let raw = value.to_str().map_err(|_| BearerExtractionError::Malformed)?;
+    let mut parts = raw.split_whitespace();
+    let scheme = parts.next().ok_or(BearerExtractionError::Malformed)?;
+    if !scheme.eq_ignore_ascii_case("Bearer") {
+        return Err(BearerExtractionError::InvalidScheme);
+    }
+
+    let token = parts.next().ok_or(BearerExtractionError::EmptyToken)?;
+    if token.trim().is_empty() {
+        return Err(BearerExtractionError::EmptyToken);
+    }
+    if parts.next().is_some() {
+        return Err(BearerExtractionError::Malformed);
+    }
+
+    Ok(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_bearer_token;
+    use axum::http::{header::AUTHORIZATION, HeaderMap, HeaderValue};
+
+    #[test]
+    fn extract_bearer_token_rejects_missing_header() {
+        let headers = HeaderMap::new();
+
+        assert!(extract_bearer_token(&headers).is_err());
+    }
+
+    #[test]
+    fn extract_bearer_token_rejects_non_bearer_scheme() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Basic abc123"));
+
+        assert!(extract_bearer_token(&headers).is_err());
+    }
+
+    #[test]
+    fn extract_bearer_token_rejects_empty_token() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer   "));
+
+        assert!(extract_bearer_token(&headers).is_err());
+    }
+
+    #[test]
+    fn extract_bearer_token_accepts_valid_token() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer rook-inbound-secret"),
+        );
+
+        assert_eq!(extract_bearer_token(&headers).unwrap(), "rook-inbound-secret");
+    }
+
+    #[test]
+    fn extract_bearer_token_accepts_case_insensitive_scheme() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("bearer rook-inbound-secret"),
+        );
+
+        assert_eq!(extract_bearer_token(&headers).unwrap(), "rook-inbound-secret");
+    }
+
+    #[test]
+    fn extract_bearer_token_trims_surrounding_whitespace() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer   rook-inbound-secret   "),
+        );
+
+        assert_eq!(extract_bearer_token(&headers).unwrap(), "rook-inbound-secret");
+    }
+
+    #[test]
+    fn extract_bearer_token_rejects_ambiguous_or_malformed_values() {
+        let mut duplicate_headers = HeaderMap::new();
+        duplicate_headers.append(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer rook-inbound-secret"),
+        );
+        duplicate_headers.append(AUTHORIZATION, HeaderValue::from_static("Bearer second-token"));
+        assert!(extract_bearer_token(&duplicate_headers).is_err());
+
+        let mut malformed_headers = HeaderMap::new();
+        malformed_headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer rook-inbound-secret extra"),
+        );
+        assert!(extract_bearer_token(&malformed_headers).is_err());
+    }
+}

--- a/clients/rook/src/auth/middleware.rs
+++ b/clients/rook/src/auth/middleware.rs
@@ -1,0 +1,48 @@
+use axum::{
+    body::Body,
+    extract::State,
+    http::Request,
+    middleware::Next,
+    response::Response,
+};
+
+use crate::{
+    admin::types::admin_unauthorized_response,
+    auth::types::{AuthenticatedPrincipal, validate_inbound_request},
+    config::InboundAuthConfig,
+    gateway::types::gateway_unauthorized_response,
+};
+
+pub async fn admin_inbound_auth(
+    State(config): State<InboundAuthConfig>,
+    mut request: Request<Body>,
+    next: Next,
+) -> Response {
+    match validate_inbound_request(request.headers(), &config) {
+        Ok(()) => {
+            if let Ok(principal) = AuthenticatedPrincipal::from_inbound_auth(request.headers(), &config)
+            {
+                request.extensions_mut().insert(principal);
+            }
+            next.run(request).await
+        }
+        Err(_) => admin_unauthorized_response(),
+    }
+}
+
+pub async fn gateway_inbound_auth(
+    State(config): State<InboundAuthConfig>,
+    mut request: Request<Body>,
+    next: Next,
+) -> Response {
+    match validate_inbound_request(request.headers(), &config) {
+        Ok(()) => {
+            if let Ok(principal) = AuthenticatedPrincipal::from_inbound_auth(request.headers(), &config)
+            {
+                request.extensions_mut().insert(principal);
+            }
+            next.run(request).await
+        }
+        Err(_) => gateway_unauthorized_response(),
+    }
+}

--- a/clients/rook/src/auth/mod.rs
+++ b/clients/rook/src/auth/mod.rs
@@ -1,0 +1,3 @@
+pub mod bearer;
+pub mod middleware;
+pub mod types;

--- a/clients/rook/src/auth/types.rs
+++ b/clients/rook/src/auth/types.rs
@@ -1,0 +1,113 @@
+use axum::http::HeaderMap;
+
+use crate::auth::bearer::{extract_bearer_token, BearerExtractionError};
+use crate::config::InboundAuthConfig;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedPrincipal {
+    pub scope_id: String,
+}
+
+impl AuthenticatedPrincipal {
+    pub fn from_inbound_auth(
+        headers: &HeaderMap,
+        config: &InboundAuthConfig,
+    ) -> Result<Self, InboundAuthFailure> {
+        if !config.enabled {
+            return Ok(Self {
+                scope_id: "anonymous-local".to_string(),
+            });
+        }
+
+        validate_inbound_request(headers, config)?;
+        let token = extract_bearer_token(headers).map_err(|error| match error {
+            BearerExtractionError::Missing => InboundAuthFailure::Missing,
+            BearerExtractionError::InvalidScheme
+            | BearerExtractionError::EmptyToken
+            | BearerExtractionError::Malformed => InboundAuthFailure::Malformed,
+        })?;
+
+        Ok(Self {
+            scope_id: token.to_string(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InboundAuthFailure {
+    Missing,
+    Malformed,
+    Invalid,
+}
+
+pub fn validate_inbound_request(
+    headers: &HeaderMap,
+    config: &InboundAuthConfig,
+) -> Result<(), InboundAuthFailure> {
+    if !config.enabled {
+        return Ok(());
+    }
+
+    let expected = config
+        .bearer_token
+        .as_deref()
+        .filter(|token| !token.trim().is_empty())
+        .ok_or(InboundAuthFailure::Invalid)?;
+
+    match extract_bearer_token(headers) {
+        Ok(token) if token == expected => Ok(()),
+        Ok(_) => Err(InboundAuthFailure::Invalid),
+        Err(BearerExtractionError::Missing) => Err(InboundAuthFailure::Missing),
+        Err(BearerExtractionError::InvalidScheme)
+        | Err(BearerExtractionError::EmptyToken)
+        | Err(BearerExtractionError::Malformed) => Err(InboundAuthFailure::Malformed),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{HeaderMap, HeaderValue};
+
+    #[test]
+    fn authenticated_principal_uses_bearer_token_scope_when_auth_enabled() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer rook-secret"),
+        );
+        let config = InboundAuthConfig {
+            enabled: true,
+            bearer_token: Some("rook-secret".to_string()),
+        };
+
+        let principal = AuthenticatedPrincipal::from_inbound_auth(&headers, &config)
+            .expect("valid bearer token should produce a principal");
+
+        assert_eq!(
+            principal,
+            AuthenticatedPrincipal {
+                scope_id: "rook-secret".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn authenticated_principal_uses_local_scope_when_auth_disabled() {
+        let headers = HeaderMap::new();
+        let config = InboundAuthConfig {
+            enabled: false,
+            bearer_token: None,
+        };
+
+        let principal = AuthenticatedPrincipal::from_inbound_auth(&headers, &config)
+            .expect("disabled auth should use the local principal scope");
+
+        assert_eq!(
+            principal,
+            AuthenticatedPrincipal {
+                scope_id: "anonymous-local".to_string(),
+            }
+        );
+    }
+}

--- a/clients/rook/src/config/mod.rs
+++ b/clients/rook/src/config/mod.rs
@@ -8,3 +8,426 @@
 //! FIXME: implement `RookConfig` struct with gateway, registry, and TUI sections.
 //! FIXME: add env-var overrides (`ROOK_*` prefix).
 //! FIXME: add `rook config validate` to the CLI once struct is stable.
+
+use crate::domain::RookError;
+use axum::http::HeaderName;
+use ipnet::IpNet;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct InboundAuthConfig {
+    pub enabled: bool,
+    pub bearer_token: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChatCompletionsIdempotencyConfig {
+    pub enabled: bool,
+    pub replay_window_seconds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdempotencyConfig {
+    pub chat_completions: ChatCompletionsIdempotencyConfig,
+}
+
+impl Default for ChatCompletionsIdempotencyConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            replay_window_seconds: 86_400,
+        }
+    }
+}
+
+impl Default for IdempotencyConfig {
+    fn default() -> Self {
+        Self {
+            chat_completions: ChatCompletionsIdempotencyConfig::default(),
+        }
+    }
+}
+
+impl ChatCompletionsIdempotencyConfig {
+    pub fn validate(&self) -> Result<(), RookError> {
+        if self.replay_window_seconds == 0 {
+            return Err(RookError::Config(
+                "chat completions idempotency replay window must be greater than zero"
+                    .to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl IdempotencyConfig {
+    pub fn validate(&self) -> Result<(), RookError> {
+        self.chat_completions.validate()
+    }
+}
+
+impl InboundAuthConfig {
+    pub fn validate(&self) -> Result<(), RookError> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        let token = self.bearer_token.as_deref().ok_or_else(|| {
+            RookError::Config("inbound auth token is required when auth is enabled".to_string())
+        })?;
+
+        if token.trim().is_empty() {
+            return Err(RookError::Config(
+                "inbound auth token must not be blank when auth is enabled".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestIdConfig {
+    pub inbound_header_name: String,
+    pub response_header_name: String,
+    pub max_length: usize,
+}
+
+impl Default for RequestIdConfig {
+    fn default() -> Self {
+        Self {
+            inbound_header_name: "x-request-id".to_string(),
+            response_header_name: "x-request-id".to_string(),
+            max_length: 128,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TrustedForwardedHeaders {
+    pub forwarded: bool,
+    pub x_forwarded_for: bool,
+    pub x_forwarded_host: bool,
+    pub x_forwarded_proto: bool,
+    pub x_forwarded_port: bool,
+    pub x_real_ip: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TrustedProxyConfig {
+    pub enabled: bool,
+    pub trusted_cidrs: Vec<String>,
+    pub allowed_headers: TrustedForwardedHeaders,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TransportConfig {
+    pub request_id: RequestIdConfig,
+    pub trusted_proxy: TrustedProxyConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SurfaceRateLimitPolicy {
+    pub max_requests: u32,
+    pub window_seconds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RateLimitConfig {
+    pub api: SurfaceRateLimitPolicy,
+    pub v1_models: SurfaceRateLimitPolicy,
+    pub v1_chat_completions: SurfaceRateLimitPolicy,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            api: SurfaceRateLimitPolicy {
+                max_requests: 60,
+                window_seconds: 60,
+            },
+            v1_models: SurfaceRateLimitPolicy {
+                max_requests: 120,
+                window_seconds: 60,
+            },
+            v1_chat_completions: SurfaceRateLimitPolicy {
+                max_requests: 30,
+                window_seconds: 60,
+            },
+        }
+    }
+}
+
+impl RateLimitConfig {
+    pub fn validate(&self) -> Result<(), RookError> {
+        self.api.validate("/api/*")?;
+        self.v1_models.validate("/v1/models")?;
+        self.v1_chat_completions
+            .validate("/v1/chat/completions")?;
+        Ok(())
+    }
+}
+
+impl SurfaceRateLimitPolicy {
+    fn validate(&self, surface: &str) -> Result<(), RookError> {
+        if self.max_requests == 0 {
+            return Err(RookError::Config(format!(
+                "rate limit max_requests for {surface} must be greater than zero"
+            )));
+        }
+
+        if self.window_seconds == 0 {
+            return Err(RookError::Config(format!(
+                "rate limit window_seconds for {surface} must be greater than zero"
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+impl TransportConfig {
+    pub fn validate(&self) -> Result<(), RookError> {
+        if self.request_id.inbound_header_name.trim().is_empty() {
+            return Err(RookError::Config(
+                "request ID inbound header name must not be blank".to_string(),
+            ));
+        }
+
+        HeaderName::from_str(&self.request_id.inbound_header_name).map_err(|error| {
+            RookError::Config(format!(
+                "request ID inbound header name is invalid: {error}"
+            ))
+        })?;
+
+        if self.request_id.response_header_name.trim().is_empty() {
+            return Err(RookError::Config(
+                "request ID response header name must not be blank".to_string(),
+            ));
+        }
+
+        HeaderName::from_str(&self.request_id.response_header_name).map_err(|error| {
+            RookError::Config(format!(
+                "request ID response header name is invalid: {error}"
+            ))
+        })?;
+
+        if self.request_id.max_length == 0 {
+            return Err(RookError::Config(
+                "request ID max length must be greater than zero".to_string(),
+            ));
+        }
+
+        if !self.trusted_proxy.enabled {
+            return Ok(());
+        }
+
+        if self.trusted_proxy.trusted_cidrs.is_empty() {
+            return Err(RookError::Config(
+                "trusted proxy CIDR list must not be empty when trusted proxy is enabled"
+                    .to_string(),
+            ));
+        }
+
+        for cidr in &self.trusted_proxy.trusted_cidrs {
+            IpNet::from_str(cidr).map_err(|error| {
+                RookError::Config(format!("invalid trusted proxy CIDR '{cidr}': {error}"))
+            })?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ChatCompletionsIdempotencyConfig, IdempotencyConfig, InboundAuthConfig, RateLimitConfig, RequestIdConfig, SurfaceRateLimitPolicy, TransportConfig, TrustedForwardedHeaders, TrustedProxyConfig};
+    use serde_json::json;
+
+    fn policy(max_requests: u32, window_seconds: u64) -> SurfaceRateLimitPolicy {
+        SurfaceRateLimitPolicy {
+            max_requests,
+            window_seconds,
+        }
+    }
+
+    #[test]
+    fn inbound_auth_config_validate_rejects_enabled_missing_token() {
+        let config = InboundAuthConfig {
+            enabled: true,
+            bearer_token: None,
+        };
+
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn inbound_auth_config_validate_rejects_enabled_blank_token() {
+        let config = InboundAuthConfig {
+            enabled: true,
+            bearer_token: Some("   ".to_string()),
+        };
+
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn inbound_auth_config_validate_accepts_enabled_valid_token() {
+        let config = InboundAuthConfig {
+            enabled: true,
+            bearer_token: Some("rook-inbound-secret".to_string()),
+        };
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn inbound_auth_config_validate_allows_disabled_missing_token() {
+        let config = InboundAuthConfig {
+            enabled: false,
+            bearer_token: None,
+        };
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn idempotency_config_defaults_to_enabled_chat_replay_window() {
+        let config = IdempotencyConfig::default();
+
+        assert_eq!(
+            config.chat_completions,
+            ChatCompletionsIdempotencyConfig {
+                enabled: true,
+                replay_window_seconds: 86_400,
+            }
+        );
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn idempotency_config_rejects_zero_replay_window() {
+        let config = IdempotencyConfig {
+            chat_completions: ChatCompletionsIdempotencyConfig {
+                enabled: true,
+                replay_window_seconds: 0,
+            },
+        };
+
+        let error = config.validate().expect_err("zero replay window must fail validation");
+        assert!(error
+            .to_string()
+            .contains("replay window must be greater than zero"));
+    }
+
+    #[test]
+    fn transport_config_defaults_to_strict_request_id_and_disabled_proxy_trust() {
+        let config = TransportConfig::default();
+
+        assert_eq!(
+            config.request_id,
+            RequestIdConfig {
+                inbound_header_name: "x-request-id".to_string(),
+                response_header_name: "x-request-id".to_string(),
+                max_length: 128,
+            }
+        );
+        assert_eq!(
+            config.trusted_proxy,
+            TrustedProxyConfig {
+                enabled: false,
+                trusted_cidrs: vec![],
+                allowed_headers: TrustedForwardedHeaders::default(),
+            }
+        );
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn transport_config_validate_rejects_enabled_proxy_without_cidrs() {
+        let config = TransportConfig {
+            trusted_proxy: TrustedProxyConfig {
+                enabled: true,
+                trusted_cidrs: vec![],
+                allowed_headers: TrustedForwardedHeaders {
+                    x_forwarded_for: true,
+                    ..TrustedForwardedHeaders::default()
+                },
+            },
+            ..TransportConfig::default()
+        };
+
+        let error = config.validate().expect_err("proxy trust without cidrs must fail");
+        assert!(error.to_string().contains("trusted proxy CIDR list must not be empty"));
+    }
+
+    #[test]
+    fn transport_config_validate_rejects_invalid_trusted_proxy_cidr() {
+        let config = TransportConfig {
+            trusted_proxy: TrustedProxyConfig {
+                enabled: true,
+                trusted_cidrs: vec!["not-a-cidr".to_string()],
+                allowed_headers: TrustedForwardedHeaders {
+                    x_forwarded_for: true,
+                    ..TrustedForwardedHeaders::default()
+                },
+            },
+            ..TransportConfig::default()
+        };
+
+        let error = config.validate().expect_err("invalid cidr must fail closed");
+        assert!(error.to_string().contains("invalid trusted proxy CIDR"));
+    }
+
+    #[test]
+    fn rate_limit_config_validate_accepts_explicit_valid_surface_policies() {
+        let config = RateLimitConfig {
+            api: policy(60, 60),
+            v1_models: policy(120, 60),
+            v1_chat_completions: policy(30, 60),
+        };
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn rate_limit_config_deserialization_fails_closed_when_any_surface_is_missing() {
+        let error = serde_json::from_value::<RateLimitConfig>(json!({
+            "api": { "max_requests": 60, "window_seconds": 60 },
+            "v1_models": { "max_requests": 120, "window_seconds": 60 }
+        }))
+        .expect_err("missing chat surface must fail closed");
+
+        assert!(error.to_string().contains("v1_chat_completions"));
+    }
+
+    #[test]
+    fn rate_limit_config_validate_rejects_zero_or_malformed_surface_values() {
+        let zero_requests = RateLimitConfig {
+            api: policy(0, 60),
+            v1_models: policy(120, 60),
+            v1_chat_completions: policy(30, 60),
+        };
+        assert!(zero_requests.validate().is_err());
+
+        let zero_window = RateLimitConfig {
+            api: policy(60, 0),
+            v1_models: policy(120, 60),
+            v1_chat_completions: policy(30, 60),
+        };
+        assert!(zero_window.validate().is_err());
+
+        let malformed = serde_json::from_value::<RateLimitConfig>(json!({
+            "api": { "max_requests": "a-lot", "window_seconds": 60 },
+            "v1_models": { "max_requests": 120, "window_seconds": 60 },
+            "v1_chat_completions": { "max_requests": 30, "window_seconds": 60 }
+        }))
+        .expect_err("string max_requests must be rejected");
+        let message = malformed.to_string();
+        assert!(message.contains("max_requests") || message.contains("invalid type"));
+    }
+}

--- a/clients/rook/src/db/idempotency.rs
+++ b/clients/rook/src/db/idempotency.rs
@@ -1,0 +1,251 @@
+use chrono::{DateTime, Duration, Utc};
+use sqlx::Row;
+
+use crate::db::SqliteDb;
+use crate::domain::RookError;
+use crate::idempotency::types::{
+    ChatIdempotencyRecord, ChatIdempotencyScope, ChatIdempotencyStatus, ReserveResult,
+    StoredGatewayResponse,
+};
+
+fn status_to_db(status: &ChatIdempotencyStatus) -> &'static str {
+    match status {
+        ChatIdempotencyStatus::InProgress => "in_progress",
+        ChatIdempotencyStatus::Completed => "completed",
+    }
+}
+
+fn status_from_db(value: &str) -> Result<ChatIdempotencyStatus, RookError> {
+    match value {
+        "in_progress" => Ok(ChatIdempotencyStatus::InProgress),
+        "completed" => Ok(ChatIdempotencyStatus::Completed),
+        other => Err(RookError::Registry(format!(
+            "invalid idempotency status '{other}'"
+        ))),
+    }
+}
+
+fn row_to_record(row: &sqlx::sqlite::SqliteRow) -> Result<ChatIdempotencyRecord, RookError> {
+    let status: String = row
+        .try_get("status")
+        .map_err(|e| RookError::Registry(format!("missing idempotency status: {e}")))?;
+    let status = status_from_db(&status)?;
+    let response_status_code: Option<i64> = row
+        .try_get("response_status_code")
+        .map_err(|e| RookError::Registry(format!("missing response_status_code: {e}")))?;
+    let response = match status {
+        ChatIdempotencyStatus::Completed => Some(StoredGatewayResponse {
+            status_code: u16::try_from(response_status_code.ok_or_else(|| {
+                RookError::Registry("completed idempotency response missing status code".to_string())
+            })?)
+            .map_err(|_| RookError::Registry("response status code out of range".to_string()))?,
+            content_type: row
+                .try_get("response_content_type")
+                .map_err(|e| RookError::Registry(format!("missing response_content_type: {e}")))?,
+            body: row
+                .try_get("response_body")
+                .map_err(|e| RookError::Registry(format!("missing response_body: {e}")))?,
+        }),
+        ChatIdempotencyStatus::InProgress => None,
+    };
+
+    Ok(ChatIdempotencyRecord {
+        scope: ChatIdempotencyScope {
+            principal_scope_id: row
+                .try_get("principal_scope_id")
+                .map_err(|e| RookError::Registry(format!("missing principal_scope_id: {e}")))?,
+            idempotency_key: row
+                .try_get("idempotency_key")
+                .map_err(|e| RookError::Registry(format!("missing idempotency_key: {e}")))?,
+            method: row
+                .try_get("http_method")
+                .map_err(|e| RookError::Registry(format!("missing http_method: {e}")))?,
+            path: row
+                .try_get("request_path")
+                .map_err(|e| RookError::Registry(format!("missing request_path: {e}")))?,
+        },
+        request_hash: row
+            .try_get("request_hash")
+            .map_err(|e| RookError::Registry(format!("missing request_hash: {e}")))?,
+        canonical_request_body: row.try_get("canonical_request_body").map_err(|e| {
+            RookError::Registry(format!("missing canonical_request_body: {e}"))
+        })?,
+        status,
+        response,
+        started_at: row
+            .try_get::<String, _>("started_at")
+            .map_err(|e| RookError::Registry(format!("missing started_at: {e}")))?
+            .parse::<DateTime<Utc>>()
+            .map_err(|e| RookError::Registry(format!("invalid started_at: {e}")))?,
+        completed_at: row
+            .try_get::<Option<String>, _>("completed_at")
+            .map_err(|e| RookError::Registry(format!("missing completed_at: {e}")))?
+            .map(|value| value.parse::<DateTime<Utc>>())
+            .transpose()
+            .map_err(|e| RookError::Registry(format!("invalid completed_at: {e}")))?,
+        expires_at: row
+            .try_get::<String, _>("expires_at")
+            .map_err(|e| RookError::Registry(format!("missing expires_at: {e}")))?
+            .parse::<DateTime<Utc>>()
+            .map_err(|e| RookError::Registry(format!("invalid expires_at: {e}")))?,
+    })
+}
+
+impl SqliteDb {
+    pub async fn prune_expired_chat_completion_idempotency(
+        &self,
+        now: DateTime<Utc>,
+    ) -> Result<u64, RookError> {
+        let result = sqlx::query(
+            "DELETE FROM chat_completion_idempotency WHERE expires_at <= ?",
+        )
+        .bind(now.to_rfc3339())
+        .execute(self.pool())
+        .await
+        .map_err(|e| RookError::Registry(format!("prune idempotency records failed: {e}")))?;
+
+        Ok(result.rows_affected())
+    }
+
+    pub async fn get_chat_completion_idempotency(
+        &self,
+        scope: &ChatIdempotencyScope,
+    ) -> Result<Option<ChatIdempotencyRecord>, RookError> {
+        let row = sqlx::query(
+            "SELECT principal_scope_id, idempotency_key, http_method, request_path, request_hash, \
+                    canonical_request_body, status, response_status_code, response_content_type, \
+                    response_body, started_at, completed_at, expires_at \
+             FROM chat_completion_idempotency \
+             WHERE principal_scope_id = ? AND idempotency_key = ? AND http_method = ? AND request_path = ?",
+        )
+        .bind(&scope.principal_scope_id)
+        .bind(&scope.idempotency_key)
+        .bind(&scope.method)
+        .bind(&scope.path)
+        .fetch_optional(self.pool())
+        .await
+        .map_err(|e| RookError::Registry(format!("load idempotency record failed: {e}")))?;
+
+        row.map(|row| row_to_record(&row)).transpose()
+    }
+
+    pub async fn reserve_chat_completion_idempotency(
+        &self,
+        scope: &ChatIdempotencyScope,
+        canonical_request_body: &[u8],
+        request_hash: &str,
+        now: DateTime<Utc>,
+        replay_window: Duration,
+    ) -> Result<ReserveResult, RookError> {
+        let mut tx = self
+            .pool()
+            .begin()
+            .await
+            .map_err(|e| RookError::Registry(format!("begin idempotency reserve failed: {e}")))?;
+
+        sqlx::query(
+            "DELETE FROM chat_completion_idempotency WHERE expires_at <= ?",
+        )
+        .bind(now.to_rfc3339())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RookError::Registry(format!("prune during reserve failed: {e}")))?;
+
+        let existing = sqlx::query(
+            "SELECT principal_scope_id, idempotency_key, http_method, request_path, request_hash, \
+                    canonical_request_body, status, response_status_code, response_content_type, \
+                    response_body, started_at, completed_at, expires_at \
+             FROM chat_completion_idempotency \
+             WHERE principal_scope_id = ? AND idempotency_key = ? AND http_method = ? AND request_path = ?",
+        )
+        .bind(&scope.principal_scope_id)
+        .bind(&scope.idempotency_key)
+        .bind(&scope.method)
+        .bind(&scope.path)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| RookError::Registry(format!("load during reserve failed: {e}")))?;
+
+        let result = if let Some(row) = existing {
+            let record = row_to_record(&row)?;
+            if record.request_hash != request_hash {
+                ReserveResult::KeyReusedMismatch
+            } else {
+                match record.status {
+                    ChatIdempotencyStatus::InProgress => ReserveResult::ReplayInProgress,
+                    ChatIdempotencyStatus::Completed => {
+                        ReserveResult::ReplayCompleted(record.response.ok_or_else(|| {
+                            RookError::Registry(
+                                "completed idempotency record missing stored response".to_string(),
+                            )
+                        })?)
+                    }
+                }
+            }
+        } else {
+            let expires_at = (now + replay_window).to_rfc3339();
+            sqlx::query(
+                "INSERT INTO chat_completion_idempotency \
+                    (principal_scope_id, idempotency_key, http_method, request_path, request_hash, \
+                     canonical_request_body, status, started_at, completed_at, expires_at) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)",
+            )
+            .bind(&scope.principal_scope_id)
+            .bind(&scope.idempotency_key)
+            .bind(&scope.method)
+            .bind(&scope.path)
+            .bind(request_hash)
+            .bind(canonical_request_body)
+            .bind(status_to_db(&ChatIdempotencyStatus::InProgress))
+            .bind(now.to_rfc3339())
+            .bind(expires_at)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| RookError::Registry(format!("insert idempotency reserve failed: {e}")))?;
+            ReserveResult::ReservedNew
+        };
+
+        tx.commit()
+            .await
+            .map_err(|e| RookError::Registry(format!("commit idempotency reserve failed: {e}")))?;
+
+        Ok(result)
+    }
+
+    pub async fn complete_chat_completion_idempotency(
+        &self,
+        scope: &ChatIdempotencyScope,
+        request_hash: &str,
+        response: &StoredGatewayResponse,
+        completed_at: DateTime<Utc>,
+    ) -> Result<(), RookError> {
+        let result = sqlx::query(
+            "UPDATE chat_completion_idempotency \
+             SET status = ?, response_status_code = ?, response_content_type = ?, response_body = ?, \
+                 completed_at = ? \
+             WHERE principal_scope_id = ? AND idempotency_key = ? AND http_method = ? AND request_path = ? \
+               AND request_hash = ?",
+        )
+        .bind(status_to_db(&ChatIdempotencyStatus::Completed))
+        .bind(i64::from(response.status_code))
+        .bind(&response.content_type)
+        .bind(&response.body)
+        .bind(completed_at.to_rfc3339())
+        .bind(&scope.principal_scope_id)
+        .bind(&scope.idempotency_key)
+        .bind(&scope.method)
+        .bind(&scope.path)
+        .bind(request_hash)
+        .execute(self.pool())
+        .await
+        .map_err(|e| RookError::Registry(format!("complete idempotency record failed: {e}")))?;
+
+        if result.rows_affected() == 0 {
+            return Err(RookError::Registry(
+                "idempotency completion did not match an existing record".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/clients/rook/src/db/mod.rs
+++ b/clients/rook/src/db/mod.rs
@@ -6,6 +6,7 @@
 //! Sub-modules are split by domain entity to keep file sizes manageable.
 
 pub mod account;
+pub mod idempotency;
 pub mod pool;
 pub mod route;
 pub mod settings;
@@ -31,6 +32,11 @@ const MIGRATION_SQL_0002: &str = include_str!(concat!(
 const MIGRATION_SQL_0003: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/migrations/0003_account_api_key.sql"
+));
+
+const MIGRATION_SQL_0004: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/migrations/0004_chat_completions_idempotency.sql"
 ));
 
 /// A handle to the Rook SQLite database.
@@ -150,6 +156,21 @@ impl SqliteDb {
             apply_migration(pool, version_0003, MIGRATION_SQL_0003).await?;
         }
 
+        // ── Migration 0004: chat completions idempotency ─────────────────────
+        let version_0004 = "0004_chat_completions_idempotency";
+        let row_0004: Option<(String,)> =
+            sqlx::query_as("SELECT version FROM schema_migrations WHERE version = ?")
+                .bind(version_0004)
+                .fetch_optional(pool)
+                .await
+                .map_err(|e| {
+                    RookError::Registry(format!("failed to check migration 0004 status: {e}"))
+                })?;
+
+        if row_0004.is_none() {
+            apply_migration(pool, version_0004, MIGRATION_SQL_0004).await?;
+        }
+
         Ok(())
     }
 }
@@ -232,6 +253,44 @@ mod tests {
         assert_eq!(
             row.map(|(version,)| version),
             Some("0003_account_api_key".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn open_in_memory_applies_chat_completion_idempotency_migration() {
+        let db = SqliteDb::open_in_memory().await.unwrap();
+
+        let columns = sqlx::query("PRAGMA table_info(chat_completion_idempotency)")
+            .fetch_all(db.pool())
+            .await
+            .unwrap();
+
+        let has_request_hash = columns.iter().any(|row| {
+            row.try_get::<String, _>("name")
+                .map(|name| name == "request_hash")
+                .unwrap_or(false)
+        });
+
+        assert!(
+            has_request_hash,
+            "chat_completion_idempotency should include request_hash column"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_in_memory_records_chat_completion_idempotency_migration_version() {
+        let db = SqliteDb::open_in_memory().await.unwrap();
+
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT version FROM schema_migrations WHERE version = ?")
+                .bind("0004_chat_completions_idempotency")
+                .fetch_optional(db.pool())
+                .await
+                .unwrap();
+
+        assert_eq!(
+            row.map(|(version,)| version),
+            Some("0004_chat_completions_idempotency".to_string())
         );
     }
 }

--- a/clients/rook/src/gateway/handlers.rs
+++ b/clients/rook/src/gateway/handlers.rs
@@ -1,11 +1,13 @@
 use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::{header, HeaderValue, StatusCode};
-use axum::response::{IntoResponse, Response};
+use axum::response::{IntoResponse, Response, Sse};
 use axum::Json;
 
+use crate::gateway::streaming::upstream_event_stream;
 use crate::gateway::types::{
     ChatCompletionRequest, GatewayErrorBody, GatewayErrorResponse, ModelListResponse, ModelObject,
+    STREAM_CONTENT_TYPE,
 };
 use crate::gateway::upstream::{self, UpstreamError};
 use crate::gateway::GatewayState;
@@ -27,14 +29,17 @@ pub async fn handle_chat_completions(State(state): State<GatewayState>, body: By
     };
 
     if request.stream == Some(true) {
-        return error_response(
-            StatusCode::BAD_REQUEST,
-            "streaming is not yet supported; set stream: false or omit the field",
-            "invalid_request_error",
-            Some("unsupported_stream"),
-        );
+        return handle_streaming_chat_completions(&state, request, body).await;
     }
 
+    handle_buffered_chat_completions(&state, request, body).await
+}
+
+async fn handle_buffered_chat_completions(
+    state: &GatewayState,
+    request: ChatCompletionRequest,
+    body: Bytes,
+) -> Response {
     let decision = match state.engine.resolve(&request.model).await {
         Ok(decision) => decision,
         Err(error) => {
@@ -75,6 +80,54 @@ pub async fn handle_chat_completions(State(state): State<GatewayState>, body: By
         Err(error) => {
             let registry = state.registry.clone();
             let account_id = decision.account.id;
+            tokio::spawn(async move {
+                registry
+                    .health()
+                    .mark_failure(account_id, FAILURE_COOLDOWN_SECS)
+                    .await;
+            });
+            map_upstream_error(error)
+        }
+    }
+}
+
+async fn handle_streaming_chat_completions(
+    state: &GatewayState,
+    request: ChatCompletionRequest,
+    body: Bytes,
+) -> Response {
+    let decision = match state.engine.resolve(&request.model).await {
+        Ok(decision) => decision,
+        Err(error) => {
+            tracing::warn!(model = %request.model, error = %error, "routing failed");
+            return error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                &error.to_string(),
+                "server_error",
+                Some("model_not_found"),
+            );
+        }
+    };
+
+    let account_id = decision.account.id;
+    match upstream::open_chat_completion_stream(&state.client, &decision.account, body).await {
+        Ok(upstream_response) => {
+            let registry = state.registry.clone();
+            tokio::spawn(async move {
+                registry.health().mark_success(account_id).await;
+            });
+
+            let stream = upstream_event_stream(upstream_response.response.bytes_stream());
+            let mut response = Sse::new(stream).into_response();
+            *response.status_mut() = StatusCode::OK;
+            response.headers_mut().insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static(STREAM_CONTENT_TYPE),
+            );
+            response
+        }
+        Err(error) => {
+            let registry = state.registry.clone();
             tokio::spawn(async move {
                 registry
                     .health()
@@ -176,6 +229,7 @@ mod tests {
         SelectionStrategy,
     };
     use crate::gateway::{build_router, GatewayState};
+    use crate::gateway::types::STREAM_CONTENT_TYPE;
     use crate::registry::RookRegistry;
     use crate::routing::RoutingEngine;
     use crate::services::{
@@ -389,8 +443,74 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn chat_completions_stream_true_returns_400() {
-        let (app, _) = test_app().await;
+    async fn chat_completions_stream_false_stays_on_buffered_json_path() {
+        let (_server, upstream) = mock_upstream(StatusCode::OK, json!({"id":"chatcmpl-buffered"})).await;
+        let (app, registry) = test_app().await;
+        seed_route(
+            &registry,
+            "gpt-4o",
+            ProviderVendor::OpenAi,
+            Some(upstream),
+            Some("sk-test".to_string()),
+        )
+        .await;
+
+        let response = app
+            .oneshot(
+                Request::post("/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "model":"gpt-4o",
+                            "stream": false,
+                            "messages":[{"role":"user","content":"Hello"}]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json = serde_json::from_slice::<Value>(&body).unwrap();
+        assert_eq!(json, json!({"id":"chatcmpl-buffered"}));
+    }
+
+    #[tokio::test]
+    async fn chat_completions_stream_true_returns_sse_chunks_and_done() {
+        use axum::http::header::CONTENT_TYPE;
+        use axum::routing::post;
+        use axum::{response::IntoResponse, Router};
+        use tokio::net::TcpListener;
+
+        async fn sse_handler() -> impl IntoResponse {
+            (
+                [(CONTENT_TYPE, "text/event-stream")],
+                Body::from(
+                    "data: {\"id\":\"chunk-1\"}\n\n\
+                     data: {\"id\":\"chunk-2\"}\n\n\
+                     data: [DONE]\n\n",
+                ),
+            )
+        }
+
+        let upstream = Router::new().route("/v1/chat/completions", post(sse_handler));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move { axum::serve(listener, upstream).await.unwrap() });
+
+        let (app, registry) = test_app().await;
+        seed_route(
+            &registry,
+            "gpt-4o",
+            ProviderVendor::OpenAi,
+            Some(format!("http://{addr}")),
+            Some("sk-test".to_string()),
+        )
+        .await;
+
         let response = app
             .oneshot(
                 Request::post("/chat/completions")
@@ -408,10 +528,81 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some(STREAM_CONTENT_TYPE)
+        );
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let json = serde_json::from_slice::<Value>(&body).unwrap();
-        assert_eq!(json["error"]["code"], json!("unsupported_stream"));
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("data: {\"id\":\"chunk-1\"}"));
+        assert!(text.contains("data: {\"id\":\"chunk-2\"}"));
+        assert_eq!(text.matches("data: [DONE]").count(), 1);
+    }
+
+    #[tokio::test]
+    async fn chat_completions_stream_true_midstream_abort_does_not_emit_done() {
+        use axum::http::header::CONTENT_TYPE;
+        use axum::routing::post;
+        use axum::{response::IntoResponse, Router};
+        use bytes::Bytes;
+        use futures_util::stream;
+        use tokio::net::TcpListener;
+
+        async fn malformed_sse_handler() -> impl IntoResponse {
+            (
+                [(CONTENT_TYPE, "text/event-stream")],
+                Body::from_stream(stream::iter(vec![
+                    Ok::<Bytes, std::convert::Infallible>(Bytes::from_static(
+                        b"data: {\"id\":\"chunk-1\"}\n\n",
+                    )),
+                    Ok::<Bytes, std::convert::Infallible>(Bytes::from_static(
+                        b"event: broken\n\n",
+                    )),
+                ])),
+            )
+        }
+
+        let upstream = Router::new().route("/v1/chat/completions", post(malformed_sse_handler));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move { axum::serve(listener, upstream).await.unwrap() });
+
+        let (app, registry) = test_app().await;
+        seed_route(
+            &registry,
+            "gpt-4o",
+            ProviderVendor::OpenAi,
+            Some(format!("http://{addr}")),
+            Some("sk-test".to_string()),
+        )
+        .await;
+
+        let response = app
+            .oneshot(
+                Request::post("/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "model":"gpt-4o",
+                            "stream": true,
+                            "messages":[{"role":"user","content":"Hello"}]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("data: {\"id\":\"chunk-1\"}"));
+        assert!(!text.contains("data: [DONE]"));
     }
 
     #[tokio::test]

--- a/clients/rook/src/gateway/mod.rs
+++ b/clients/rook/src/gateway/mod.rs
@@ -11,6 +11,7 @@
 //! the listener bound to loopback by default before any external exposure.
 
 pub mod handlers;
+pub mod streaming;
 pub mod types;
 pub mod upstream;
 pub mod vendor;
@@ -33,8 +34,17 @@ pub struct GatewayState {
 
 pub fn build_router(state: GatewayState) -> Router {
     Router::new()
-        .route("/chat/completions", post(handlers::handle_chat_completions))
-        .route("/models", get(handlers::handle_list_models))
+        .merge(build_models_router(state.clone()))
+        .merge(build_chat_router(state))
         .layer(DefaultBodyLimit::max(1024 * 1024))
+}
+
+pub fn build_models_router(state: GatewayState) -> Router {
+    Router::new().route("/models", get(handlers::handle_list_models)).with_state(state)
+}
+
+pub fn build_chat_router(state: GatewayState) -> Router {
+    Router::new()
+        .route("/chat/completions", post(handlers::handle_chat_completions))
         .with_state(state)
 }

--- a/clients/rook/src/gateway/streaming.rs
+++ b/clients/rook/src/gateway/streaming.rs
@@ -1,0 +1,213 @@
+use bytes::Bytes;
+use futures_util::stream;
+use futures_util::{Stream, StreamExt};
+use std::collections::VecDeque;
+use std::convert::Infallible;
+
+use crate::gateway::types::STREAM_DONE_SENTINEL;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum OpenAiSseParseError {
+    MalformedFrame { frame: String },
+    DuplicateDoneSentinel,
+}
+
+#[derive(Default)]
+pub struct OpenAiSseParser {
+    buffer: Vec<u8>,
+    seen_done: bool,
+}
+
+impl OpenAiSseParser {
+    pub fn push(&mut self, chunk: &Bytes) -> Result<Vec<String>, OpenAiSseParseError> {
+        self.buffer.extend_from_slice(chunk);
+        let mut events = Vec::new();
+
+        while let Some(boundary) = self
+            .buffer
+            .windows(2)
+            .position(|window| window == b"\n\n")
+        {
+            let frame = self.buffer.drain(..boundary + 2).collect::<Vec<u8>>();
+            let frame = String::from_utf8_lossy(&frame[..frame.len() - 2]).to_string();
+            if frame.trim().is_empty() {
+                continue;
+            }
+
+            let payload = parse_frame(&frame)?;
+            if payload == STREAM_DONE_SENTINEL {
+                if self.seen_done {
+                    return Err(OpenAiSseParseError::DuplicateDoneSentinel);
+                }
+                self.seen_done = true;
+            }
+            events.push(payload);
+        }
+
+        Ok(events)
+    }
+}
+
+fn parse_frame(frame: &str) -> Result<String, OpenAiSseParseError> {
+    let mut data_lines = Vec::new();
+
+    for line in frame.lines() {
+        if let Some(payload) = line.strip_prefix("data: ") {
+            data_lines.push(payload.to_string());
+        } else {
+            return Err(OpenAiSseParseError::MalformedFrame {
+                frame: frame.to_string(),
+            });
+        }
+    }
+
+    if data_lines.is_empty() {
+        return Err(OpenAiSseParseError::MalformedFrame {
+            frame: frame.to_string(),
+        });
+    }
+
+    Ok(data_lines.join("\n"))
+}
+
+pub fn normalize_openai_sse_bytes(body: &[u8]) -> (String, bool) {
+    let text = String::from_utf8_lossy(body);
+    let mut rendered = String::new();
+    let mut seen_done = false;
+
+    for frame in text.split("\n\n") {
+        let trimmed = frame.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let payload = match parse_frame(trimmed) {
+            Ok(payload) => payload,
+            Err(_) => return (rendered, false),
+        };
+
+        if payload == STREAM_DONE_SENTINEL {
+            if seen_done {
+                return (rendered, false);
+            }
+            seen_done = true;
+            rendered.push_str("data: ");
+            rendered.push_str(STREAM_DONE_SENTINEL);
+            rendered.push_str("\n\n");
+            break;
+        }
+
+        rendered.push_str("data: ");
+        rendered.push_str(&payload);
+        rendered.push_str("\n\n");
+    }
+
+    (rendered, seen_done)
+}
+
+pub fn text_event_stream(body: String) -> impl Stream<Item = Result<axum::response::sse::Event, std::convert::Infallible>> {
+    let events = body
+        .split("\n\n")
+        .filter_map(|frame| {
+            let payload = frame.strip_prefix("data: ")?;
+            Some(Ok(axum::response::sse::Event::default().data(payload)))
+        })
+        .collect::<Vec<_>>();
+    stream::iter(events)
+}
+
+pub fn upstream_event_stream<S, E>(upstream: S) -> impl Stream<Item = Result<axum::response::sse::Event, Infallible>>
+where
+    S: Stream<Item = Result<Bytes, E>> + Unpin,
+{
+    stream::unfold(
+        (
+            OpenAiSseParser::default(),
+            upstream,
+            VecDeque::<String>::new(),
+            false,
+        ),
+        |(mut parser, mut upstream, mut pending, terminated)| async move {
+            if terminated {
+                return None;
+            }
+
+            loop {
+                if let Some(payload) = pending.pop_front() {
+                    let is_done = payload == STREAM_DONE_SENTINEL;
+                    let event = axum::response::sse::Event::default().data(payload);
+                    return Some((Ok(event), (parser, upstream, pending, is_done)));
+                }
+
+                match upstream.next().await {
+                    Some(Ok(chunk)) => match parser.push(&chunk) {
+                        Ok(payloads) => {
+                            pending.extend(payloads);
+                        }
+                        Err(_) => return None,
+                    },
+                    Some(Err(_)) | None => return None,
+                }
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::{OpenAiSseParseError, OpenAiSseParser};
+
+    #[test]
+    fn parser_reconstructs_ordered_events_across_split_boundaries() {
+        let mut parser = OpenAiSseParser::default();
+
+        let first = parser
+            .push(&Bytes::from_static(b"data: {\"id\":\"chunk-1\"}"))
+            .unwrap();
+        assert!(first.is_empty());
+
+        let second = parser
+            .push(&Bytes::from_static(
+                b"\n\ndata: {\"id\":\"chunk-2\"}\n\ndata: [DONE]\n\n",
+            ))
+            .unwrap();
+
+        assert_eq!(
+            second,
+            vec![
+                "{\"id\":\"chunk-1\"}".to_string(),
+                "{\"id\":\"chunk-2\"}".to_string(),
+                "[DONE]".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn parser_rejects_malformed_frames() {
+        let mut parser = OpenAiSseParser::default();
+
+        let error = parser
+            .push(&Bytes::from_static(b"event: message\n\n"))
+            .unwrap_err();
+
+        assert!(matches!(error, OpenAiSseParseError::MalformedFrame { .. }));
+    }
+
+    #[test]
+    fn parser_allows_done_once_and_rejects_duplicates() {
+        let mut parser = OpenAiSseParser::default();
+
+        let first = parser
+            .push(&Bytes::from_static(b"data: [DONE]\n\n"))
+            .unwrap();
+        assert_eq!(first, vec!["[DONE]".to_string()]);
+
+        let error = parser
+            .push(&Bytes::from_static(b"data: [DONE]\n\n"))
+            .unwrap_err();
+
+        assert!(matches!(error, OpenAiSseParseError::DuplicateDoneSentinel));
+    }
+}

--- a/clients/rook/src/gateway/types.rs
+++ b/clients/rook/src/gateway/types.rs
@@ -1,6 +1,15 @@
 use std::collections::BTreeMap;
 
+use axum::{
+    Json,
+    http::{HeaderValue, StatusCode, header::RETRY_AFTER, header::WWW_AUTHENTICATE},
+    response::{IntoResponse, Response},
+};
 use serde::{Deserialize, Serialize};
+
+pub const IDEMPOTENCY_REPLAYED_HEADER: &str = "idempotency-replayed";
+pub const STREAM_CONTENT_TYPE: &str = "text/event-stream";
+pub const STREAM_DONE_SENTINEL: &str = "[DONE]";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -89,10 +98,116 @@ pub struct GatewayErrorBody {
     pub code: Option<String>,
 }
 
+pub fn gateway_unauthorized_response() -> Response {
+    let mut response = (
+        StatusCode::UNAUTHORIZED,
+        Json(GatewayErrorResponse {
+            error: GatewayErrorBody {
+                message: "valid inbound bearer token required".to_string(),
+                error_type: "invalid_request_error".to_string(),
+                code: Some("unauthorized".to_string()),
+            },
+        }),
+    )
+        .into_response();
+    response
+        .headers_mut()
+        .insert(WWW_AUTHENTICATE, HeaderValue::from_static("Bearer"));
+    response
+}
+
+pub fn gateway_rate_limited_response(retry_after_seconds: u64) -> Response {
+    let mut response = (
+        StatusCode::TOO_MANY_REQUESTS,
+        Json(GatewayErrorResponse {
+            error: GatewayErrorBody {
+                message: "global rate limit exceeded for this endpoint".to_string(),
+                error_type: "rate_limit_error".to_string(),
+                code: Some("rate_limited".to_string()),
+            },
+        }),
+    )
+        .into_response();
+    response.headers_mut().insert(
+        RETRY_AFTER,
+        HeaderValue::from_str(&retry_after_seconds.to_string())
+            .unwrap_or_else(|_| HeaderValue::from_static("1")),
+    );
+    response
+}
+
+pub fn gateway_idempotency_error_response(
+    status: StatusCode,
+    message: &str,
+    code: &str,
+) -> Response {
+    (
+        status,
+        Json(GatewayErrorResponse {
+            error: GatewayErrorBody {
+                message: message.to_string(),
+                error_type: if status == StatusCode::SERVICE_UNAVAILABLE {
+                    "server_error".to_string()
+                } else {
+                    "invalid_request_error".to_string()
+                },
+                code: Some(code.to_string()),
+            },
+        }),
+    )
+        .into_response()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::to_bytes;
+    use axum::http::{header::WWW_AUTHENTICATE, StatusCode};
     use serde_json::json;
+
+    #[test]
+    fn idempotency_helpers_expose_replay_header_constant() {
+        assert_eq!(IDEMPOTENCY_REPLAYED_HEADER, "idempotency-replayed");
+    }
+
+    #[test]
+    fn streaming_helpers_expose_openai_sse_constants() {
+        assert_eq!(STREAM_CONTENT_TYPE, "text/event-stream");
+        assert_eq!(STREAM_DONE_SENTINEL, "[DONE]");
+    }
+
+    #[tokio::test]
+    async fn gateway_idempotency_error_response_uses_gateway_error_shape() {
+        let response = gateway_idempotency_error_response(
+            StatusCode::CONFLICT,
+            "request is already in progress",
+            "idempotency_request_in_progress",
+        );
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["error"]["type"], json!("invalid_request_error"));
+        assert_eq!(
+            json["error"]["code"],
+            json!("idempotency_request_in_progress")
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_idempotency_unavailable_response_uses_server_error_shape() {
+        let response = gateway_idempotency_error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "idempotency storage unavailable",
+            "idempotency_unavailable",
+        );
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["error"]["type"], json!("server_error"));
+        assert_eq!(json["error"]["code"], json!("idempotency_unavailable"));
+    }
 
     #[test]
     fn chat_completion_request_deserializes_minimal_payload() {
@@ -284,5 +399,36 @@ mod tests {
         );
         assert_eq!(json["error"]["type"], json!("server_error"));
         assert_eq!(json["error"]["code"], json!("model_not_found"));
+    }
+
+    #[tokio::test]
+    async fn gateway_unauthorized_response_uses_gateway_shape_and_bearer_header() {
+        let response = gateway_unauthorized_response();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.headers()[WWW_AUTHENTICATE], "Bearer");
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"]["type"], json!("invalid_request_error"));
+        assert_eq!(json["error"]["code"], json!("unauthorized"));
+        assert_eq!(json["error"]["message"], json!("valid inbound bearer token required"));
+    }
+
+    #[tokio::test]
+    async fn gateway_rate_limited_response_uses_gateway_shape_and_retry_after_header() {
+        let response = gateway_rate_limited_response(11);
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers()["retry-after"], "11");
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"]["type"], json!("rate_limit_error"));
+        assert_eq!(json["error"]["code"], json!("rate_limited"));
+        assert_eq!(
+            json["error"]["message"],
+            json!("global rate limit exceeded for this endpoint")
+        );
     }
 }

--- a/clients/rook/src/gateway/upstream.rs
+++ b/clients/rook/src/gateway/upstream.rs
@@ -13,6 +13,13 @@ pub struct UpstreamResponse {
 }
 
 #[derive(Debug)]
+pub struct UpstreamStreamingResponse {
+    pub status: StatusCode,
+    pub content_type: Option<String>,
+    pub response: reqwest::Response,
+}
+
+#[derive(Debug)]
 pub enum UpstreamError {
     MissingBaseUrl {
         account_id: String,
@@ -37,48 +44,46 @@ pub enum UpstreamError {
     },
 }
 
+pub async fn open_chat_completion_stream(
+    client: &reqwest::Client,
+    account: &ProviderAccount,
+    raw_body: Bytes,
+) -> Result<UpstreamStreamingResponse, UpstreamError> {
+    let response = send_chat_completion_request(client, account, raw_body).await?;
+    let status = response.status();
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+
+    if !status.is_success() {
+        let body = response
+            .bytes()
+            .await
+            .map_err(|error| UpstreamError::ReadBody {
+                message: format!("failed to read upstream response body: {error}"),
+            })?;
+        return Err(UpstreamError::UpstreamStatus {
+            status,
+            body,
+            content_type,
+        });
+    }
+
+    Ok(UpstreamStreamingResponse {
+        status,
+        content_type,
+        response,
+    })
+}
+
 pub async fn proxy_chat_completion(
     client: &reqwest::Client,
     account: &ProviderAccount,
     raw_body: Bytes,
 ) -> Result<UpstreamResponse, UpstreamError> {
-    let base =
-        vendor::effective_base_url(account).ok_or_else(|| UpstreamError::MissingBaseUrl {
-            account_id: account.id.to_string(),
-            vendor: format!("{:?}", account.vendor),
-        })?;
-    let url = format!("{base}/v1/chat/completions");
-
-    let mut request = client
-        .post(&url)
-        .header("content-type", "application/json")
-        .body(raw_body);
-
-    if let Some(api_key) = account.api_key.as_deref() {
-        let (header_name, header_value) = vendor::auth_header(&account.vendor, api_key)
-            .ok_or_else(|| UpstreamError::MissingAuthHeader {
-                vendor: format!("{:?}", account.vendor),
-            })?;
-        request = request.header(header_name, &header_value);
-    } else {
-        warn!(
-            account_id = %account.id,
-            vendor = ?account.vendor,
-            "proxying upstream request without API credentials"
-        );
-    }
-
-    let response = request.send().await.map_err(|error| {
-        if error.is_timeout() {
-            UpstreamError::Timeout {
-                message: format!("upstream request to {url} timed out: {error}"),
-            }
-        } else {
-            UpstreamError::Transport {
-                message: format!("upstream request to {url} failed: {error}"),
-            }
-        }
-    })?;
+    let response = send_chat_completion_request(client, account, raw_body).await?;
 
     let status = response.status();
     let content_type = response
@@ -106,6 +111,56 @@ pub async fn proxy_chat_completion(
         status,
         body,
         content_type,
+    })
+}
+
+async fn send_chat_completion_request(
+    client: &reqwest::Client,
+    account: &ProviderAccount,
+    raw_body: Bytes,
+) -> Result<reqwest::Response, UpstreamError> {
+    let base =
+        vendor::effective_base_url(account).ok_or_else(|| UpstreamError::MissingBaseUrl {
+            account_id: account.id.to_string(),
+            vendor: format!("{:?}", account.vendor),
+        })?;
+    let url = format!("{base}/v1/chat/completions");
+
+    let mut request = client
+        .post(&url)
+        .header("content-type", "application/json")
+        .body(raw_body);
+
+    if let Some(api_key) = account.api_key.as_deref() {
+        if api_key.trim().is_empty() {
+            return Err(UpstreamError::MissingAuthHeader {
+                vendor: format!("{:?}", account.vendor),
+            });
+        }
+
+        let (header_name, header_value) = vendor::auth_header(&account.vendor, api_key)
+            .ok_or_else(|| UpstreamError::MissingAuthHeader {
+                vendor: format!("{:?}", account.vendor),
+            })?;
+        request = request.header(header_name, &header_value);
+    } else {
+        warn!(
+            account_id = %account.id,
+            vendor = ?account.vendor,
+            "proxying upstream request without API credentials"
+        );
+    }
+
+    request.send().await.map_err(|error| {
+        if error.is_timeout() {
+            UpstreamError::Timeout {
+                message: format!("upstream request to {url} timed out: {error}"),
+            }
+        } else {
+            UpstreamError::Transport {
+                message: format!("upstream request to {url} failed: {error}"),
+            }
+        }
     })
 }
 
@@ -349,5 +404,91 @@ mod tests {
             error,
             UpstreamError::Transport { .. } | UpstreamError::Timeout { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn open_chat_completion_stream_returns_missing_base_url_error() {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap();
+        let account = make_account(ProviderVendor::Other("mistral".to_string()));
+
+        let error = open_chat_completion_stream(&client, &account, Bytes::from_static(br#"{}"#))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, UpstreamError::MissingBaseUrl { .. }));
+    }
+
+    #[tokio::test]
+    async fn open_chat_completion_stream_rejects_blank_api_key_when_auth_header_cannot_be_built() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let (base_url, _handle) =
+            mock_upstream(StatusCode::OK, json!({"ok":true}), captured).await;
+
+        let mut account = make_account(ProviderVendor::OpenAi);
+        account.api_base_override = Some(base_url);
+        account.api_key = Some("   ".to_string());
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap();
+
+        let error = open_chat_completion_stream(&client, &account, Bytes::from_static(br#"{}"#))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, UpstreamError::MissingAuthHeader { .. }));
+    }
+
+    #[tokio::test]
+    async fn open_chat_completion_stream_maps_transport_failures_before_stream_start() {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(200))
+            .build()
+            .unwrap();
+        let mut account = make_account(ProviderVendor::OpenAi);
+        account.api_base_override = Some("http://127.0.0.1:9".to_string());
+
+        let error = open_chat_completion_stream(&client, &account, Bytes::from_static(br#"{}"#))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            UpstreamError::Transport { .. } | UpstreamError::Timeout { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn open_chat_completion_stream_maps_upstream_non_success_status_before_stream_start() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let (base_url, _handle) = mock_upstream(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            json!({"error":{"message":"boom"}}),
+            captured,
+        )
+        .await;
+
+        let mut account = make_account(ProviderVendor::OpenAi);
+        account.api_base_override = Some(base_url);
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap();
+
+        let error = open_chat_completion_stream(&client, &account, Bytes::from_static(br#"{}"#))
+            .await
+            .unwrap_err();
+
+        match error {
+            UpstreamError::UpstreamStatus { status, body, .. } => {
+                assert_eq!(status, reqwest::StatusCode::INTERNAL_SERVER_ERROR);
+                assert_eq!(body, Bytes::from_static(br#"{"error":{"message":"boom"}}"#));
+            }
+            other => panic!("expected UpstreamStatus error, got {other:?}"),
+        }
     }
 }

--- a/clients/rook/src/idempotency/canonical.rs
+++ b/clients/rook/src/idempotency/canonical.rs
@@ -1,0 +1,106 @@
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{canonicalize_json, canonicalize_json_bytes, hash_canonical_json};
+
+    #[test]
+    fn canonical_json_treats_object_key_reordering_as_equivalent() {
+        let left = json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "metadata": {"b": 2, "a": 1}
+        });
+        let right = json!({
+            "metadata": {"a": 1, "b": 2},
+            "messages": [{"content": "Hello", "role": "user"}],
+            "model": "gpt-4o"
+        });
+
+        assert_eq!(canonicalize_json(&left), canonicalize_json(&right));
+        assert_eq!(hash_canonical_json(&left), hash_canonical_json(&right));
+    }
+
+    #[test]
+    fn canonical_json_treats_array_reordering_as_a_mismatch() {
+        let left = json!({
+            "model": "gpt-4o",
+            "messages": [
+                {"role": "system", "content": "You are helpful"},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let right = json!({
+            "model": "gpt-4o",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "system", "content": "You are helpful"}
+            ]
+        });
+
+        assert_ne!(canonicalize_json(&left), canonicalize_json(&right));
+        assert_ne!(hash_canonical_json(&left), hash_canonical_json(&right));
+    }
+
+    #[test]
+    fn canonical_json_hash_includes_unknown_passthrough_fields() {
+        let with_passthrough = json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "logprobs": true
+        });
+        let without_passthrough = json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        assert_ne!(
+            hash_canonical_json(&with_passthrough),
+            hash_canonical_json(&without_passthrough)
+        );
+    }
+
+    #[test]
+    fn canonicalize_json_bytes_returns_stable_bytes_for_semantically_equal_payloads() {
+        let left = br#"{"b":2,"a":1}"#;
+        let right = br#"{"a":1,"b":2}"#;
+
+        assert_eq!(
+            canonicalize_json_bytes(left).expect("left payload should canonicalize"),
+            canonicalize_json_bytes(right).expect("right payload should canonicalize")
+        );
+    }
+}
+use serde_json::{Map, Value};
+
+pub fn canonicalize_json(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let sorted = map
+                .iter()
+                .map(|(key, value)| (key.clone(), canonicalize_json(value)))
+                .collect::<Map<String, Value>>();
+            Value::Object(sorted)
+        }
+        Value::Array(values) => Value::Array(values.iter().map(canonicalize_json).collect()),
+        _ => value.clone(),
+    }
+}
+
+pub fn canonicalize_json_bytes(raw: &[u8]) -> Result<Vec<u8>, serde_json::Error> {
+    let value: Value = serde_json::from_slice(raw)?;
+    serde_json::to_vec(&canonicalize_json(&value))
+}
+
+pub fn hash_canonical_json(value: &Value) -> String {
+    let canonical = serde_json::to_vec(&canonicalize_json(value))
+        .expect("canonical JSON serialization should not fail");
+    hash_canonical_bytes(&canonical)
+}
+
+pub fn hash_canonical_bytes(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+
+    let digest = Sha256::digest(bytes);
+    format!("{digest:x}")
+}

--- a/clients/rook/src/idempotency/middleware.rs
+++ b/clients/rook/src/idempotency/middleware.rs
@@ -1,0 +1,224 @@
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body, Bytes};
+use axum::extract::State;
+use axum::http::{HeaderValue, Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::IntoResponse;
+use axum::response::Response;
+use chrono::{Duration, Utc};
+
+use crate::auth::types::AuthenticatedPrincipal;
+use crate::config::ChatCompletionsIdempotencyConfig;
+use crate::gateway::types::ChatCompletionRequest;
+use crate::gateway::types::{
+    gateway_idempotency_error_response, GatewayErrorBody, GatewayErrorResponse,
+    IDEMPOTENCY_REPLAYED_HEADER,
+};
+use crate::idempotency::canonical::{canonicalize_json_bytes, hash_canonical_bytes};
+use crate::idempotency::types::{ChatIdempotencyScope, ReserveResult, StoredGatewayResponse};
+use crate::idempotency::is_valid_idempotency_key;
+use crate::services::idempotency::SharedIdempotencyService;
+use axum::Json;
+
+#[derive(Clone, Debug)]
+pub struct ChatIdempotencyMiddlewareState {
+    pub config: Arc<ChatCompletionsIdempotencyConfig>,
+    pub service: SharedIdempotencyService,
+}
+
+pub async fn apply_chat_idempotency(
+    State(state): State<ChatIdempotencyMiddlewareState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    if !state.config.enabled {
+        return next.run(request).await;
+    }
+
+    let key = request
+        .headers()
+        .get("idempotency-key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+
+    if key.is_none() {
+        return next.run(request).await;
+    }
+
+    let (mut parts, body) = request.into_parts();
+    let raw_body = match to_bytes(body, usize::MAX).await {
+        Ok(body) => body,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(GatewayErrorResponse {
+                    error: GatewayErrorBody {
+                        message: "invalid request body".to_string(),
+                        error_type: "invalid_request_error".to_string(),
+                        code: None,
+                    },
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    let canonical_body = match canonicalize_json_bytes(&raw_body) {
+        Ok(body) => body,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(GatewayErrorResponse {
+                    error: GatewayErrorBody {
+                        message: "invalid request body".to_string(),
+                        error_type: "invalid_request_error".to_string(),
+                        code: None,
+                    },
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    if matches!(
+        serde_json::from_slice::<ChatCompletionRequest>(&canonical_body),
+        Ok(ChatCompletionRequest {
+            stream: Some(true),
+            ..
+        })
+    ) {
+        let request = Request::from_parts(parts, Body::from(raw_body));
+        return next.run(request).await;
+    }
+
+    let key = key.expect("checked above");
+
+    if !is_valid_idempotency_key(&key) {
+        return gateway_idempotency_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid idempotency key",
+            "invalid_idempotency_key",
+        );
+    }
+
+    let request_hash = hash_canonical_bytes(&canonical_body);
+    let principal_scope_id = parts
+        .extensions
+        .get::<AuthenticatedPrincipal>()
+        .map(|principal| principal.scope_id.clone())
+        .unwrap_or_else(|| "anonymous-local".to_string());
+    let scope = ChatIdempotencyScope {
+        principal_scope_id,
+        method: parts.method.as_str().to_string(),
+        path: parts.uri.path().to_string(),
+        idempotency_key: key,
+    };
+    let now = Utc::now();
+    let replay_window = Duration::seconds(
+        i64::try_from(state.config.replay_window_seconds).unwrap_or(i64::MAX),
+    );
+
+    let reserve = match state
+        .service
+        .inner()
+        .reserve_chat_completion(&scope, &canonical_body, &request_hash, now, replay_window)
+        .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            return gateway_idempotency_error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "idempotency storage unavailable",
+                "idempotency_unavailable",
+            );
+        }
+    };
+
+    match reserve {
+        ReserveResult::ReplayCompleted(stored) => replay_response(stored),
+        ReserveResult::ReplayInProgress => gateway_idempotency_error_response(
+            StatusCode::CONFLICT,
+            "an equivalent request is already in progress",
+            "idempotency_request_in_progress",
+        ),
+        ReserveResult::KeyReusedMismatch => gateway_idempotency_error_response(
+            StatusCode::CONFLICT,
+            "idempotency key has already been used for a different request",
+            "idempotency_key_reused",
+        ),
+        ReserveResult::ReservedNew => {
+            parts.extensions.insert(raw_body.clone());
+            let request = Request::from_parts(parts, Body::from(raw_body.clone()));
+            let response = next.run(request).await;
+            finalize_response(state, scope, request_hash, response).await
+        }
+    }
+}
+
+async fn finalize_response(
+    state: ChatIdempotencyMiddlewareState,
+    scope: ChatIdempotencyScope,
+    request_hash: String,
+    response: Response,
+) -> Response {
+    let (parts, body) = response.into_parts();
+    let body_bytes = match to_bytes(body, usize::MAX).await {
+        Ok(body) => body,
+        Err(_) => {
+            return gateway_idempotency_error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "idempotency storage unavailable",
+                "idempotency_unavailable",
+            );
+        }
+    };
+
+    let content_type = parts
+        .headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("application/json")
+        .to_string();
+
+    if state
+        .service
+        .inner()
+        .complete_chat_completion(
+            &scope,
+            &request_hash,
+            StoredGatewayResponse {
+                status_code: parts.status.as_u16(),
+                content_type,
+                body: body_bytes.clone().to_vec(),
+            },
+            Utc::now(),
+        )
+        .await
+        .is_err()
+    {
+        return gateway_idempotency_error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "idempotency storage unavailable",
+            "idempotency_unavailable",
+        );
+    }
+
+    Response::from_parts(parts, Body::from(body_bytes))
+}
+
+fn replay_response(stored: StoredGatewayResponse) -> Response {
+    let mut response = Response::new(Body::from(Bytes::from(stored.body)));
+    *response.status_mut() = StatusCode::from_u16(stored.status_code)
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    response.headers_mut().insert(
+        axum::http::header::CONTENT_TYPE,
+        HeaderValue::from_str(&stored.content_type)
+            .unwrap_or_else(|_| HeaderValue::from_static("application/json")),
+    );
+    response.headers_mut().insert(
+        IDEMPOTENCY_REPLAYED_HEADER,
+        HeaderValue::from_static("true"),
+    );
+    response
+}

--- a/clients/rook/src/idempotency/mod.rs
+++ b/clients/rook/src/idempotency/mod.rs
@@ -1,0 +1,32 @@
+pub mod canonical;
+pub mod middleware;
+pub mod types;
+
+pub const MAX_IDEMPOTENCY_KEY_LENGTH: usize = 255;
+
+pub fn is_valid_idempotency_key(value: &str) -> bool {
+    let len = value.len();
+    if len == 0 || len > MAX_IDEMPOTENCY_KEY_LENGTH {
+        return false;
+    }
+
+    value
+        .bytes()
+        .all(|byte| (0x21..=0x7e).contains(&byte) && byte != b' ')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_valid_idempotency_key;
+
+    #[test]
+    fn idempotency_key_validation_accepts_visible_ascii_without_spaces() {
+        assert!(is_valid_idempotency_key("chat-123_ABC~z"));
+    }
+
+    #[test]
+    fn idempotency_key_validation_rejects_spaces_and_control_characters() {
+        assert!(!is_valid_idempotency_key("bad key"));
+        assert!(!is_valid_idempotency_key("bad\nkey"));
+    }
+}

--- a/clients/rook/src/idempotency/types.rs
+++ b/clients/rook/src/idempotency/types.rs
@@ -1,0 +1,42 @@
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ChatIdempotencyScope {
+    pub principal_scope_id: String,
+    pub method: String,
+    pub path: String,
+    pub idempotency_key: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChatIdempotencyStatus {
+    InProgress,
+    Completed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredGatewayResponse {
+    pub status_code: u16,
+    pub content_type: String,
+    pub body: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChatIdempotencyRecord {
+    pub scope: ChatIdempotencyScope,
+    pub request_hash: String,
+    pub canonical_request_body: Vec<u8>,
+    pub status: ChatIdempotencyStatus,
+    pub response: Option<StoredGatewayResponse>,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReserveResult {
+    ReservedNew,
+    ReplayCompleted(StoredGatewayResponse),
+    ReplayInProgress,
+    KeyReusedMismatch,
+}

--- a/clients/rook/src/lib.rs
+++ b/clients/rook/src/lib.rs
@@ -2,14 +2,17 @@
 //!
 //! Exposes the public module tree for the gateway, TUI, and operator surfaces.
 
+pub mod auth;
 pub mod admin;
 pub mod config;
 pub mod dashboard;
 pub mod db;
 pub mod domain;
 pub mod gateway;
+pub mod idempotency;
 pub mod registry;
 pub mod routing;
 pub mod server;
 pub mod services;
+pub mod transport;
 pub mod tui;

--- a/clients/rook/src/main.rs
+++ b/clients/rook/src/main.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use rook::config::{ChatCompletionsIdempotencyConfig, IdempotencyConfig, InboundAuthConfig, RateLimitConfig, TransportConfig};
 use rook::server::ServerConfig;
 
 #[derive(Parser)]
@@ -37,6 +38,42 @@ enum Commands {
         /// Path to the on-disk SQLite database file
         #[arg(long)]
         db_path: Option<String>,
+
+        /// Enable inbound bearer auth for `/api/*` and `/v1/*`
+        #[arg(long, default_value_t = false)]
+        inbound_auth_enabled: bool,
+
+        /// Static inbound bearer token for protected HTTP entrypoints
+        #[arg(long)]
+        inbound_auth_token: Option<String>,
+
+        /// Global max requests allowed per window for `/api/*`
+        #[arg(long, default_value_t = 60)]
+        api_rate_limit_max_requests: u32,
+
+        /// Window size in seconds for `/api/*` global rate limiting
+        #[arg(long, default_value_t = 60)]
+        api_rate_limit_window_seconds: u64,
+
+        /// Global max requests allowed per window for `GET /v1/models`
+        #[arg(long, default_value_t = 120)]
+        models_rate_limit_max_requests: u32,
+
+        /// Window size in seconds for `GET /v1/models` global rate limiting
+        #[arg(long, default_value_t = 60)]
+        models_rate_limit_window_seconds: u64,
+
+        /// Global max requests allowed per window for `POST /v1/chat/completions`
+        #[arg(long, default_value_t = 30)]
+        chat_rate_limit_max_requests: u32,
+
+        /// Window size in seconds for `POST /v1/chat/completions` global rate limiting
+        #[arg(long, default_value_t = 60)]
+        chat_rate_limit_window_seconds: u64,
+
+        /// Replay window in seconds for keyed `POST /v1/chat/completions` idempotency
+        #[arg(long, default_value_t = 86_400)]
+        chat_idempotency_replay_window_seconds: u64,
     },
     /// Launch the operator TUI
     Tui,
@@ -67,13 +104,31 @@ async fn main() -> Result<()> {
             port,
             tui,
             db_path,
+            inbound_auth_enabled,
+            inbound_auth_token,
+            api_rate_limit_max_requests,
+            api_rate_limit_window_seconds,
+            models_rate_limit_max_requests,
+            models_rate_limit_window_seconds,
+            chat_rate_limit_max_requests,
+            chat_rate_limit_window_seconds,
+            chat_idempotency_replay_window_seconds,
         } => {
-            let config = ServerConfig {
+            let config = build_server_config(
                 host,
                 port,
-                enable_tui: tui,
+                tui,
                 db_path,
-            };
+                inbound_auth_enabled,
+                inbound_auth_token,
+                api_rate_limit_max_requests,
+                api_rate_limit_window_seconds,
+                models_rate_limit_max_requests,
+                models_rate_limit_window_seconds,
+                chat_rate_limit_max_requests,
+                chat_rate_limit_window_seconds,
+                chat_idempotency_replay_window_seconds,
+            );
             rook::server::run(config).await?;
         }
         Commands::Tui => {
@@ -93,4 +148,155 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn build_server_config(
+    host: String,
+    port: u16,
+    enable_tui: bool,
+    db_path: Option<String>,
+    inbound_auth_enabled: bool,
+    inbound_auth_token: Option<String>,
+    api_rate_limit_max_requests: u32,
+    api_rate_limit_window_seconds: u64,
+    models_rate_limit_max_requests: u32,
+    models_rate_limit_window_seconds: u64,
+    chat_rate_limit_max_requests: u32,
+    chat_rate_limit_window_seconds: u64,
+    chat_idempotency_replay_window_seconds: u64,
+) -> ServerConfig {
+    ServerConfig {
+        host,
+        port,
+        enable_tui,
+        db_path,
+        inbound_auth: InboundAuthConfig {
+            enabled: inbound_auth_enabled,
+            bearer_token: inbound_auth_token,
+        },
+        transport: TransportConfig::default(),
+        rate_limits: RateLimitConfig {
+            api: rook::config::SurfaceRateLimitPolicy {
+                max_requests: api_rate_limit_max_requests,
+                window_seconds: api_rate_limit_window_seconds,
+            },
+            v1_models: rook::config::SurfaceRateLimitPolicy {
+                max_requests: models_rate_limit_max_requests,
+                window_seconds: models_rate_limit_window_seconds,
+            },
+            v1_chat_completions: rook::config::SurfaceRateLimitPolicy {
+                max_requests: chat_rate_limit_max_requests,
+                window_seconds: chat_rate_limit_window_seconds,
+            },
+        },
+        idempotency: IdempotencyConfig {
+            chat_completions: ChatCompletionsIdempotencyConfig {
+                enabled: true,
+                replay_window_seconds: chat_idempotency_replay_window_seconds,
+            },
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serve_cli_parses_inbound_auth_flags() {
+        let cli = Cli::try_parse_from([
+            "rook",
+            "serve",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "9999",
+            "--db-path",
+            "./rook.db",
+            "--inbound-auth-enabled",
+            "--inbound-auth-token",
+            "rook-inbound-secret",
+            "--api-rate-limit-max-requests",
+            "61",
+            "--api-rate-limit-window-seconds",
+            "30",
+            "--models-rate-limit-max-requests",
+            "121",
+            "--models-rate-limit-window-seconds",
+            "31",
+            "--chat-rate-limit-max-requests",
+            "32",
+            "--chat-rate-limit-window-seconds",
+            "33",
+            "--chat-idempotency-replay-window-seconds",
+            "3600",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Serve {
+                host,
+                port,
+                tui,
+                db_path,
+                inbound_auth_enabled,
+                inbound_auth_token,
+                api_rate_limit_max_requests,
+                api_rate_limit_window_seconds,
+                models_rate_limit_max_requests,
+                models_rate_limit_window_seconds,
+                chat_rate_limit_max_requests,
+                chat_rate_limit_window_seconds,
+                chat_idempotency_replay_window_seconds,
+            } => {
+                assert_eq!(host, "0.0.0.0");
+                assert_eq!(port, 9999);
+                assert!(!tui);
+                assert_eq!(db_path, Some("./rook.db".to_string()));
+                assert!(inbound_auth_enabled);
+                assert_eq!(inbound_auth_token, Some("rook-inbound-secret".to_string()));
+                assert_eq!(api_rate_limit_max_requests, 61);
+                assert_eq!(api_rate_limit_window_seconds, 30);
+                assert_eq!(models_rate_limit_max_requests, 121);
+                assert_eq!(models_rate_limit_window_seconds, 31);
+                assert_eq!(chat_rate_limit_max_requests, 32);
+                assert_eq!(chat_rate_limit_window_seconds, 33);
+                assert_eq!(chat_idempotency_replay_window_seconds, 3600);
+            }
+            _ => panic!("expected serve command"),
+        }
+    }
+
+    #[test]
+    fn build_server_config_keeps_inbound_auth_separate() {
+        let config = build_server_config(
+            "127.0.0.1".to_string(),
+            4141,
+            false,
+            None,
+            true,
+            Some("rook-inbound-secret".to_string()),
+            61,
+            30,
+            121,
+            31,
+            32,
+            33,
+            3600,
+        );
+
+        assert!(config.inbound_auth.enabled);
+        assert_eq!(
+            config.inbound_auth.bearer_token,
+            Some("rook-inbound-secret".to_string())
+        );
+        assert_eq!(config.transport, TransportConfig::default());
+        assert_eq!(config.rate_limits.api.max_requests, 61);
+        assert_eq!(config.rate_limits.api.window_seconds, 30);
+        assert_eq!(config.rate_limits.v1_models.max_requests, 121);
+        assert_eq!(config.rate_limits.v1_models.window_seconds, 31);
+        assert_eq!(config.rate_limits.v1_chat_completions.max_requests, 32);
+        assert_eq!(config.rate_limits.v1_chat_completions.window_seconds, 33);
+        assert_eq!(config.idempotency.chat_completions.replay_window_seconds, 3600);
+    }
 }

--- a/clients/rook/src/registry/mod.rs
+++ b/clients/rook/src/registry/mod.rs
@@ -23,8 +23,9 @@
 use crate::db::SqliteDb;
 use crate::domain::RookError;
 use crate::services::{
-    account::SqliteAccountService, health::InMemoryHealthService, pool::SqlitePoolService,
-    route::SqliteRouteService, settings::SqliteSettingsService,
+    account::SqliteAccountService, health::InMemoryHealthService,
+    idempotency::SqliteIdempotencyService, pool::SqlitePoolService, route::SqliteRouteService,
+    settings::SqliteSettingsService,
 };
 
 /// Composition root — holds all service singletons for a Rook instance.
@@ -36,6 +37,7 @@ pub struct RookRegistry {
     pools: SqlitePoolService,
     routes: SqliteRouteService,
     settings: SqliteSettingsService,
+    idempotency: SqliteIdempotencyService,
     health: InMemoryHealthService,
     #[cfg(test)]
     db: SqliteDb,
@@ -63,6 +65,7 @@ impl RookRegistry {
             pools: SqlitePoolService::new(db.clone()),
             routes: SqliteRouteService::new(db.clone()),
             settings: SqliteSettingsService::new(db.clone()),
+            idempotency: SqliteIdempotencyService::new(db.clone()),
             health: InMemoryHealthService::new(),
             #[cfg(test)]
             db,
@@ -96,6 +99,11 @@ impl RookRegistry {
     /// Settings service — global runtime configuration.
     pub fn settings(&self) -> &SqliteSettingsService {
         &self.settings
+    }
+
+    /// Idempotency service — keyed replay protection for chat completions.
+    pub fn idempotency(&self) -> &SqliteIdempotencyService {
+        &self.idempotency
     }
 
     /// Health service — track per-account health state.

--- a/clients/rook/src/server/mod.rs
+++ b/clients/rook/src/server/mod.rs
@@ -4,13 +4,21 @@
 //! configured address and blocks until a graceful shutdown signal is received.
 
 use crate::admin;
+use crate::auth::middleware::{admin_inbound_auth, gateway_inbound_auth};
+use crate::config::{IdempotencyConfig, InboundAuthConfig, RateLimitConfig, TransportConfig};
 use crate::dashboard;
 use crate::domain::RookError;
 use crate::gateway::{self, GatewayState};
+use crate::idempotency::middleware::{ChatIdempotencyMiddlewareState, apply_chat_idempotency};
 use crate::registry::RookRegistry;
 use crate::routing::RoutingEngine;
-use axum::Router;
+use crate::services::idempotency::SharedIdempotencyService;
+use crate::transport::context::{RateLimitedSurface, RouteSurface};
+use crate::transport::middleware::{TransportMiddlewareState, apply_transport_baseline};
+use crate::transport::rate_limit::{RateLimitMiddlewareState, RateLimitState, apply_rate_limit};
+use axum::{Router, middleware};
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tracing::info;
 
 // ---------------------------------------------------------------------------
@@ -28,6 +36,14 @@ pub struct ServerConfig {
     pub enable_tui: bool,
     /// Path to the SQLite database file. Defaults to `"./rook.db"`.
     pub db_path: Option<String>,
+    /// Inbound auth config for protected `/api/*` and `/v1/*` routes.
+    pub inbound_auth: InboundAuthConfig,
+    /// Transport middleware baseline config for `/api/*` and `/v1/*`.
+    pub transport: TransportConfig,
+    /// Explicit global-by-surface rate-limit policies for covered routes.
+    pub rate_limits: RateLimitConfig,
+    /// Route-local idempotency config for chat completions.
+    pub idempotency: IdempotencyConfig,
 }
 
 impl Default for ServerConfig {
@@ -37,6 +53,10 @@ impl Default for ServerConfig {
             port: 4141,
             enable_tui: false,
             db_path: None,
+            inbound_auth: InboundAuthConfig::default(),
+            transport: TransportConfig::default(),
+            rate_limits: RateLimitConfig::default(),
+            idempotency: IdempotencyConfig::default(),
         }
     }
 }
@@ -59,9 +79,23 @@ async fn build_app(config: ServerConfig) -> Result<Router, RookError> {
 }
 
 async fn build_app_with_registry(
-    _config: ServerConfig,
+    config: ServerConfig,
     registry: RookRegistry,
 ) -> Result<Router, RookError> {
+    let idempotency_service = SharedIdempotencyService::boxed(registry.idempotency().clone());
+    build_app_with_registry_and_idempotency(config, registry, idempotency_service).await
+}
+
+async fn build_app_with_registry_and_idempotency(
+    config: ServerConfig,
+    registry: RookRegistry,
+    idempotency_service: SharedIdempotencyService,
+) -> Result<Router, RookError> {
+    config.inbound_auth.validate()?;
+    config.transport.validate()?;
+    config.rate_limits.validate()?;
+    config.idempotency.validate()?;
+
     let engine = RoutingEngine::new(registry.clone());
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
@@ -74,9 +108,73 @@ async fn build_app_with_registry(
         client,
     };
 
+    let inbound_auth = config.inbound_auth.clone();
+    let transport_config = Arc::new(config.transport.clone());
+    let rate_limit_state = RateLimitState::new(&config.rate_limits);
+    let admin_transport = TransportMiddlewareState {
+        config: transport_config.clone(),
+        surface: RouteSurface::AdminApi,
+    };
+    let gateway_transport = TransportMiddlewareState {
+        config: transport_config,
+        surface: RouteSurface::GatewayV1,
+    };
+    let admin_rate_limit = RateLimitMiddlewareState {
+        state: rate_limit_state.clone(),
+        surface: RateLimitedSurface::AdminApi,
+    };
+    let models_rate_limit = RateLimitMiddlewareState {
+        state: rate_limit_state.clone(),
+        surface: RateLimitedSurface::GatewayModels,
+    };
+    let chat_rate_limit = RateLimitMiddlewareState {
+        state: rate_limit_state,
+        surface: RateLimitedSurface::GatewayChatCompletions,
+    };
+    let chat_idempotency = ChatIdempotencyMiddlewareState {
+        config: Arc::new(config.idempotency.chat_completions.clone()),
+        service: idempotency_service,
+    };
+    let admin_router = admin::build_router(registry)
+        .layer(middleware::from_fn_with_state(
+            inbound_auth.clone(),
+            admin_inbound_auth,
+        ))
+        .layer(middleware::from_fn_with_state(admin_rate_limit, apply_rate_limit))
+        .layer(middleware::from_fn_with_state(
+            admin_transport,
+            apply_transport_baseline,
+        ));
+    let gateway_router = Router::new()
+        .merge(
+            gateway::build_models_router(gateway_state.clone())
+                .layer(middleware::from_fn_with_state(
+                    inbound_auth.clone(),
+                    gateway_inbound_auth,
+                ))
+                .layer(middleware::from_fn_with_state(models_rate_limit, apply_rate_limit))
+                .layer(middleware::from_fn_with_state(
+                    gateway_transport.clone(),
+                    apply_transport_baseline,
+                )),
+        )
+        .merge(
+            gateway::build_chat_router(gateway_state)
+                .layer(middleware::from_fn_with_state(
+                    chat_idempotency,
+                    apply_chat_idempotency,
+                ))
+                .layer(middleware::from_fn_with_state(inbound_auth, gateway_inbound_auth))
+                .layer(middleware::from_fn_with_state(chat_rate_limit, apply_rate_limit))
+                .layer(middleware::from_fn_with_state(
+                    gateway_transport,
+                    apply_transport_baseline,
+                )),
+        );
+
     Ok(Router::new()
-        .nest("/api", admin::build_router(registry))
-        .nest("/v1", gateway::build_router(gateway_state))
+        .nest("/api", admin_router)
+        .nest("/v1", gateway_router)
         .merge(dashboard::router()))
 }
 
@@ -105,7 +203,7 @@ pub async fn run(config: ServerConfig) -> Result<(), RookError> {
 
     info!("Rook listening on http://{}:{}", config.host, config.port);
 
-    axum::serve(listener, app)
+    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
         .with_graceful_shutdown(shutdown_signal())
         .await
         .map_err(RookError::Io)?;
@@ -128,9 +226,20 @@ async fn shutdown_signal() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{IdempotencyConfig, RateLimitConfig, SurfaceRateLimitPolicy, TransportConfig};
+    use crate::domain::{AccountId, ModelRoute, PoolId, ProviderAccount, ProviderPool, ProviderVendor, RouteId, SelectionStrategy};
+    use crate::gateway::types::STREAM_CONTENT_TYPE;
+    use crate::idempotency::types::{ChatIdempotencyRecord, ChatIdempotencyScope, ReserveResult, StoredGatewayResponse};
+    use crate::services::{account::AccountService as _, pool::PoolService as _, route::RouteService as _};
+    use crate::services::idempotency::{IdempotencyService, SharedIdempotencyService};
     use axum::body::{to_bytes, Body};
+    use axum::extract::State;
     use axum::http::{Request, StatusCode};
     use serde_json::json;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+    use tokio::sync::Notify;
     use tower::util::ServiceExt;
 
     async fn request_json(app: axum::Router, path: &str) -> (StatusCode, serde_json::Value) {
@@ -152,6 +261,181 @@ mod tests {
         let status = response.status();
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         (status, body.to_vec())
+    }
+
+    async fn request_with_bearer(
+        app: axum::Router,
+        method: axum::http::Method,
+        path: &str,
+        bearer: Option<&str>,
+        body: Option<serde_json::Value>,
+    ) -> (StatusCode, axum::http::HeaderMap, Vec<u8>) {
+        let mut builder = Request::builder().method(method).uri(path);
+        if let Some(token) = bearer {
+            builder = builder.header("authorization", format!("Bearer {token}"));
+        }
+        let request_body = if let Some(value) = body {
+            builder
+                .header("content-type", "application/json")
+                .body(Body::from(value.to_string()))
+                .unwrap()
+        } else {
+            builder.body(Body::empty()).unwrap()
+        };
+
+        let response = app.oneshot(request_body).await.unwrap();
+        let status = response.status();
+        let headers = response.headers().clone();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (status, headers, body.to_vec())
+    }
+
+    fn retry_after_seconds(headers: &axum::http::HeaderMap) -> u64 {
+        headers["retry-after"]
+            .to_str()
+            .expect("retry-after should be ascii")
+            .parse::<u64>()
+            .expect("retry-after should be an integer")
+    }
+
+    fn auth_enabled_config(token: Option<&str>) -> ServerConfig {
+        ServerConfig {
+            host: "127.0.0.1".to_string(),
+            port: 4141,
+            enable_tui: false,
+            db_path: None,
+            inbound_auth: InboundAuthConfig {
+                enabled: true,
+                bearer_token: token.map(ToOwned::to_owned),
+            },
+            transport: TransportConfig::default(),
+            rate_limits: RateLimitConfig {
+                api: SurfaceRateLimitPolicy {
+                    max_requests: 60,
+                    window_seconds: 60,
+                },
+                v1_models: SurfaceRateLimitPolicy {
+                    max_requests: 120,
+                    window_seconds: 60,
+                },
+                v1_chat_completions: SurfaceRateLimitPolicy {
+                    max_requests: 30,
+                    window_seconds: 60,
+                },
+            },
+            idempotency: IdempotencyConfig::default(),
+        }
+    }
+
+    fn limited_server_config() -> ServerConfig {
+        ServerConfig {
+            rate_limits: RateLimitConfig {
+                api: SurfaceRateLimitPolicy {
+                    max_requests: 1,
+                    window_seconds: 60,
+                },
+                v1_models: SurfaceRateLimitPolicy {
+                    max_requests: 1,
+                    window_seconds: 60,
+                },
+                v1_chat_completions: SurfaceRateLimitPolicy {
+                    max_requests: 1,
+                    window_seconds: 60,
+                },
+            },
+            idempotency: IdempotencyConfig::default(),
+            ..ServerConfig::default()
+        }
+    }
+
+    async fn seed_route(
+        registry: &RookRegistry,
+        logical_model: &str,
+        vendor: ProviderVendor,
+        api_base_override: Option<String>,
+        api_key: Option<String>,
+    ) -> AccountId {
+        let account = ProviderAccount {
+            id: AccountId::generate(),
+            vendor,
+            display_name: "test-account".to_string(),
+            api_base_override,
+            api_key,
+            enabled: true,
+            weight: 1,
+            priority: 0,
+            tags: vec![],
+            capabilities: vec![],
+        };
+        let account_id = account.id;
+        registry.accounts().create(account).await.unwrap();
+
+        let pool = ProviderPool {
+            id: PoolId::generate(),
+            name: "test-pool".to_string(),
+            strategy: SelectionStrategy::Priority,
+            members: vec![account_id],
+            fallback_pool_id: None,
+        };
+        let pool_id = pool.id;
+        registry.pools().create(pool).await.unwrap();
+
+        let route = ModelRoute {
+            id: RouteId::generate(),
+            logical_model: logical_model.to_string(),
+            target_pool_id: pool_id,
+            fallback_route_id: None,
+            capability_constraints: vec![],
+        };
+        registry.routes().create(route).await.unwrap();
+
+        account_id
+    }
+
+    type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+    #[derive(Clone, Default)]
+    struct FailingIdempotencyService;
+
+    impl IdempotencyService for FailingIdempotencyService {
+        fn reserve_chat_completion<'a>(
+            &'a self,
+            _scope: &'a ChatIdempotencyScope,
+            _canonical_request_body: &'a [u8],
+            _request_hash: &'a str,
+            _now: chrono::DateTime<chrono::Utc>,
+            _replay_window: chrono::Duration,
+        ) -> BoxFuture<'a, Result<ReserveResult, RookError>> {
+            Box::pin(async {
+                Err(RookError::Registry(
+                    "forced idempotency failure for tests".to_string(),
+                ))
+            })
+        }
+
+        fn complete_chat_completion<'a>(
+            &'a self,
+            _scope: &'a ChatIdempotencyScope,
+            _request_hash: &'a str,
+            _response: StoredGatewayResponse,
+            _completed_at: chrono::DateTime<chrono::Utc>,
+        ) -> BoxFuture<'a, Result<(), RookError>> {
+            Box::pin(async { Err(RookError::Registry("forced completion failure".to_string())) })
+        }
+
+        fn prune_expired_chat_completions<'a>(
+            &'a self,
+            _now: chrono::DateTime<chrono::Utc>,
+        ) -> BoxFuture<'a, Result<u64, RookError>> {
+            Box::pin(async { Ok(0) })
+        }
+
+        fn get_chat_completion<'a>(
+            &'a self,
+            _scope: &'a ChatIdempotencyScope,
+        ) -> BoxFuture<'a, Result<Option<ChatIdempotencyRecord>, RookError>> {
+            Box::pin(async { Ok(None) })
+        }
     }
 
     #[test]
@@ -177,9 +461,92 @@ mod tests {
             port: 8080,
             enable_tui: true,
             db_path: None,
+            inbound_auth: InboundAuthConfig::default(),
+            transport: TransportConfig::default(),
+            rate_limits: RateLimitConfig {
+                api: SurfaceRateLimitPolicy {
+                    max_requests: 60,
+                    window_seconds: 60,
+                },
+                v1_models: SurfaceRateLimitPolicy {
+                    max_requests: 120,
+                    window_seconds: 60,
+                },
+                v1_chat_completions: SurfaceRateLimitPolicy {
+                    max_requests: 30,
+                    window_seconds: 60,
+                },
+            },
+            idempotency: IdempotencyConfig::default(),
         };
         assert_eq!(cfg.socket_addr(), "0.0.0.0:8080");
         assert!(cfg.enable_tui);
+    }
+
+    #[tokio::test]
+    async fn covered_routes_include_effective_request_id_and_dashboard_root_stays_out_of_scope() {
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let app = build_app_with_registry(ServerConfig::default(), registry)
+            .await
+            .unwrap();
+
+        let api_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/health")
+                    .header("x-request-id", "api-trace-123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(api_response.status(), StatusCode::OK);
+        assert_eq!(
+            api_response.headers().get("x-request-id").unwrap(),
+            "api-trace-123"
+        );
+
+        let models_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/models")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(models_response.status(), StatusCode::OK);
+        assert!(models_response.headers().get("x-request-id").is_some());
+
+        let dashboard_response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(dashboard_response.status(), StatusCode::OK);
+        assert!(dashboard_response.headers().get("x-request-id").is_none());
+    }
+
+    #[tokio::test]
+    async fn auth_failures_still_include_effective_request_id_on_covered_routes() {
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let app = build_app_with_registry(auth_enabled_config(Some("rook-inbound-secret")), registry)
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/models")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(response.headers().get("x-request-id").is_some());
     }
 
     #[test]
@@ -188,6 +555,856 @@ mod tests {
         let cloned = cfg.clone();
         assert_eq!(cfg.host, cloned.host);
         assert_eq!(cfg.port, cloned.port);
+    }
+
+    #[tokio::test]
+    async fn protected_routes_require_valid_bearer_when_auth_enabled() {
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let app = build_app_with_registry(auth_enabled_config(Some("rook-inbound-secret")), registry)
+            .await
+            .unwrap();
+
+        let (api_status, api_headers, api_body) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::GET,
+            "/api/health",
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(api_status, StatusCode::UNAUTHORIZED);
+        assert_eq!(api_headers["www-authenticate"], "Bearer");
+        let api_json: serde_json::Value = serde_json::from_slice(&api_body).unwrap();
+        assert_eq!(api_json["error"]["code"], json!("unauthorized"));
+
+        let (models_status, _, models_body) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::GET,
+            "/v1/models",
+            Some("wrong-token"),
+            None,
+        )
+        .await;
+        assert_eq!(models_status, StatusCode::UNAUTHORIZED);
+        let models_json: serde_json::Value = serde_json::from_slice(&models_body).unwrap();
+        assert_eq!(models_json["error"]["code"], json!("unauthorized"));
+
+        let (chat_status, _, chat_body) = request_with_bearer(
+            app,
+            axum::http::Method::POST,
+            "/v1/chat/completions",
+            Some("wrong-token"),
+            Some(json!({"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]})),
+        )
+        .await;
+        assert_eq!(chat_status, StatusCode::UNAUTHORIZED);
+        let chat_json: serde_json::Value = serde_json::from_slice(&chat_body).unwrap();
+        assert_eq!(chat_json["error"]["code"], json!("unauthorized"));
+    }
+
+    #[tokio::test]
+    async fn protected_routes_reach_handlers_with_valid_bearer_and_dashboard_stays_public() {
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let app = build_app_with_registry(auth_enabled_config(Some("rook-inbound-secret")), registry)
+            .await
+            .unwrap();
+
+        let (api_status, _, api_body) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::GET,
+            "/api/health",
+            Some("rook-inbound-secret"),
+            None,
+        )
+        .await;
+        assert_eq!(api_status, StatusCode::OK);
+        assert_eq!(api_body, b"ok");
+
+        let (models_status, _, models_body) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::GET,
+            "/v1/models",
+            Some("rook-inbound-secret"),
+            None,
+        )
+        .await;
+        assert_eq!(models_status, StatusCode::OK);
+        let models_json: serde_json::Value = serde_json::from_slice(&models_body).unwrap();
+        assert_eq!(models_json, json!({"object":"list","data":[]}));
+
+        let (chat_status, _, chat_body) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::POST,
+            "/v1/chat/completions",
+            Some("rook-inbound-secret"),
+            Some(json!({"invalid": true})),
+        )
+        .await;
+        assert_eq!(chat_status, StatusCode::BAD_REQUEST);
+        let chat_json: serde_json::Value = serde_json::from_slice(&chat_body).unwrap();
+        assert_eq!(chat_json["error"]["type"], json!("invalid_request_error"));
+
+        let (root_status, root_body) = request_text(app, "/").await;
+        assert_eq!(root_status, StatusCode::OK);
+        assert!(String::from_utf8_lossy(&root_body).contains("Corvus Rook"));
+    }
+
+    #[tokio::test]
+    async fn build_app_fails_closed_when_enabled_auth_token_is_missing_or_blank() {
+        let missing = build_app_with_registry(
+            auth_enabled_config(None),
+            RookRegistry::open_in_memory().await.unwrap(),
+        )
+        .await;
+        assert!(matches!(missing, Err(RookError::Config(_))));
+
+        let blank = build_app_with_registry(
+            auth_enabled_config(Some("   ")),
+            RookRegistry::open_in_memory().await.unwrap(),
+        )
+        .await;
+        assert!(matches!(blank, Err(RookError::Config(_))));
+    }
+
+    #[tokio::test]
+    async fn build_app_fails_closed_when_rate_limit_config_is_incomplete() {
+        let invalid = build_app_with_registry(
+            ServerConfig {
+                rate_limits: RateLimitConfig {
+                    api: SurfaceRateLimitPolicy {
+                        max_requests: 0,
+                        window_seconds: 60,
+                    },
+                    v1_models: SurfaceRateLimitPolicy {
+                        max_requests: 1,
+                        window_seconds: 60,
+                    },
+                    v1_chat_completions: SurfaceRateLimitPolicy {
+                        max_requests: 1,
+                        window_seconds: 60,
+                    },
+                },
+                ..ServerConfig::default()
+            },
+            RookRegistry::open_in_memory().await.unwrap(),
+        )
+        .await;
+
+        assert!(matches!(invalid, Err(RookError::Config(_))));
+    }
+
+    #[tokio::test]
+    async fn exhausted_surfaces_reject_with_429_retry_after_and_independent_budgets() {
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let app = build_app_with_registry(limited_server_config(), registry)
+            .await
+            .unwrap();
+
+        let (api_ok, _, _) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::GET,
+            "/api/health",
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(api_ok, StatusCode::OK);
+
+        let (api_limited, api_headers, api_body) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::GET,
+            "/api/health",
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(api_limited, StatusCode::TOO_MANY_REQUESTS);
+        assert!(retry_after_seconds(&api_headers) >= 1);
+        let api_json: serde_json::Value = serde_json::from_slice(&api_body).unwrap();
+        assert_eq!(api_json["error"]["code"], json!("rate_limited"));
+
+        let (models_ok, _, _) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::GET,
+            "/v1/models",
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(models_ok, StatusCode::OK);
+
+        let (models_limited, models_headers, models_body) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::GET,
+            "/v1/models",
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(models_limited, StatusCode::TOO_MANY_REQUESTS);
+        assert!(retry_after_seconds(&models_headers) >= 1);
+        let models_json: serde_json::Value = serde_json::from_slice(&models_body).unwrap();
+        assert_eq!(models_json["error"]["type"], json!("rate_limit_error"));
+
+        let (chat_ok, _, _) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::POST,
+            "/v1/chat/completions",
+            None,
+            Some(json!({"invalid": true})),
+        )
+        .await;
+        assert_eq!(chat_ok, StatusCode::BAD_REQUEST);
+
+        let (chat_limited, chat_headers, chat_body) = request_with_bearer(
+            app,
+            axum::http::Method::POST,
+            "/v1/chat/completions",
+            None,
+            Some(json!({"invalid": true})),
+        )
+        .await;
+        assert_eq!(chat_limited, StatusCode::TOO_MANY_REQUESTS);
+        assert!(retry_after_seconds(&chat_headers) >= 1);
+        let chat_json: serde_json::Value = serde_json::from_slice(&chat_body).unwrap();
+        assert_eq!(chat_json["error"]["type"], json!("rate_limit_error"));
+    }
+
+    #[tokio::test]
+    async fn rate_limit_rejections_happen_before_auth_and_dashboard_routes_stay_out_of_scope() {
+        let app = build_app_with_registry(
+            ServerConfig {
+                inbound_auth: InboundAuthConfig {
+                    enabled: true,
+                    bearer_token: Some("rook-inbound-secret".to_string()),
+                },
+                ..limited_server_config()
+            },
+            RookRegistry::open_in_memory().await.unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let (first_models, _, _) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::GET,
+            "/v1/models",
+            Some("rook-inbound-secret"),
+            None,
+        )
+        .await;
+        assert_eq!(first_models, StatusCode::OK);
+
+        let (limited_models, _, limited_body) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::GET,
+            "/v1/models",
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(limited_models, StatusCode::TOO_MANY_REQUESTS);
+        let limited_json: serde_json::Value = serde_json::from_slice(&limited_body).unwrap();
+        assert_eq!(limited_json["error"]["code"], json!("rate_limited"));
+
+        let (dashboard_first, dashboard_body_first) = request_text(app.clone(), "/").await;
+        let (dashboard_second, dashboard_body_second) = request_text(app, "/").await;
+        assert_eq!(dashboard_first, StatusCode::OK);
+        assert_eq!(dashboard_second, StatusCode::OK);
+        assert!(String::from_utf8_lossy(&dashboard_body_first).contains("Corvus Rook"));
+        assert!(String::from_utf8_lossy(&dashboard_body_second).contains("Corvus Rook"));
+    }
+
+    #[tokio::test]
+    async fn rate_limit_slice_acceptance_does_not_require_streaming_or_idempotency_work() {
+        let app = build_app_with_registry(limited_server_config(), RookRegistry::open_in_memory().await.unwrap())
+            .await
+            .unwrap();
+
+        let (first_status, _, _) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::POST,
+            "/v1/chat/completions",
+            None,
+            Some(json!({"invalid": true})),
+        )
+        .await;
+        assert_eq!(first_status, StatusCode::BAD_REQUEST);
+
+        let (second_status, second_headers, second_body) = request_with_bearer(
+            app,
+            axum::http::Method::POST,
+            "/v1/chat/completions",
+            None,
+            Some(json!({"invalid": true})),
+        )
+        .await;
+        assert_eq!(second_status, StatusCode::TOO_MANY_REQUESTS);
+        assert!(retry_after_seconds(&second_headers) >= 1);
+        let second_json: serde_json::Value = serde_json::from_slice(&second_body).unwrap();
+        assert_eq!(second_json["error"]["code"], json!("rate_limited"));
+    }
+
+    #[tokio::test]
+    async fn valid_inbound_auth_does_not_replace_outbound_provider_auth() {
+        use axum::extract::{Json, State};
+        use axum::http::HeaderMap;
+        use axum::{Router, body::Bytes, routing::post};
+        use std::net::SocketAddr;
+
+        async fn capture_auth(
+            State(auth_header): State<std::sync::Arc<tokio::sync::Mutex<Option<String>>>>,
+            headers: HeaderMap,
+            _body: Bytes,
+        ) -> Json<serde_json::Value> {
+            let auth_value = headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string);
+            *auth_header.lock().await = auth_value.clone();
+            Json(json!({"authorization": auth_value}))
+        }
+
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let captured = std::sync::Arc::new(tokio::sync::Mutex::new(None));
+        let upstream = Router::new()
+            .route("/v1/chat/completions", post(capture_auth))
+            .with_state(captured.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move {
+            axum::serve(listener, upstream).await.unwrap();
+        });
+
+        let account = ProviderAccount {
+            id: AccountId::generate(),
+            vendor: ProviderVendor::OpenAi,
+            display_name: "provider-account".to_string(),
+            api_base_override: Some(format!("http://{addr}")),
+            api_key: Some("sk-provider".to_string()),
+            enabled: true,
+            weight: 1,
+            priority: 0,
+            tags: vec![],
+            capabilities: vec!["chat".to_string()],
+        };
+        let account_id = account.id;
+        registry.accounts().create(account).await.unwrap();
+        let pool = ProviderPool {
+            id: PoolId::generate(),
+            name: "pool".to_string(),
+            strategy: SelectionStrategy::RoundRobin,
+            members: vec![account_id],
+            fallback_pool_id: None,
+        };
+        let pool_id = pool.id;
+        registry.pools().create(pool).await.unwrap();
+        registry
+            .routes()
+            .create(ModelRoute {
+                id: RouteId::generate(),
+                logical_model: "gpt-4o".to_string(),
+                target_pool_id: pool_id,
+                fallback_route_id: None,
+                capability_constraints: vec!["chat".to_string()],
+            })
+            .await
+            .unwrap();
+
+        let app = build_app_with_registry(auth_enabled_config(Some("rook-inbound-secret")), registry)
+            .await
+            .unwrap();
+
+        let (status, _, body) = request_with_bearer(
+            app,
+            axum::http::Method::POST,
+            "/v1/chat/completions",
+            Some("rook-inbound-secret"),
+            Some(json!({"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]})),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["authorization"], json!("Bearer sk-provider"));
+        assert_ne!(json["authorization"], json!("Bearer rook-inbound-secret"));
+    }
+
+    #[tokio::test]
+    async fn chat_idempotency_is_route_local_and_does_not_touch_models_or_admin_routes() {
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let app = build_app_with_registry(ServerConfig::default(), registry)
+            .await
+            .unwrap();
+
+        let models = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::GET)
+                    .uri("/v1/models")
+                    .header("idempotency-key", "bad key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(models.status(), StatusCode::OK);
+
+        let admin = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::GET)
+                    .uri("/api/health")
+                    .header("idempotency-key", "bad key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(admin.status(), StatusCode::OK);
+
+        let chat = app
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::POST)
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .header("idempotency-key", "bad key")
+                    .body(Body::from(
+                        json!({"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(chat.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(chat.into_body(), usize::MAX).await.unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["error"]["code"], json!("invalid_idempotency_key"));
+    }
+
+    #[tokio::test]
+    async fn chat_idempotency_replays_completed_response_without_second_upstream_call() {
+        use axum::{Json, Router, routing::post};
+        use std::net::SocketAddr;
+
+        async fn handler(
+            State(counter): State<Arc<AtomicUsize>>,
+        ) -> Json<serde_json::Value> {
+            let count = counter.fetch_add(1, Ordering::SeqCst) + 1;
+            Json(json!({"id": format!("chat-{count}")}))
+        }
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let upstream = Router::new()
+            .route("/v1/chat/completions", post(handler))
+            .with_state(counter.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move { axum::serve(listener, upstream).await.unwrap() });
+
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        seed_route(
+            &registry,
+            "gpt-4o",
+            ProviderVendor::OpenAi,
+            Some(format!("http://{addr}")),
+            Some("sk-test".to_string()),
+        )
+        .await;
+        let app = build_app_with_registry(ServerConfig::default(), registry)
+            .await
+            .unwrap();
+        let body = json!({"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]});
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::POST)
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .header("idempotency-key", "chat-123")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        let first_body = to_bytes(first.into_body(), usize::MAX).await.unwrap();
+        let first_json = serde_json::from_slice::<serde_json::Value>(&first_body).unwrap();
+
+        let second = app
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::POST)
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .header("idempotency-key", "chat-123")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::OK);
+        assert_eq!(
+            second.headers().get("idempotency-replayed").unwrap(),
+            "true"
+        );
+        let second_body = to_bytes(second.into_body(), usize::MAX).await.unwrap();
+        let second_json = serde_json::from_slice::<serde_json::Value>(&second_body).unwrap();
+
+        assert_eq!(first_json, second_json);
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn chat_idempotency_rejects_in_progress_and_mismatched_replays() {
+        use axum::{Json, Router, routing::post};
+        use std::net::SocketAddr;
+
+        async fn blocking_handler(
+            State((counter, notify)): State<(Arc<AtomicUsize>, Arc<Notify>)>,
+        ) -> Json<serde_json::Value> {
+            counter.fetch_add(1, Ordering::SeqCst);
+            notify.notified().await;
+            Json(json!({"id": "chat-final"}))
+        }
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let notify = Arc::new(Notify::new());
+        let upstream = Router::new()
+            .route("/v1/chat/completions", post(blocking_handler))
+            .with_state((counter.clone(), notify.clone()));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move { axum::serve(listener, upstream).await.unwrap() });
+
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        seed_route(
+            &registry,
+            "gpt-4o",
+            ProviderVendor::OpenAi,
+            Some(format!("http://{addr}")),
+            Some("sk-test".to_string()),
+        )
+        .await;
+        let app = build_app_with_registry(ServerConfig::default(), registry)
+            .await
+            .unwrap();
+
+        let first_app = app.clone();
+        let first = tokio::spawn(async move {
+            first_app
+                .oneshot(
+                    Request::builder()
+                        .method(axum::http::Method::POST)
+                        .uri("/v1/chat/completions")
+                        .header("content-type", "application/json")
+                        .header("idempotency-key", "chat-123")
+                        .body(Body::from(
+                            json!({"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]})
+                                .to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+        });
+
+        while counter.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+
+        let in_progress = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::POST)
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .header("idempotency-key", "chat-123")
+                    .body(Body::from(
+                        json!({"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(in_progress.status(), StatusCode::CONFLICT);
+        let in_progress_body = to_bytes(in_progress.into_body(), usize::MAX).await.unwrap();
+        let in_progress_json = serde_json::from_slice::<serde_json::Value>(&in_progress_body).unwrap();
+        assert_eq!(
+            in_progress_json["error"]["code"],
+            json!("idempotency_request_in_progress")
+        );
+
+        let mismatch = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::POST)
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .header("idempotency-key", "chat-123")
+                    .body(Body::from(
+                        json!({"model":"gpt-4o","messages":[{"role":"user","content":"Different"}]})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(mismatch.status(), StatusCode::CONFLICT);
+        let mismatch_body = to_bytes(mismatch.into_body(), usize::MAX).await.unwrap();
+        let mismatch_json = serde_json::from_slice::<serde_json::Value>(&mismatch_body).unwrap();
+        assert_eq!(mismatch_json["error"]["code"], json!("idempotency_key_reused"));
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+        notify.notify_waiters();
+        let finished = first.await.unwrap();
+        assert_eq!(finished.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn chat_idempotency_missing_key_does_not_enable_replay_protection() {
+        use axum::{Json, Router, routing::post};
+        use std::net::SocketAddr;
+
+        async fn handler(State(counter): State<Arc<AtomicUsize>>) -> Json<serde_json::Value> {
+            let count = counter.fetch_add(1, Ordering::SeqCst) + 1;
+            Json(json!({"id": format!("chat-{count}")}))
+        }
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let upstream = Router::new()
+            .route("/v1/chat/completions", post(handler))
+            .with_state(counter.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move { axum::serve(listener, upstream).await.unwrap() });
+
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        seed_route(
+            &registry,
+            "gpt-4o",
+            ProviderVendor::OpenAi,
+            Some(format!("http://{addr}")),
+            Some("sk-test".to_string()),
+        )
+        .await;
+        let app = build_app_with_registry(ServerConfig::default(), registry)
+            .await
+            .unwrap();
+        let body = json!({"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]});
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::POST)
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let first_body = to_bytes(first.into_body(), usize::MAX).await.unwrap();
+
+        let second = app
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::POST)
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(second.headers().get("idempotency-replayed").is_none());
+        let second_body = to_bytes(second.into_body(), usize::MAX).await.unwrap();
+
+        assert_ne!(first_body, second_body);
+        assert_eq!(counter.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn chat_idempotency_replays_completed_terminal_error_response() {
+        use axum::{Json, Router, routing::post};
+        use std::net::SocketAddr;
+
+        async fn handler(
+            State(counter): State<Arc<AtomicUsize>>,
+        ) -> (StatusCode, Json<serde_json::Value>) {
+            counter.fetch_add(1, Ordering::SeqCst);
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({
+                    "error": {
+                        "message": "upstream temporarily unavailable",
+                        "type": "gateway_error",
+                        "code": "upstream_failed"
+                    }
+                })),
+            )
+        }
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let upstream = Router::new()
+            .route("/v1/chat/completions", post(handler))
+            .with_state(counter.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move { axum::serve(listener, upstream).await.unwrap() });
+
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        seed_route(
+            &registry,
+            "gpt-4o",
+            ProviderVendor::OpenAi,
+            Some(format!("http://{addr}")),
+            Some("sk-test".to_string()),
+        )
+        .await;
+        let app = build_app_with_registry(ServerConfig::default(), registry)
+            .await
+            .unwrap();
+        let body = json!({"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]});
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::POST)
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .header("idempotency-key", "chat-error")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::BAD_GATEWAY);
+        let first_body = to_bytes(first.into_body(), usize::MAX).await.unwrap();
+
+        let second = app
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::POST)
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .header("idempotency-key", "chat-error")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(second.headers().get("idempotency-replayed").unwrap(), "true");
+        let second_body = to_bytes(second.into_body(), usize::MAX).await.unwrap();
+
+        assert_eq!(first_body, second_body);
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn chat_idempotency_fails_closed_when_storage_is_unavailable() {
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let app = build_app_with_registry_and_idempotency(
+            ServerConfig::default(),
+            registry,
+            SharedIdempotencyService::boxed(FailingIdempotencyService),
+        )
+        .await
+        .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::POST)
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .header("idempotency-key", "chat-123")
+                    .body(Body::from(
+                        json!({"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["error"]["code"], json!("idempotency_unavailable"));
+    }
+
+    #[tokio::test]
+    async fn streaming_chat_requests_bypass_buffered_idempotency_validation() {
+        use axum::http::header::CONTENT_TYPE;
+        use axum::routing::post;
+        use axum::{response::IntoResponse, Router};
+        use std::net::SocketAddr;
+
+        async fn sse_handler() -> impl IntoResponse {
+            (
+                [(CONTENT_TYPE, "text/event-stream")],
+                Body::from("data: {\"id\":\"chunk-1\"}\n\ndata: [DONE]\n\n"),
+            )
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        let upstream = Router::new().route("/v1/chat/completions", post(sse_handler));
+        let _server = tokio::spawn(async move { axum::serve(listener, upstream).await.unwrap() });
+
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        seed_route(
+            &registry,
+            "gpt-4o",
+            ProviderVendor::OpenAi,
+            Some(format!("http://{addr}")),
+            Some("sk-test".to_string()),
+        )
+        .await;
+        let app = build_app_with_registry(ServerConfig::default(), registry)
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::POST)
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .header("idempotency-key", "bad key")
+                    .body(Body::from(
+                        json!({"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"Hello"}]})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some(STREAM_CONTENT_TYPE)
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("data: [DONE]"));
     }
 
     #[tokio::test]

--- a/clients/rook/src/services/idempotency.rs
+++ b/clients/rook/src/services/idempotency.rs
@@ -1,0 +1,352 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use chrono::{DateTime, Duration, Utc};
+
+use crate::db::SqliteDb;
+use crate::domain::RookError;
+use crate::idempotency::types::{ChatIdempotencyRecord, ChatIdempotencyScope, ReserveResult, StoredGatewayResponse};
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+pub trait IdempotencyService: Send + Sync {
+    fn reserve_chat_completion<'a>(
+        &'a self,
+        scope: &'a ChatIdempotencyScope,
+        canonical_request_body: &'a [u8],
+        request_hash: &'a str,
+        now: DateTime<Utc>,
+        replay_window: Duration,
+    ) -> BoxFuture<'a, Result<ReserveResult, RookError>>;
+
+    fn complete_chat_completion<'a>(
+        &'a self,
+        scope: &'a ChatIdempotencyScope,
+        request_hash: &'a str,
+        response: StoredGatewayResponse,
+        completed_at: DateTime<Utc>,
+    ) -> BoxFuture<'a, Result<(), RookError>>;
+
+    fn prune_expired_chat_completions<'a>(
+        &'a self,
+        now: DateTime<Utc>,
+    ) -> BoxFuture<'a, Result<u64, RookError>>;
+
+    fn get_chat_completion<'a>(
+        &'a self,
+        scope: &'a ChatIdempotencyScope,
+    ) -> BoxFuture<'a, Result<Option<ChatIdempotencyRecord>, RookError>>;
+}
+
+#[derive(Clone, Debug)]
+pub struct SqliteIdempotencyService {
+    db: SqliteDb,
+}
+
+impl SqliteIdempotencyService {
+    pub fn new(db: SqliteDb) -> Self {
+        Self { db }
+    }
+}
+
+impl IdempotencyService for SqliteIdempotencyService {
+    fn reserve_chat_completion<'a>(
+        &'a self,
+        scope: &'a ChatIdempotencyScope,
+        canonical_request_body: &'a [u8],
+        request_hash: &'a str,
+        now: DateTime<Utc>,
+        replay_window: Duration,
+    ) -> BoxFuture<'a, Result<ReserveResult, RookError>> {
+        Box::pin(async move {
+            self.db
+                .reserve_chat_completion_idempotency(
+                    scope,
+                    canonical_request_body,
+                    request_hash,
+                    now,
+                    replay_window,
+                )
+                .await
+        })
+    }
+
+    fn complete_chat_completion<'a>(
+        &'a self,
+        scope: &'a ChatIdempotencyScope,
+        request_hash: &'a str,
+        response: StoredGatewayResponse,
+        completed_at: DateTime<Utc>,
+    ) -> BoxFuture<'a, Result<(), RookError>> {
+        Box::pin(async move {
+            self.db
+                .complete_chat_completion_idempotency(
+                    scope,
+                    request_hash,
+                    &response,
+                    completed_at,
+                )
+                .await
+        })
+    }
+
+    fn prune_expired_chat_completions<'a>(
+        &'a self,
+        now: DateTime<Utc>,
+    ) -> BoxFuture<'a, Result<u64, RookError>> {
+        Box::pin(async move { self.db.prune_expired_chat_completion_idempotency(now).await })
+    }
+
+    fn get_chat_completion<'a>(
+        &'a self,
+        scope: &'a ChatIdempotencyScope,
+    ) -> BoxFuture<'a, Result<Option<ChatIdempotencyRecord>, RookError>> {
+        Box::pin(async move { self.db.get_chat_completion_idempotency(scope).await })
+    }
+}
+
+#[derive(Clone)]
+pub struct SharedIdempotencyService {
+    inner: Arc<dyn IdempotencyService>,
+}
+
+impl SharedIdempotencyService {
+    pub fn new(inner: Arc<dyn IdempotencyService>) -> Self {
+        Self { inner }
+    }
+
+    pub fn boxed(inner: impl IdempotencyService + 'static) -> Self {
+        Self::new(Arc::new(inner))
+    }
+
+    pub fn inner(&self) -> Arc<dyn IdempotencyService> {
+        self.inner.clone()
+    }
+}
+
+impl std::fmt::Debug for SharedIdempotencyService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedIdempotencyService").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{Duration, TimeZone, Utc};
+
+    use crate::idempotency::types::{
+        ChatIdempotencyScope, ChatIdempotencyStatus, ReserveResult, StoredGatewayResponse,
+    };
+
+    use super::{IdempotencyService, SqliteIdempotencyService};
+
+    fn scope(key: &str) -> ChatIdempotencyScope {
+        ChatIdempotencyScope {
+            principal_scope_id: "principal-a".to_string(),
+            method: "POST".to_string(),
+            path: "/v1/chat/completions".to_string(),
+            idempotency_key: key.to_string(),
+        }
+    }
+
+    fn response(status_code: u16, body: &[u8]) -> StoredGatewayResponse {
+        StoredGatewayResponse {
+            status_code,
+            content_type: "application/json".to_string(),
+            body: body.to_vec(),
+        }
+    }
+
+    async fn service() -> SqliteIdempotencyService {
+        let db = crate::db::SqliteDb::open_in_memory()
+            .await
+            .expect("in-memory db should open");
+        SqliteIdempotencyService::new(db)
+    }
+
+    #[tokio::test]
+    async fn reserve_chat_completion_returns_reserved_new_for_new_scope() {
+        let service = service().await;
+        let now = Utc.with_ymd_and_hms(2026, 4, 22, 0, 0, 0).unwrap();
+
+        let result = service
+            .reserve_chat_completion(
+                &scope("chat-1"),
+                br#"{"model":"gpt-4o"}"#,
+                "hash-a",
+                now,
+                Duration::hours(24),
+            )
+            .await
+            .expect("reserve should succeed");
+
+        assert!(matches!(result, ReserveResult::ReservedNew));
+    }
+
+    #[tokio::test]
+    async fn reserve_chat_completion_replays_completed_response_for_equivalent_request() {
+        let service = service().await;
+        let now = Utc.with_ymd_and_hms(2026, 4, 22, 0, 0, 0).unwrap();
+        let scope = scope("chat-2");
+        service
+            .reserve_chat_completion(
+                &scope,
+                br#"{"model":"gpt-4o"}"#,
+                "hash-a",
+                now,
+                Duration::hours(24),
+            )
+            .await
+            .expect("initial reserve should succeed");
+        service
+            .complete_chat_completion(&scope, "hash-a", response(200, br#"{"id":"chat-1"}"#), now)
+            .await
+            .expect("completion should succeed");
+
+        let replay = service
+            .reserve_chat_completion(
+                &scope,
+                br#"{"model":"gpt-4o"}"#,
+                "hash-a",
+                now + Duration::minutes(5),
+                Duration::hours(24),
+            )
+            .await
+            .expect("replay reserve should succeed");
+
+        match replay {
+            ReserveResult::ReplayCompleted(stored) => {
+                assert_eq!(stored.status_code, 200);
+                assert_eq!(stored.body, br#"{"id":"chat-1"}"#.to_vec());
+            }
+            other => panic!("expected completed replay, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn reserve_chat_completion_rejects_in_progress_replay_and_mismatch_and_allows_expiry() {
+        let service = service().await;
+        let now = Utc.with_ymd_and_hms(2026, 4, 22, 0, 0, 0).unwrap();
+        let scope = scope("chat-3");
+
+        service
+            .reserve_chat_completion(
+                &scope,
+                br#"{"model":"gpt-4o"}"#,
+                "hash-a",
+                now,
+                Duration::minutes(1),
+            )
+            .await
+            .expect("initial reserve should succeed");
+
+        let in_progress = service
+            .reserve_chat_completion(
+                &scope,
+                br#"{"model":"gpt-4o"}"#,
+                "hash-a",
+                now + Duration::seconds(10),
+                Duration::minutes(1),
+            )
+            .await
+            .expect("in-progress replay should succeed");
+        assert!(matches!(in_progress, ReserveResult::ReplayInProgress));
+
+        let mismatch = service
+            .reserve_chat_completion(
+                &scope,
+                br#"{"model":"gpt-4o-mini"}"#,
+                "hash-b",
+                now + Duration::seconds(20),
+                Duration::minutes(1),
+            )
+            .await
+            .expect("mismatch should succeed");
+        assert!(matches!(mismatch, ReserveResult::KeyReusedMismatch));
+
+        let expired = service
+            .reserve_chat_completion(
+                &scope,
+                br#"{"model":"gpt-4o"}"#,
+                "hash-a",
+                now + Duration::minutes(2),
+                Duration::minutes(1),
+            )
+            .await
+            .expect("expired reserve should succeed");
+        assert!(matches!(expired, ReserveResult::ReservedNew));
+    }
+
+    #[tokio::test]
+    async fn complete_chat_completion_persists_terminal_status() {
+        let service = service().await;
+        let now = Utc.with_ymd_and_hms(2026, 4, 22, 0, 0, 0).unwrap();
+        let scope = scope("chat-4");
+
+        service
+            .reserve_chat_completion(
+                &scope,
+                br#"{"model":"gpt-4o"}"#,
+                "hash-a",
+                now,
+                Duration::hours(24),
+            )
+            .await
+            .expect("initial reserve should succeed");
+        service
+            .complete_chat_completion(&scope, "hash-a", response(502, br#"{"error":"boom"}"#), now)
+            .await
+            .expect("completion should succeed");
+
+        let record = service
+            .get_chat_completion(&scope)
+            .await
+            .expect("load should succeed")
+            .expect("record should exist");
+        assert_eq!(record.status, ChatIdempotencyStatus::Completed);
+        assert_eq!(record.response.expect("response should exist").status_code, 502);
+    }
+
+    #[tokio::test]
+    async fn reserve_chat_completion_scopes_same_raw_key_by_principal() {
+        let service = service().await;
+        let now = Utc.with_ymd_and_hms(2026, 4, 22, 0, 0, 0).unwrap();
+        let scope_a = ChatIdempotencyScope {
+            principal_scope_id: "principal-a".to_string(),
+            idempotency_key: "chat-shared".to_string(),
+            method: "POST".to_string(),
+            path: "/v1/chat/completions".to_string(),
+        };
+        let scope_b = ChatIdempotencyScope {
+            principal_scope_id: "principal-b".to_string(),
+            idempotency_key: "chat-shared".to_string(),
+            method: "POST".to_string(),
+            path: "/v1/chat/completions".to_string(),
+        };
+
+        let first = service
+            .reserve_chat_completion(
+                &scope_a,
+                br#"{"model":"gpt-4o"}"#,
+                "hash-a",
+                now,
+                Duration::hours(24),
+            )
+            .await
+            .expect("principal A reserve should succeed");
+        assert!(matches!(first, ReserveResult::ReservedNew));
+
+        let second = service
+            .reserve_chat_completion(
+                &scope_b,
+                br#"{"model":"gpt-4o"}"#,
+                "hash-a",
+                now,
+                Duration::hours(24),
+            )
+            .await
+            .expect("principal B reserve should also succeed independently");
+        assert!(matches!(second, ReserveResult::ReservedNew));
+    }
+}

--- a/clients/rook/src/services/mod.rs
+++ b/clients/rook/src/services/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod account;
 pub mod health;
+pub mod idempotency;
 pub mod pool;
 pub mod route;
 pub mod settings;

--- a/clients/rook/src/transport/context.rs
+++ b/clients/rook/src/transport/context.rs
@@ -1,0 +1,53 @@
+use std::net::{IpAddr, SocketAddr};
+use std::hash::Hash;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteSurface {
+    AdminApi,
+    GatewayV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RateLimitedSurface {
+    AdminApi,
+    GatewayModels,
+    GatewayChatCompletions,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForwardedTrust {
+    Absent,
+    Ignored,
+    Trusted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SanitizedForwardedContext {
+    pub trust: ForwardedTrust,
+    pub client_ip: Option<IpAddr>,
+    pub host: Option<String>,
+    pub proto: Option<String>,
+    pub port: Option<u16>,
+    pub ignored_headers: Vec<&'static str>,
+}
+
+impl Default for SanitizedForwardedContext {
+    fn default() -> Self {
+        Self {
+            trust: ForwardedTrust::Absent,
+            client_ip: None,
+            host: None,
+            proto: None,
+            port: None,
+            ignored_headers: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SanitizedTransportContext {
+    pub request_id: String,
+    pub route_surface: RouteSurface,
+    pub direct_peer_addr: Option<SocketAddr>,
+    pub forwarded: SanitizedForwardedContext,
+}

--- a/clients/rook/src/transport/forwarded.rs
+++ b/clients/rook/src/transport/forwarded.rs
@@ -1,0 +1,319 @@
+use axum::http::HeaderMap;
+use ipnet::IpNet;
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+
+use crate::config::TrustedProxyConfig;
+use crate::transport::context::{ForwardedTrust, SanitizedForwardedContext};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForwardedResolution {
+    pub context: SanitizedForwardedContext,
+    pub forwarded_present: bool,
+}
+
+pub fn resolve_forwarded_context(
+    headers: &HeaderMap,
+    direct_peer_addr: Option<SocketAddr>,
+    config: &TrustedProxyConfig,
+) -> ForwardedResolution {
+    let mut context = SanitizedForwardedContext::default();
+    let forwarded_present = has_forwarded_metadata(headers);
+
+    if !forwarded_present {
+        return ForwardedResolution {
+            context,
+            forwarded_present: false,
+        };
+    }
+
+    if !config.enabled {
+        context.trust = ForwardedTrust::Ignored;
+        return ForwardedResolution {
+            context,
+            forwarded_present: true,
+        };
+    }
+
+    let Some(peer_addr) = direct_peer_addr else {
+        context.trust = ForwardedTrust::Ignored;
+        return ForwardedResolution {
+            context,
+            forwarded_present: true,
+        };
+    };
+
+    if !peer_matches_trusted_proxy(peer_addr.ip(), &config.trusted_cidrs) {
+        context.trust = ForwardedTrust::Ignored;
+        return ForwardedResolution {
+            context,
+            forwarded_present: true,
+        };
+    }
+
+    let mut trusted_any = false;
+    let mut malformed_any = false;
+
+    if config.allowed_headers.x_forwarded_for && headers.contains_key("x-forwarded-for") {
+        match parse_ip_header(headers, "x-forwarded-for") {
+            Some(value) => {
+                context.client_ip = Some(value);
+                trusted_any = true;
+            }
+            None => {
+                malformed_any = true;
+                context.ignored_headers.push("x-forwarded-for");
+            }
+        }
+    }
+
+    if config.allowed_headers.x_real_ip && headers.contains_key("x-real-ip") {
+        match parse_ip_header(headers, "x-real-ip") {
+            Some(value) => {
+                if context.client_ip.is_none() {
+                    context.client_ip = Some(value);
+                }
+                trusted_any = true;
+            }
+            None => {
+                malformed_any = true;
+                context.ignored_headers.push("x-real-ip");
+            }
+        }
+    }
+
+    if config.allowed_headers.x_forwarded_host && headers.contains_key("x-forwarded-host") {
+        match parse_visible_header(headers, "x-forwarded-host") {
+            Some(value) => {
+                context.host = Some(value);
+                trusted_any = true;
+            }
+            None => {
+                malformed_any = true;
+                context.ignored_headers.push("x-forwarded-host");
+            }
+        }
+    }
+
+    if config.allowed_headers.x_forwarded_proto && headers.contains_key("x-forwarded-proto") {
+        match parse_proto_header(headers, "x-forwarded-proto") {
+            Some(value) => {
+                context.proto = Some(value);
+                trusted_any = true;
+            }
+            None => {
+                malformed_any = true;
+                context.ignored_headers.push("x-forwarded-proto");
+            }
+        }
+    }
+
+    if config.allowed_headers.x_forwarded_port && headers.contains_key("x-forwarded-port") {
+        match parse_port_header(headers, "x-forwarded-port") {
+            Some(value) => {
+                context.port = Some(value);
+                trusted_any = true;
+            }
+            None => {
+                malformed_any = true;
+                context.ignored_headers.push("x-forwarded-port");
+            }
+        }
+    }
+
+    context.trust = if trusted_any {
+        ForwardedTrust::Trusted
+    } else if malformed_any || forwarded_present {
+        ForwardedTrust::Ignored
+    } else {
+        ForwardedTrust::Absent
+    };
+
+    ForwardedResolution {
+        context,
+        forwarded_present: true,
+    }
+}
+
+fn has_forwarded_metadata(headers: &HeaderMap) -> bool {
+    [
+        "forwarded",
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-forwarded-proto",
+        "x-forwarded-port",
+        "x-real-ip",
+        "via",
+    ]
+    .iter()
+    .any(|header| headers.contains_key(*header))
+}
+
+fn peer_matches_trusted_proxy(peer_ip: IpAddr, trusted_cidrs: &[String]) -> bool {
+    trusted_cidrs.iter().any(|cidr| {
+        IpNet::from_str(cidr)
+            .map(|network| network.contains(&peer_ip))
+            .unwrap_or(false)
+    })
+}
+
+fn single_header_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    let mut values = headers.get_all(name).iter();
+    let value = values.next()?.to_str().ok()?.trim();
+    if values.next().is_some() || value.is_empty() {
+        return None;
+    }
+    Some(value)
+}
+
+fn parse_visible_header(headers: &HeaderMap, name: &str) -> Option<String> {
+    let value = single_header_value(headers, name)?;
+    if value.chars().all(|character| character.is_ascii_graphic()) {
+        Some(value.to_string())
+    } else {
+        None
+    }
+}
+
+fn parse_ip_header(headers: &HeaderMap, name: &str) -> Option<IpAddr> {
+    let value = single_header_value(headers, name)?;
+    let candidate = value.split(',').next()?.trim();
+    candidate.parse().ok()
+}
+
+fn parse_proto_header(headers: &HeaderMap, name: &str) -> Option<String> {
+    let value = single_header_value(headers, name)?;
+    match value {
+        "http" | "https" => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn parse_port_header(headers: &HeaderMap, name: &str) -> Option<u16> {
+    let value = single_header_value(headers, name)?;
+    let port: u16 = value.parse().ok()?;
+    (port > 0).then_some(port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_forwarded_context;
+    use crate::config::{TrustedForwardedHeaders, TrustedProxyConfig};
+    use crate::transport::context::ForwardedTrust;
+    use axum::http::HeaderMap;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    fn trusted_proxy_config() -> TrustedProxyConfig {
+        TrustedProxyConfig {
+            enabled: true,
+            trusted_cidrs: vec!["127.0.0.0/8".to_string()],
+            allowed_headers: TrustedForwardedHeaders {
+                x_forwarded_for: true,
+                x_forwarded_host: true,
+                x_forwarded_proto: true,
+                x_forwarded_port: true,
+                x_real_ip: true,
+                ..TrustedForwardedHeaders::default()
+            },
+        }
+    }
+
+    #[test]
+    fn disabled_trust_policy_ignores_forwarded_metadata() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "203.0.113.9".parse().unwrap());
+
+        let resolution = resolve_forwarded_context(&headers, None, &TrustedProxyConfig::default());
+
+        assert!(resolution.forwarded_present);
+        assert_eq!(resolution.context.trust, ForwardedTrust::Ignored);
+        assert_eq!(resolution.context.client_ip, None);
+    }
+
+    #[test]
+    fn enabled_policy_without_peer_address_falls_back_to_strict_default() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-proto", "https".parse().unwrap());
+
+        let resolution = resolve_forwarded_context(&headers, None, &trusted_proxy_config());
+
+        assert_eq!(resolution.context.trust, ForwardedTrust::Ignored);
+        assert_eq!(resolution.context.proto, None);
+    }
+
+    #[test]
+    fn untrusted_source_ignores_forwarded_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-host", "public.example.com".parse().unwrap());
+
+        let resolution = resolve_forwarded_context(
+            &headers,
+            Some(SocketAddr::from((Ipv4Addr::new(10, 0, 0, 5), 8080))),
+            &trusted_proxy_config(),
+        );
+
+        assert_eq!(resolution.context.trust, ForwardedTrust::Ignored);
+        assert_eq!(resolution.context.host, None);
+    }
+
+    #[test]
+    fn trusted_source_adopts_allowed_forwarded_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "203.0.113.9".parse().unwrap());
+        headers.insert("x-forwarded-host", "public.example.com".parse().unwrap());
+        headers.insert("x-forwarded-proto", "https".parse().unwrap());
+        headers.insert("x-forwarded-port", "443".parse().unwrap());
+
+        let resolution = resolve_forwarded_context(
+            &headers,
+            Some(SocketAddr::from((Ipv4Addr::LOCALHOST, 8080))),
+            &trusted_proxy_config(),
+        );
+
+        assert_eq!(resolution.context.trust, ForwardedTrust::Trusted);
+        assert_eq!(
+            resolution.context.client_ip,
+            Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)))
+        );
+        assert_eq!(resolution.context.host.as_deref(), Some("public.example.com"));
+        assert_eq!(resolution.context.proto.as_deref(), Some("https"));
+        assert_eq!(resolution.context.port, Some(443));
+    }
+
+    #[test]
+    fn malformed_values_are_ignored_and_tracked() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "not-an-ip".parse().unwrap());
+        headers.insert("x-forwarded-port", "0".parse().unwrap());
+
+        let resolution = resolve_forwarded_context(
+            &headers,
+            Some(SocketAddr::from((Ipv4Addr::LOCALHOST, 8080))),
+            &trusted_proxy_config(),
+        );
+
+        assert_eq!(resolution.context.trust, ForwardedTrust::Ignored);
+        assert_eq!(resolution.context.client_ip, None);
+        assert_eq!(resolution.context.port, None);
+        assert!(resolution.context.ignored_headers.contains(&"x-forwarded-for"));
+        assert!(resolution.context.ignored_headers.contains(&"x-forwarded-port"));
+    }
+
+    #[test]
+    fn via_is_diagnostic_only_even_for_trusted_sources() {
+        let mut headers = HeaderMap::new();
+        headers.insert("via", "1.1 proxy.example.com".parse().unwrap());
+
+        let resolution = resolve_forwarded_context(
+            &headers,
+            Some(SocketAddr::from((Ipv4Addr::LOCALHOST, 8080))),
+            &trusted_proxy_config(),
+        );
+
+        assert!(resolution.forwarded_present);
+        assert_eq!(resolution.context.client_ip, None);
+        assert_eq!(resolution.context.host, None);
+        assert_eq!(resolution.context.proto, None);
+        assert_eq!(resolution.context.port, None);
+    }
+}

--- a/clients/rook/src/transport/middleware.rs
+++ b/clients/rook/src/transport/middleware.rs
@@ -1,0 +1,210 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::body::Body;
+use axum::extract::{ConnectInfo, Request, State};
+use axum::middleware::Next;
+use axum::response::Response;
+use tracing::info;
+
+use crate::config::TransportConfig;
+use crate::transport::context::{ForwardedTrust, RouteSurface, SanitizedTransportContext};
+use crate::transport::forwarded::resolve_forwarded_context;
+use crate::transport::request_id::{resolve_request_id, set_response_request_id_header};
+
+#[derive(Debug, Clone)]
+pub struct TransportMiddlewareState {
+    pub config: Arc<TransportConfig>,
+    pub surface: RouteSurface,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CompletionLogFields {
+    request_id: String,
+    surface: RouteSurface,
+    method: String,
+    route: String,
+    status: u16,
+    duration_ms: u64,
+    forwarded_trust: ForwardedTrust,
+    forwarded_present: bool,
+    ignored_forwarded_headers: Vec<&'static str>,
+}
+
+fn build_completion_log_fields(
+    request_id: &str,
+    surface: RouteSurface,
+    method: &axum::http::Method,
+    route: &str,
+    status: axum::http::StatusCode,
+    duration_ms: u64,
+    forwarded_trust: ForwardedTrust,
+    forwarded_present: bool,
+    ignored_forwarded_headers: &[&'static str],
+) -> CompletionLogFields {
+    CompletionLogFields {
+        request_id: request_id.to_string(),
+        surface,
+        method: method.to_string(),
+        route: route.to_string(),
+        status: status.as_u16(),
+        duration_ms,
+        forwarded_trust,
+        forwarded_present,
+        ignored_forwarded_headers: ignored_forwarded_headers.to_vec(),
+    }
+}
+
+pub async fn apply_transport_baseline(
+    State(state): State<TransportMiddlewareState>,
+    mut request: Request<Body>,
+    next: Next,
+) -> Response {
+    let started_at = Instant::now();
+    let request_id = resolve_request_id(request.headers(), &state.config.request_id);
+    let direct_peer_addr = request
+        .extensions()
+        .get::<ConnectInfo<std::net::SocketAddr>>()
+        .map(|info| info.0);
+    let forwarded = resolve_forwarded_context(
+        request.headers(),
+        direct_peer_addr,
+        &state.config.trusted_proxy,
+    );
+
+    request.extensions_mut().insert(SanitizedTransportContext {
+        request_id: request_id.effective().to_string(),
+        route_surface: state.surface,
+        direct_peer_addr,
+        forwarded: forwarded.context.clone(),
+    });
+
+    let method = request.method().clone();
+    let route = request.uri().path().to_string();
+
+    let mut response = next.run(request).await;
+    let duration_ms = started_at.elapsed().as_millis() as u64;
+    let status = response.status();
+
+    set_response_request_id_header(
+        response.headers_mut(),
+        request_id.effective(),
+        &state.config.request_id,
+    );
+
+    let completion = build_completion_log_fields(
+        request_id.effective(),
+        state.surface,
+        &method,
+        &route,
+        status,
+        duration_ms,
+        forwarded.context.trust,
+        forwarded.forwarded_present,
+        &forwarded.context.ignored_headers,
+    );
+
+    info!(
+        request_id = %completion.request_id,
+        surface = ?completion.surface,
+        method = %completion.method,
+        route = %completion.route,
+        status = completion.status,
+        duration_ms = completion.duration_ms,
+        forwarded_trust = ?completion.forwarded_trust,
+        forwarded_present = completion.forwarded_present,
+        ignored_forwarded_headers = ?completion.ignored_forwarded_headers,
+        "completed rook transport request"
+    );
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TransportMiddlewareState, apply_transport_baseline};
+    use crate::config::TransportConfig;
+    use crate::transport::context::{RouteSurface, SanitizedTransportContext};
+    use axum::http::{Request, StatusCode};
+    use axum::middleware;
+    use axum::response::IntoResponse;
+    use axum::routing::get;
+    use axum::{Json, Router};
+    use serde_json::json;
+    use std::sync::Arc;
+    use tower::util::ServiceExt;
+    fn middleware_state() -> TransportMiddlewareState {
+        TransportMiddlewareState {
+            config: Arc::new(TransportConfig::default()),
+            surface: RouteSurface::GatewayV1,
+        }
+    }
+
+    fn probe_app() -> Router {
+        async fn probe_handler(
+            axum::extract::Extension(context): axum::extract::Extension<SanitizedTransportContext>,
+        ) -> impl IntoResponse {
+            Json(json!({
+                "request_id": context.request_id,
+                "surface": format!("{:?}", context.route_surface),
+                "forwarded_trust": format!("{:?}", context.forwarded.trust),
+                "forwarded_host": context.forwarded.host,
+            }))
+        }
+
+        Router::new()
+            .route("/probe", get(probe_handler))
+            .layer(middleware::from_fn_with_state(
+                middleware_state(),
+                apply_transport_baseline,
+            ))
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn middleware_injects_sanitized_transport_context_before_handler_logic() {
+        let response = probe_app()
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .header("x-request-id", "trace-123")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["request_id"], json!("trace-123"));
+        assert_eq!(json["surface"], json!("GatewayV1"));
+        assert_eq!(json["forwarded_trust"], json!("Absent"));
+    }
+
+    #[test]
+    fn middleware_completion_log_fields_remain_structured_and_secret_free() {
+        let completion = super::build_completion_log_fields(
+            "trace-789",
+            RouteSurface::GatewayV1,
+            &axum::http::Method::GET,
+            "/probe",
+            StatusCode::OK,
+            12,
+            crate::transport::context::ForwardedTrust::Absent,
+            false,
+            &[],
+        );
+
+        assert_eq!(completion.request_id, "trace-789");
+        assert_eq!(completion.method, "GET");
+        assert_eq!(completion.route, "/probe");
+        assert_eq!(completion.status, 200);
+        assert_eq!(completion.duration_ms, 12);
+        assert_eq!(completion.forwarded_trust, crate::transport::context::ForwardedTrust::Absent);
+        assert!(!completion.forwarded_present);
+        let serialized = format!("{completion:?}");
+        assert!(!serialized.contains("super-secret"));
+    }
+}

--- a/clients/rook/src/transport/mod.rs
+++ b/clients/rook/src/transport/mod.rs
@@ -1,0 +1,10 @@
+pub mod context;
+pub mod forwarded;
+pub mod middleware;
+pub mod rate_limit;
+pub mod request_id;
+
+pub use context::{
+    ForwardedTrust, RateLimitedSurface, RouteSurface, SanitizedForwardedContext,
+    SanitizedTransportContext,
+};

--- a/clients/rook/src/transport/rate_limit.rs
+++ b/clients/rook/src/transport/rate_limit.rs
@@ -1,0 +1,209 @@
+use crate::admin::types::admin_rate_limited_response;
+use crate::config::{RateLimitConfig, SurfaceRateLimitPolicy};
+use crate::gateway::types::gateway_rate_limited_response;
+use crate::transport::context::RateLimitedSurface;
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::middleware::Next;
+use axum::response::Response;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RateLimitDecision {
+    Allow,
+    Reject { retry_after_seconds: u64 },
+}
+
+#[derive(Debug, Clone)]
+pub struct SurfaceWindowState {
+    pub window_started_at: Instant,
+    pub request_count: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct RateLimitState {
+    pub policies: HashMap<RateLimitedSurface, SurfaceRateLimitPolicy>,
+    pub windows: Arc<tokio::sync::Mutex<HashMap<RateLimitedSurface, SurfaceWindowState>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RateLimitMiddlewareState {
+    pub state: RateLimitState,
+    pub surface: RateLimitedSurface,
+}
+
+impl RateLimitState {
+    pub fn new(config: &RateLimitConfig) -> Self {
+        let policies = HashMap::from([
+            (RateLimitedSurface::AdminApi, config.api.clone()),
+            (RateLimitedSurface::GatewayModels, config.v1_models.clone()),
+            (
+                RateLimitedSurface::GatewayChatCompletions,
+                config.v1_chat_completions.clone(),
+            ),
+        ]);
+        Self {
+            policies,
+            windows: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub async fn check(&self, surface: RateLimitedSurface) -> RateLimitDecision {
+        let now = Instant::now();
+        let policy = self
+            .policies
+            .get(&surface)
+            .expect("covered surface policy must exist");
+        let mut windows = self.windows.lock().await;
+        let window = windows.entry(surface).or_insert_with(|| SurfaceWindowState {
+            window_started_at: now,
+            request_count: 0,
+        });
+        evaluate_surface_limit(now, policy, window)
+    }
+}
+
+pub fn evaluate_surface_limit(
+    now: Instant,
+    policy: &SurfaceRateLimitPolicy,
+    window: &mut SurfaceWindowState,
+) -> RateLimitDecision {
+    let window_duration = Duration::from_secs(policy.window_seconds);
+
+    if now.duration_since(window.window_started_at) >= window_duration {
+        window.window_started_at = now;
+        window.request_count = 0;
+    }
+
+    if window.request_count < policy.max_requests {
+        window.request_count += 1;
+        return RateLimitDecision::Allow;
+    }
+
+    let window_ends_at = window.window_started_at + window_duration;
+    let remaining = window_ends_at.saturating_duration_since(now);
+    let retry_after_seconds = remaining.as_secs().max(1);
+
+    RateLimitDecision::Reject {
+        retry_after_seconds,
+    }
+}
+
+pub async fn apply_rate_limit(
+    State(state): State<RateLimitMiddlewareState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    match state.state.check(state.surface).await {
+        RateLimitDecision::Allow => next.run(request).await,
+        RateLimitDecision::Reject {
+            retry_after_seconds,
+        } => match state.surface {
+            RateLimitedSurface::AdminApi => admin_rate_limited_response(retry_after_seconds),
+            RateLimitedSurface::GatewayModels | RateLimitedSurface::GatewayChatCompletions => {
+                gateway_rate_limited_response(retry_after_seconds)
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RateLimitDecision, RateLimitState, SurfaceWindowState, evaluate_surface_limit};
+    use crate::config::{RateLimitConfig, SurfaceRateLimitPolicy};
+    use crate::transport::context::RateLimitedSurface;
+    use std::time::{Duration, Instant};
+
+    fn policy(max_requests: u32, window_seconds: u64) -> SurfaceRateLimitPolicy {
+        SurfaceRateLimitPolicy {
+            max_requests,
+            window_seconds,
+        }
+    }
+
+    #[test]
+    fn evaluate_surface_limit_allows_within_budget_then_rejects_with_retry_after() {
+        let now = Instant::now();
+        let policy = policy(1, 60);
+        let mut window = SurfaceWindowState {
+            window_started_at: now,
+            request_count: 0,
+        };
+
+        assert_eq!(evaluate_surface_limit(now, &policy, &mut window), RateLimitDecision::Allow);
+        assert_eq!(window.request_count, 1);
+
+        assert_eq!(
+            evaluate_surface_limit(now + Duration::from_secs(1), &policy, &mut window),
+            RateLimitDecision::Reject {
+                retry_after_seconds: 59,
+            }
+        );
+    }
+
+    #[test]
+    fn evaluate_surface_limit_resets_window_after_expiration() {
+        let started_at = Instant::now();
+        let policy = policy(1, 60);
+        let mut window = SurfaceWindowState {
+            window_started_at: started_at,
+            request_count: 1,
+        };
+
+        assert_eq!(
+            evaluate_surface_limit(started_at + Duration::from_secs(60), &policy, &mut window),
+            RateLimitDecision::Allow
+        );
+        assert_eq!(window.request_count, 1);
+        assert_eq!(window.window_started_at, started_at + Duration::from_secs(60));
+    }
+
+    #[test]
+    fn evaluate_surface_limit_clamps_retry_after_to_at_least_one_second() {
+        let started_at = Instant::now();
+        let policy = policy(1, 60);
+        let mut window = SurfaceWindowState {
+            window_started_at: started_at,
+            request_count: 1,
+        };
+
+        assert_eq!(
+            evaluate_surface_limit(
+                started_at + Duration::from_secs(59) + Duration::from_millis(900),
+                &policy,
+                &mut window,
+            ),
+            RateLimitDecision::Reject {
+                retry_after_seconds: 1,
+            }
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rate_limit_state_keeps_surface_budgets_independent() {
+        let state = RateLimitState::new(&RateLimitConfig {
+            api: policy(1, 60),
+            v1_models: policy(1, 60),
+            v1_chat_completions: policy(1, 60),
+        });
+
+        assert_eq!(state.check(RateLimitedSurface::AdminApi).await, RateLimitDecision::Allow);
+        assert_eq!(
+            state.check(RateLimitedSurface::AdminApi).await,
+            RateLimitDecision::Reject {
+                retry_after_seconds: 59,
+            }
+        );
+
+        assert_eq!(
+            state.check(RateLimitedSurface::GatewayModels).await,
+            RateLimitDecision::Allow
+        );
+        assert_eq!(
+            state.check(RateLimitedSurface::GatewayChatCompletions).await,
+            RateLimitDecision::Allow
+        );
+    }
+}

--- a/clients/rook/src/transport/request_id.rs
+++ b/clients/rook/src/transport/request_id.rs
@@ -1,0 +1,154 @@
+use axum::http::{HeaderMap, HeaderName, HeaderValue};
+use uuid::Uuid;
+
+use crate::config::RequestIdConfig;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequestIdAdoption {
+    Adopted(String),
+    Generated(String),
+}
+
+impl RequestIdAdoption {
+    pub fn effective(&self) -> &str {
+        match self {
+            Self::Adopted(value) | Self::Generated(value) => value,
+        }
+    }
+}
+
+pub fn resolve_request_id(headers: &HeaderMap, config: &RequestIdConfig) -> RequestIdAdoption {
+    let header_name = HeaderName::from_bytes(config.inbound_header_name.as_bytes())
+        .expect("request ID header name must be validated before runtime use");
+    let values: Vec<_> = headers.get_all(&header_name).iter().collect();
+
+    if values.len() == 1 {
+        if let Some(candidate) = validate_request_id_value(values[0], config.max_length) {
+            return RequestIdAdoption::Adopted(candidate);
+        }
+    }
+
+    RequestIdAdoption::Generated(Uuid::new_v4().hyphenated().to_string())
+}
+
+pub fn set_response_request_id_header(
+    headers: &mut HeaderMap,
+    request_id: &str,
+    config: &RequestIdConfig,
+) {
+    let header_name = HeaderName::from_bytes(config.response_header_name.as_bytes())
+        .expect("response request ID header name must be validated before runtime use");
+    let header_value = HeaderValue::from_str(request_id)
+        .expect("effective request ID must always be valid for response headers");
+    headers.insert(header_name, header_value);
+}
+
+fn validate_request_id_value(value: &HeaderValue, max_length: usize) -> Option<String> {
+    let text = value.to_str().ok()?.trim();
+    if text.is_empty() || text.len() > max_length {
+        return None;
+    }
+
+    if !text
+        .chars()
+        .all(|character| character.is_ascii_graphic() && character != ',')
+    {
+        return None;
+    }
+
+    Some(text.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RequestIdAdoption, resolve_request_id, set_response_request_id_header};
+    use crate::config::RequestIdConfig;
+    use axum::http::{HeaderMap, HeaderValue};
+
+    fn config() -> RequestIdConfig {
+        RequestIdConfig::default()
+    }
+
+    #[test]
+    fn resolves_generated_request_id_when_header_absent() {
+        let headers = HeaderMap::new();
+
+        let request_id = resolve_request_id(&headers, &config());
+
+        match request_id {
+            RequestIdAdoption::Generated(value) => assert_eq!(value.len(), 36),
+            other => panic!("expected generated request id, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolves_adopted_request_id_for_valid_inbound_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", HeaderValue::from_static("trace-123"));
+
+        let request_id = resolve_request_id(&headers, &config());
+
+        assert_eq!(request_id, RequestIdAdoption::Adopted("trace-123".to_string()));
+    }
+
+    #[test]
+    fn resolves_generated_request_id_for_empty_inbound_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", HeaderValue::from_static(""));
+
+        let request_id = resolve_request_id(&headers, &config());
+
+        assert!(matches!(request_id, RequestIdAdoption::Generated(_)));
+    }
+
+    #[test]
+    fn resolves_generated_request_id_for_whitespace_inbound_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", HeaderValue::from_static("   "));
+
+        let request_id = resolve_request_id(&headers, &config());
+
+        assert!(matches!(request_id, RequestIdAdoption::Generated(_)));
+    }
+
+    #[test]
+    fn resolves_generated_request_id_for_malformed_inbound_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", HeaderValue::from_static("trace id"));
+
+        let request_id = resolve_request_id(&headers, &config());
+
+        assert!(matches!(request_id, RequestIdAdoption::Generated(_)));
+    }
+
+    #[test]
+    fn resolves_generated_request_id_for_multi_value_input() {
+        let mut headers = HeaderMap::new();
+        headers.append("x-request-id", HeaderValue::from_static("trace-1"));
+        headers.append("x-request-id", HeaderValue::from_static("trace-2"));
+
+        let request_id = resolve_request_id(&headers, &config());
+
+        assert!(matches!(request_id, RequestIdAdoption::Generated(_)));
+    }
+
+    #[test]
+    fn resolves_generated_request_id_for_oversized_input() {
+        let oversized = "a".repeat(129);
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", HeaderValue::from_str(&oversized).unwrap());
+
+        let request_id = resolve_request_id(&headers, &config());
+
+        assert!(matches!(request_id, RequestIdAdoption::Generated(_)));
+    }
+
+    #[test]
+    fn writes_effective_request_id_to_response_header() {
+        let mut headers = HeaderMap::new();
+
+        set_response_request_id_header(&mut headers, "trace-123", &config());
+
+        assert_eq!(headers.get("x-request-id").unwrap(), "trace-123");
+    }
+}

--- a/openspec/changes/archive/2026-04-21-rook-589-gateway-api/state.yaml
+++ b/openspec/changes/archive/2026-04-21-rook-589-gateway-api/state.yaml
@@ -1,5 +1,5 @@
 change: rook-589-gateway-api
-current_phase: verify
+current_phase: archive
 completed:
   - propose
   - spec
@@ -7,5 +7,6 @@ completed:
   - tasks
   - apply
   - verify
-next: archive
+  - archive
+next: none
 updated: 2026-04-21

--- a/openspec/changes/archive/2026-04-22-rook-591-chat-completions-idempotency/design.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-chat-completions-idempotency/design.md
@@ -1,0 +1,429 @@
+# Design: Chat Completions Idempotency for Meaningful Replay Protection
+
+## Technical Approach
+
+This slice adds route-local idempotency at the Rook HTTP gateway boundary for `POST /v1/chat/completions` only. The implementation stays inside `clients/rook`, composes after inbound auth and before the existing chat-completions handler, and uses a dedicated SQLite-backed idempotency store so replay state survives process restarts within a bounded window.
+
+The core flow is:
+
+1. `gateway_inbound_auth` authenticates the request and establishes an inbound principal scope.
+2. A new chat-completions-only idempotency middleware validates `Idempotency-Key`, canonicalizes the request body, and checks/reserves a scoped idempotency record.
+3. If an equivalent completed request already exists, the middleware returns the stored terminal response with `Idempotency-Replayed: true`.
+4. If the same logical request is already in progress, the middleware returns a shaped `409` without invoking the handler.
+5. Otherwise the middleware reserves an in-progress record, lets the existing handler execute once, then persists the terminal response for deterministic replay.
+
+This maps directly to the delta spec in `openspec/changes/rook-591-chat-completions-idempotency/specs/gateway/spec.md`: keyed-only participation, principal scoping, canonical body equivalence, deterministic replay for completed work, `409` for in-progress and mismatch, `503` for idempotency unavailability, and no widening to `/api/*`, `GET /v1/models`, or streaming.
+
+## Architecture Decisions
+
+### Decision: Keep idempotency at the gateway transport boundary, not inside upstream proxying
+
+**Choice**: Add a dedicated middleware layer only on the router returned by `gateway::build_chat_router`, composed in `clients/rook/src/server/mod.rs` after inbound auth and before the current chat handler.
+
+**Alternatives considered**:
+- Put idempotency inside `gateway::handlers::handle_chat_completions`
+- Add one shared `/v1/*` middleware for all gateway routes
+- Add idempotency inside `gateway/upstream.rs`
+
+**Rationale**: The route already has explicit per-surface composition in `server/mod.rs` for auth, transport, and rate limit. Adding idempotency at that same boundary preserves the narrow scope from the proposal, keeps `/api/*` and `/v1/models` untouched, and avoids coupling replay logic to provider proxying or handler internals. It also keeps the chat handler focused on request validation, routing, and upstream mapping.
+
+### Decision: Use SQLite-backed replay state through the registry instead of in-memory-only state
+
+**Choice**: Add a dedicated SQLite persistence/service pair exposed from `RookRegistry`, with records retained for a configurable replay window.
+
+**Alternatives considered**:
+- Reuse the existing in-memory `health` service pattern
+- Keep records only in process memory behind `Arc<Mutex<...>>`
+- Skip persistence and rely on provider-side idempotency
+
+**Rationale**: The spec explicitly says this is meaningful bounded replay protection, not just best-effort dedupe during one process lifetime. The registry already acts as the composition root for Rook persistence, and migrations are already the standard mechanism for adding gateway state. SQLite gives deterministic behavior across process restarts, keeps rollback local to Rook, and avoids inventing a second storage technology.
+
+### Decision: Scope records by authenticated inbound principal derived from the existing auth boundary
+
+**Choice**: Extend the existing inbound auth path to place a lightweight `AuthenticatedPrincipal` extension on successful requests. For this slice, the principal identifier is the validated inbound bearer token string when auth is enabled, and a constant local principal (for example `anonymous-local`) when inbound auth is disabled.
+
+**Alternatives considered**:
+- Scope only by raw `Idempotency-Key`
+- Scope by client IP or transport headers
+- Scope by provider account or routed pool after model resolution
+
+**Rationale**: The spec requires composition with the current inbound-auth boundary and explicitly says the same raw key from different authenticated principals must not collide. The auth middleware is the only current place that knows whether the request passed the inbound boundary. IP-based scoping is weaker and transport-dependent. Provider-based scoping is too late in the flow and wrong semantically because idempotency identity belongs to the caller, not the chosen upstream account.
+
+### Decision: Canonicalize the raw JSON body structurally and hash the canonical bytes
+
+**Choice**: Parse the request body into `serde_json::Value`, serialize it into a stable canonical JSON form with sorted object keys, preserved array order, and unchanged scalar values, then hash those canonical bytes for record comparison/storage.
+
+**Alternatives considered**:
+- Compare typed `ChatCompletionRequest` values only
+- Compare raw incoming bytes as-is
+- Canonicalize only known OpenAI fields and ignore passthrough fields
+
+**Rationale**: `ChatCompletionRequest` already preserves unknown passthrough fields through `#[serde(flatten)]`, but typed comparison alone is still the wrong abstraction because the spec requires full-body equivalence including unknown fields. Raw-byte comparison would incorrectly treat semantically identical JSON with different object key ordering as different requests. Structural canonicalization matches the spec and remains future-safe for passthrough fields.
+
+### Decision: Return stored terminal responses for completed work, but reject concurrent replays instead of waiting
+
+**Choice**: Completed equivalent replays return the original stored status/body with `Idempotency-Replayed: true`. Equivalent requests that encounter a reserved in-progress record return `409 idempotency_request_in_progress` immediately.
+
+**Alternatives considered**:
+- Block the second request until the first one completes
+- Poll the store until completion
+- Replay only successful `2xx` responses and ignore terminal errors
+
+**Rationale**: Immediate `409` aligns with the delta spec, keeps middleware simple, and avoids tying up server capacity or introducing waiter coordination. Storing both successes and terminal error responses matches the requirement for deterministic terminal replay and prevents duplicate upstream work when the original call already failed visibly to the client.
+
+### Decision: Fail keyed requests closed when idempotency state is unavailable
+
+**Choice**: Any failure to validate, reserve, load, update, or finalize required idempotency state for a keyed request produces a gateway-shaped `503 idempotency_unavailable` before upstream execution, or, if finalization fails after an upstream response exists, the response is converted to `503` and the failure is logged as an idempotency durability error.
+
+**Alternatives considered**:
+- Fail open and allow the request through without replay protection
+- Best-effort write after response, but still return the upstream result on persistence failure
+
+**Rationale**: The spec is explicit that keyed requests must fail closed when required replay state is unavailable. Best-effort behavior would silently violate the contract and make repeated submissions ambiguous exactly where this slice is meant to provide determinism.
+
+## Data Flow
+
+### Request sequence
+
+```text
+Client
+  │
+  │ POST /v1/chat/completions + Authorization + Idempotency-Key
+  ▼
+gateway_inbound_auth
+  │ validates inbound bearer token
+  │ inserts AuthenticatedPrincipal extension
+  ▼
+apply_rate_limit (existing)
+  ▼
+apply_transport_baseline (existing)
+  ▼
+apply_chat_idempotency (new, route-local)
+  │ validate Idempotency-Key syntax
+  │ read raw JSON body
+  │ canonicalize body + hash
+  │ lookup/reserve scoped record in SQLite
+  ├── completed equivalent ───────► return stored response + Idempotency-Replayed: true
+  ├── in_progress equivalent ─────► return 409 idempotency_request_in_progress
+  ├── mismatch ───────────────────► return 409 idempotency_key_reused
+  ├── unavailable ────────────────► return 503 idempotency_unavailable
+  └── reserved new request ───────► next handler
+                                      ▼
+                              handle_chat_completions (existing)
+                                      │
+                                      │ route + upstream call
+                                      ▼
+                              apply_chat_idempotency finalization
+                                      │ persist terminal status/body/headers subset
+                                      ▼
+                                   Client
+```
+
+### Persistence lifecycle
+
+```text
+Missing record
+  └─ reserve_new() ──► InProgress
+                         │ started_at, expires_at, request hash
+                         │
+                         ├─ finalize(status, body, content_type) ─► Completed
+                         │                                           retained until expires_at
+                         │
+                         └─ expires without completion ───────────► eligible for overwrite/prune
+
+Equivalent replay during Completed  ─► return stored response
+Equivalent replay during InProgress ─► return 409 in-progress
+Mismatched replay within window     ─► return 409 key reused
+Expired record                      ─► treat as new request after prune/replace
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `clients/rook/src/server/mod.rs` | Modify | Add idempotency config validation/state wiring and compose the new middleware only on `gateway::build_chat_router(...)`. |
+| `clients/rook/src/gateway/mod.rs` | Modify | Add chat router builder support for route-local idempotency middleware state if needed. |
+| `clients/rook/src/gateway/handlers.rs` | Modify | Keep business logic intact, but rely on idempotency middleware to pass through the raw body and possibly use a shared response helper for stored/replayed/error responses. |
+| `clients/rook/src/gateway/types.rs` | Modify | Add reusable helpers/constants for idempotency error responses and the `Idempotency-Replayed` header. |
+| `clients/rook/src/auth/middleware.rs` | Modify | Insert an `AuthenticatedPrincipal` request extension on successful auth for both admin and gateway paths, with gateway idempotency consuming the gateway one. |
+| `clients/rook/src/auth/types.rs` | Modify | Define `AuthenticatedPrincipal` and a helper to derive it from current inbound auth state without widening authorization responsibilities. |
+| `clients/rook/src/config/mod.rs` | Modify | Add `IdempotencyConfig` with replay window and enablement/retention validation for keyed chat-completions replay. |
+| `clients/rook/src/main.rs` | Modify | Surface narrow CLI flags for idempotency replay window if operator tuning is exposed from startup config. |
+| `clients/rook/src/lib.rs` | Modify | Export the new idempotency module. |
+| `clients/rook/src/idempotency/mod.rs` | Create | Module root for chat-completions idempotency middleware, types, canonicalization, and store/service interfaces. |
+| `clients/rook/src/idempotency/middleware.rs` | Create | Axum middleware that validates the header, canonicalizes the request, performs store reserve/replay logic, and finalizes terminal responses. |
+| `clients/rook/src/idempotency/types.rs` | Create | Store record structs, status enums, scoped key types, replay decision enums, and sanitized response snapshot types. |
+| `clients/rook/src/idempotency/canonical.rs` | Create | Canonical JSON serialization + hashing for full-body request equivalence. |
+| `clients/rook/src/services/idempotency.rs` | Create | Service trait + SQLite-backed implementation used by the middleware through the registry. |
+| `clients/rook/src/db/idempotency.rs` | Create | Low-level SQL helpers for reserve/load/finalize/prune operations. |
+| `clients/rook/src/db/mod.rs` | Modify | Register the new DB module and wire a new migration. |
+| `clients/rook/src/registry/mod.rs` | Modify | Add `SqliteIdempotencyService` to the composition root and expose `registry.idempotency()`. |
+| `clients/rook/migrations/0004_chat_completions_idempotency.sql` | Create | Add the replay-state table and indexes. |
+| `openspec/changes/rook-591-chat-completions-idempotency/design.md` | Create | This technical design artifact. |
+| `openspec/changes/rook-591-chat-completions-idempotency/state.yaml` | Modify | Mark the design phase complete and move the change to `tasks`. |
+
+## Interfaces / Contracts
+
+### Configuration
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdempotencyConfig {
+    pub chat_completions: ChatCompletionsIdempotencyConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChatCompletionsIdempotencyConfig {
+    pub enabled: bool,
+    pub replay_window_seconds: u64,
+}
+```
+
+Design notes:
+
+- Default: `enabled = true`, `replay_window_seconds = 86_400`.
+- Validation rejects zero replay windows.
+- The config stays route-specific; no generic cross-surface idempotency map is introduced in this slice.
+
+### Principal scope
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedPrincipal {
+    pub scope_id: String,
+}
+
+impl AuthenticatedPrincipal {
+    pub fn from_inbound_auth(headers: &HeaderMap, config: &InboundAuthConfig) -> Result<Self, InboundAuthFailure>;
+}
+```
+
+Design notes:
+
+- When inbound auth is enabled, `scope_id` is derived from the validated bearer token.
+- When inbound auth is disabled, `scope_id` is a fixed local scope string so unauthenticated local development still gets stable per-process semantics without pretending to be multi-principal.
+- This principal is for idempotency scoping only; it does not change authorization behavior.
+
+### Store key and record
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ChatIdempotencyScope {
+    pub principal_scope_id: String,
+    pub method: String, // always POST for this slice
+    pub path: String,   // always /v1/chat/completions after nesting
+    pub idempotency_key: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChatIdempotencyStatus {
+    InProgress,
+    Completed,
+}
+
+#[derive(Debug, Clone)]
+pub struct StoredGatewayResponse {
+    pub status_code: u16,
+    pub content_type: String,
+    pub body: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChatIdempotencyRecord {
+    pub scope: ChatIdempotencyScope,
+    pub request_hash: String,
+    pub canonical_request_body: Vec<u8>,
+    pub status: ChatIdempotencyStatus,
+    pub response: Option<StoredGatewayResponse>,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub expires_at: DateTime<Utc>,
+}
+```
+
+### Store/service contract
+
+```rust
+pub enum ReserveResult {
+    ReservedNew,
+    ReplayCompleted(StoredGatewayResponse),
+    ReplayInProgress,
+    KeyReusedMismatch,
+}
+
+pub trait IdempotencyService: Send + Sync {
+    async fn reserve_chat_completion(
+        &self,
+        scope: &ChatIdempotencyScope,
+        canonical_request_body: &[u8],
+        request_hash: &str,
+        now: DateTime<Utc>,
+        replay_window: chrono::Duration,
+    ) -> Result<ReserveResult, RookError>;
+
+    async fn complete_chat_completion(
+        &self,
+        scope: &ChatIdempotencyScope,
+        request_hash: &str,
+        response: StoredGatewayResponse,
+        completed_at: DateTime<Utc>,
+    ) -> Result<(), RookError>;
+
+    async fn prune_expired_chat_completions(
+        &self,
+        now: DateTime<Utc>,
+    ) -> Result<u64, RookError>;
+}
+```
+
+### Middleware state
+
+```rust
+#[derive(Clone)]
+pub struct ChatIdempotencyMiddlewareState {
+    pub config: Arc<ChatCompletionsIdempotencyConfig>,
+    pub registry: RookRegistry,
+}
+```
+
+### SQLite table shape
+
+```sql
+CREATE TABLE chat_completion_idempotency (
+    principal_scope_id      TEXT NOT NULL,
+    idempotency_key         TEXT NOT NULL,
+    http_method             TEXT NOT NULL,
+    request_path            TEXT NOT NULL,
+    request_hash            TEXT NOT NULL,
+    canonical_request_body  BLOB NOT NULL,
+    status                  TEXT NOT NULL CHECK (status IN ('in_progress', 'completed')),
+    response_status_code    INTEGER,
+    response_content_type   TEXT,
+    response_body           BLOB,
+    started_at              TEXT NOT NULL,
+    completed_at            TEXT,
+    expires_at              TEXT NOT NULL,
+    PRIMARY KEY (principal_scope_id, idempotency_key, http_method, request_path)
+);
+
+CREATE INDEX idx_chat_completion_idempotency_expires_at
+    ON chat_completion_idempotency(expires_at);
+```
+
+Design notes:
+
+- The primary key ensures one live record per scoped key per route.
+- `canonical_request_body` is stored mainly for diagnostics and future-proofing; equality checks use the request hash first.
+- Expired rows are pruned opportunistically during reserve attempts; no background scheduler is introduced in this slice.
+
+## Request Canonicalization / Equivalence Strategy
+
+1. Read the raw request bytes once in idempotency middleware.
+2. Parse into `serde_json::Value`; invalid JSON still returns the existing `400 invalid_request_error` shape.
+3. Canonicalize recursively:
+   - JSON objects: sort keys lexicographically.
+   - Arrays: preserve original order.
+   - Scalars: preserve exact JSON value semantics.
+   - Unknown passthrough fields: include them unchanged.
+4. Serialize canonical value to bytes.
+5. Compute a stable digest (for example SHA-256 hex) over the canonical bytes.
+6. Treat requests as equivalent only when principal scope, method, path, and digest all match.
+
+This means:
+
+- `{ "a":1, "b":2 }` and `{ "b":2, "a":1 }` are equivalent.
+- Arrays with reordered elements are not equivalent.
+- Omitting unknown passthrough fields changes the digest and causes mismatch.
+- The path/method remain part of the store scope even though this slice only handles one route, keeping the contract explicit and rollback-safe.
+
+## Replay Behavior
+
+### Completed work
+
+- If the scoped key exists in `Completed` state and the request hash matches, return the stored status/body/content-type.
+- Add header `Idempotency-Replayed: true`.
+- Do not re-run routing or proxying.
+- Replay both success and terminal error responses (`200`, `502`, `504`, etc.) because the spec requires deterministic terminal replay.
+
+### In-progress work
+
+- If the scoped key exists in `InProgress` state and is not expired and the request hash matches, return HTTP `409` with `GatewayErrorResponse` code `idempotency_request_in_progress`.
+- Do not wait on or subscribe to the original request.
+- Do not start a second upstream execution.
+
+### Mismatch
+
+- If the scoped key exists and the request hash differs, return HTTP `409` with code `idempotency_key_reused`.
+- This applies to both `InProgress` and `Completed` stored records inside the replay window.
+
+### Expiration
+
+- If `expires_at <= now`, the store prunes or overwrites the stale row and treats the request as new work.
+- No guarantee is made after expiration, matching the spec.
+
+## Error Shaping Strategy
+
+All idempotency-specific failures remain OpenAI-shaped through `GatewayErrorResponse` in `clients/rook/src/gateway/types.rs`.
+
+| Condition | HTTP | `error.type` | `error.code` | Message intent |
+|-----------|------|--------------|--------------|----------------|
+| Invalid `Idempotency-Key` syntax | 400 | `invalid_request_error` | `invalid_idempotency_key` | Client sent malformed replay key. |
+| Same key reused with different canonical body | 409 | `invalid_request_error` | `idempotency_key_reused` | Key already bound to a different logical request. |
+| Equivalent replay while original is still running | 409 | `invalid_request_error` | `idempotency_request_in_progress` | Original request has not reached terminal state. |
+| Required store/reservation/finalization unavailable | 503 | `server_error` | `idempotency_unavailable` | Gateway cannot safely provide replay protection for this keyed request. |
+
+Notes:
+
+- `Content-Type` remains `application/json`.
+- Replayed terminal responses preserve their original status/body and only add `Idempotency-Replayed: true`.
+- Existing non-idempotency errors like `unsupported_stream`, `model_not_found`, `upstream_error`, and `upstream_timeout` stay unchanged and, when produced by an originally keyed request, become replayable terminal results.
+
+## Test Strategy
+
+| Layer | What to Test | Approach |
+|-------|--------------|----------|
+| Unit | `Idempotency-Key` validation | Add focused tests for allowed ASCII visible characters, max length, and rejection of spaces/control characters. |
+| Unit | Canonical JSON equivalence | Test object key reordering equivalence, array order sensitivity, unknown field participation, and hash stability. |
+| Unit | Principal derivation | Test authenticated scope creation with auth enabled and fallback local scope when auth is disabled. |
+| Unit | Store reserve state machine | Test new reserve, completed replay, in-progress replay, mismatch, and expiry overwrite against the SQLite service. |
+| Integration | Router composition boundaries | Add `server/mod.rs` tests proving idempotency is applied to `POST /v1/chat/completions` only and ignored for `/api/*` and `GET /v1/models`. |
+| Integration | Completed replay | Use the existing mock upstream style in `gateway/handlers.rs` tests; send the same keyed request twice and assert one upstream hit plus replayed response header/body. |
+| Integration | In-progress replay | Hold the first upstream request open with a test server, send a second equivalent keyed request, assert `409 idempotency_request_in_progress` and still one upstream execution. |
+| Integration | Mismatch | Send same key with different body and assert `409 idempotency_key_reused` before a second upstream call. |
+| Integration | Availability failure | Inject a broken/poisoned SQLite path or service stub and assert keyed request fails with `503 idempotency_unavailable` before proxying. |
+| Integration | Expiry behavior | Use a short replay window in a service-level test and verify expired records can be treated as new work. |
+| E2E | None for this slice | Keep scope narrow; existing Rust integration tests around axum routers are sufficient for this change. |
+
+## Migration / Rollout
+
+No external migration is required, but one internal SQLite schema migration is required:
+
+- Add `clients/rook/migrations/0004_chat_completions_idempotency.sql`.
+- Update `clients/rook/src/db/mod.rs` to apply migration `0004_chat_completions_idempotency`.
+
+Rollout plan:
+
+1. Ship schema + service + middleware together behind route-local config.
+2. Default replay window to 24 hours.
+3. Keep the feature isolated to keyed `POST /v1/chat/completions`; unkeyed requests preserve current behavior.
+
+Rollback plan:
+
+1. Remove the middleware composition from the chat-completions route.
+2. Remove/ignore `IdempotencyConfig` startup wiring.
+3. Leave the SQLite table in place if necessary for safe downgrade; it is orphan-tolerant and does not affect other surfaces.
+
+Because the composition is route-local, rollback does not require undoing inbound auth, transport baseline, rate limits, `/api/*`, `GET /v1/models`, or vendor auth behavior.
+
+## Tradeoffs and Rejected Alternatives
+
+- **SQLite persistence vs in-memory store**: SQLite is more code and adds a migration, but it gives replay continuity across restarts. In-memory would be simpler but not meaningful enough for real retries.
+- **Immediate `409` for in-progress vs waiting**: Immediate `409` is simpler and spec-aligned, but clients must retry later instead of piggybacking on the first request. Waiting would improve ergonomics but adds coordination complexity and cancellation edge cases.
+- **Store full response body vs only success payloads**: Storing all terminal bodies increases DB usage, but it is necessary for deterministic replay of visible gateway outcomes, especially terminal errors.
+- **Use bearer token directly as scope id vs hashing it**: Reusing the validated token string is the narrowest path because the current auth boundary already compares exact static tokens. Implementation SHOULD hash the principal scope before persistence/logging to avoid writing raw secrets into SQLite, even though the logical scope derives from the bearer token. This keeps the design aligned with the security rule not to log or persist secrets unnecessarily.
+- **Opportunistic pruning vs scheduler**: Opportunistic pruning on reserve is cheaper and narrower. A background cleanup task is rejected for this slice because it widens lifecycle complexity without being required for correctness.
+
+## Open Questions
+
+- [ ] Should the persisted `principal_scope_id` be the raw validated bearer token or a one-way digest of it? The implementation should strongly prefer a digest to avoid secret persistence, but this must be applied consistently in tests and diagnostics.
+- [ ] Should `IdempotencyConfig` be operator-tunable through CLI now, or should the first implementation keep the default 24-hour window in `ServerConfig` and postpone CLI exposure until broader config loading exists in Rook?

--- a/openspec/changes/archive/2026-04-22-rook-591-chat-completions-idempotency/proposal.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-chat-completions-idempotency/proposal.md
@@ -1,0 +1,136 @@
+# Proposal: Add Chat Completions Idempotency for Meaningful Replay Protection
+
+## Intent
+
+Rook issue #591 still needs a narrow replay-protection slice after the archived inbound auth,
+transport middleware baseline, and global surface rate-limit changes. The next follow-up should add
+idempotency only where duplicate submission is materially harmful in the current gateway surface:
+`POST /v1/chat/completions`.
+
+The goal is meaningful replay protection for non-streaming chat-completion creation requests without
+expanding scope into admin APIs, model-list reads, fairness/rate limiting, TLS, RBAC, or outbound
+provider authentication. This keeps the slice tight: protect the one mutation-style public route
+where a retried request can otherwise create duplicate upstream work and ambiguous client outcomes.
+
+## Scope
+
+### In Scope
+
+- Define a dedicated #591 follow-up slice for idempotency on `POST /v1/chat/completions` only.
+- Define the request/response contract for meaningful replay protection on repeated
+  `POST /v1/chat/completions` submissions.
+- Define how the server recognizes a duplicate chat-completions create attempt for this slice.
+- Define replay behavior for equivalent repeated chat-completions requests so clients receive a
+  deterministic result instead of duplicate execution when the original request has already been
+  accepted.
+- Define mismatch behavior when the same idempotency identity is reused with materially different
+  `POST /v1/chat/completions` inputs.
+- Define the minimum retention/window and lifecycle expectations needed so replay protection is
+  meaningful for practical client retries.
+- Define how idempotency composes with the archived inbound-auth boundary and transport middleware
+  baseline without changing their responsibilities.
+- Identify the minimal server, gateway, persistence/cache, config, and spec areas that follow-on
+  spec/design work must cover.
+
+### Out of Scope
+
+- Any idempotency behavior for `/api/*` admin routes.
+- Any idempotency behavior for `GET /v1/models`.
+- Any idempotency behavior for routes outside `POST /v1/chat/completions`.
+- Per-client fairness, rate limiting, quotas, abuse controls, or request scheduling.
+- Streaming chat completions or partial-response replay behavior.
+- TLS, mTLS, certificate handling, or network-edge deployment policy.
+- RBAC, route scopes, tenancy policy, or authorization-model expansion.
+- Outbound provider authentication/header changes in `clients/rook/src/gateway/vendor.rs`.
+- Broader deduplication across unrelated endpoints, cross-route request correlation, or general
+  exactly-once guarantees.
+
+## Approach
+
+Treat this slice as a transport/gateway boundary contract applied only to non-streaming
+`POST /v1/chat/completions`. The design should define an explicit idempotency identity that the
+request must present, a normalization or equivalence rule for determining whether a replay is the
+same logical request, and a bounded retention model so the server can return a deterministic
+duplicate outcome instead of re-executing the upstream call.
+
+The core contract is simple:
+
+- Only `POST /v1/chat/completions` participates in this slice.
+- `GET /v1/models` and all `/api/*` routes remain unaffected.
+- Replays that match the original idempotent chat-completions request within the supported replay
+  window MUST resolve deterministically without causing duplicate meaningful execution.
+- Reuse of the same idempotency identity with materially different chat-completions inputs MUST be
+  rejected explicitly rather than silently treated as equivalent.
+- The slice MUST remain non-streaming; acceptance MUST NOT depend on stream replay semantics.
+- The slice SHOULD be implemented with reversible server-side storage/cache and startup/config
+  wiring rather than hard-coded, non-expiring behavior.
+
+This proposal intentionally avoids promising universal exactly-once processing. Here is the thing:
+for a networked gateway, the practical value is bounded replay protection for meaningful client
+retries on the one mutation-like endpoint that exists today, not an overly broad guarantee that
+would drag in distributed transaction semantics.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `clients/rook/src/server/mod.rs` | Modified | Compose chat-completions-only idempotency handling in front of the existing `POST /v1/chat/completions` route without affecting `/api/*` or `GET /v1/models`. |
+| `clients/rook/src/gateway/` | Modified | Enforce idempotency requirements and replay semantics for `POST /v1/chat/completions` while preserving current OpenAI-shaped gateway behavior. |
+| `clients/rook/src/config/` | Modified | Define startup/config inputs for replay-window, storage/cache behavior, and validation rules if this slice exposes operator-tunable idempotency settings. |
+| `clients/rook/src/` transport/middleware or replay-protection module(s) | New or Modified | Add helpers for idempotency identity lookup, request equivalence checks, stored-result lifecycle, and duplicate/mismatch response shaping. |
+| `clients/rook/src/gateway/vendor.rs` | Unchanged by scope | Outbound provider authentication/header behavior remains explicitly out of scope for this slice. |
+| `openspec/specs/gateway/spec.md` | Modified (follow-on) | Add delta requirements for `POST /v1/chat/completions` idempotency, replay acceptance, mismatch rejection, and excluded surfaces. |
+| `openspec/changes/rook-591-chat-completions-idempotency/` | New | Proposal and follow-on spec/design/tasks artifacts for this slice. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Idempotency scope creeps onto `/api/*` or `GET /v1/models` because the transport layer is shared | High | State explicit route boundaries in spec/design and require route-level composition that only wraps `POST /v1/chat/completions`. |
+| The system accepts the same idempotency identity for materially different request bodies | High | Define canonical equivalence rules and explicit conflict behavior for mismatched replays. |
+| Retention is too short to protect realistic client retries or too long for safe operational cost | Medium | Specify a bounded replay window with operator-visible configuration semantics and clear cleanup expectations. |
+| Replay storage/cache failures create ambiguous behavior under retry | Medium | Design fail-closed vs fail-open behavior explicitly in the follow-on spec/design and keep rollback easy by isolating the feature behind targeted composition/config. |
+| Clients mistake replay protection for general exactly-once guarantees across providers | Medium | Document that this slice provides meaningful bounded replay protection for one route, not universal exactly-once semantics. |
+| Non-streaming assumptions are accidentally violated by future stream support | Medium | Keep `stream: true` and all streaming semantics explicitly out of scope for this slice and require separate future work. |
+
+## Rollback Plan
+
+If this slice causes regressions or operational confusion, revert the chat-completions-only
+idempotency composition for `POST /v1/chat/completions`, remove any startup/config entries and
+replay storage/cache wiring introduced for this feature, and restore the current behavior in which
+chat-completion retries are processed without replay protection. Because this slice is intentionally
+limited to one route, rollback should not require changes to `/api/*`, `GET /v1/models`, inbound
+auth semantics, rate-limit behavior, TLS policy, RBAC, or outbound provider auth.
+
+## Dependencies
+
+- The archived `rook-591-inbound-auth-boundary` slice remains a completed prerequisite and must stay
+  separate from this idempotency slice.
+- The archived `rook-591-transport-middleware-baseline` slice remains the transport composition
+  baseline and should host this route-specific replay protection cleanly rather than widening
+  middleware scope.
+- The archived `rook-591-global-surface-rate-limits` slice remains separate; this change must not
+  absorb fairness or quota responsibilities.
+- Existing server composition in `clients/rook/src/server/mod.rs` must continue to host `/api/*`,
+  `GET /v1/models`, and `POST /v1/chat/completions` without broadening replay protection to the
+  excluded surfaces.
+- The gateway spec in `openspec/specs/gateway/spec.md` will need a follow-on delta for chat
+  completions idempotency, duplicate replay behavior, mismatch handling, and route exclusions.
+- Follow-on design work must confirm where replay state lives, how request equivalence is computed,
+  and what retention/config model is operationally safe in `clients/rook`.
+
+## Success Criteria
+
+- [ ] The change remains narrowly scoped to idempotency for `POST /v1/chat/completions` only.
+- [ ] The proposal explicitly excludes `/api/*` admin routes and `GET /v1/models` from idempotency
+      coverage.
+- [ ] The proposal defines meaningful replay protection as deterministic duplicate handling for
+      equivalent chat-completions retries within a bounded replay window.
+- [ ] The proposal explicitly requires mismatch handling when the same idempotency identity is reused
+      with materially different chat-completions inputs.
+- [ ] The proposal keeps fairness/rate limiting, streaming, TLS, RBAC, and outbound provider auth
+      work explicitly deferred.
+- [ ] The rollback plan is route-local and does not require undoing archived auth, transport, or
+      rate-limit slices.
+- [ ] The change is ready for `sdd-spec` and `sdd-design` to define concrete requirements and
+      technical decisions.

--- a/openspec/changes/archive/2026-04-22-rook-591-chat-completions-idempotency/specs/gateway/spec.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-chat-completions-idempotency/specs/gateway/spec.md
@@ -1,0 +1,279 @@
+# Delta for gateway
+
+## ADDED Requirements
+
+### Requirement: Chat Completions Idempotency Surface
+
+The system MUST apply this idempotency slice only to `POST /v1/chat/completions`.
+
+The system MUST NOT apply this slice to `/api/*`, `GET /v1/models`, or any other route.
+
+The system MUST scope idempotency records by the authenticated inbound principal established by the
+existing inbound-auth boundary, so the same raw idempotency key used by different authenticated
+principals SHALL NOT collide.
+
+#### Scenario: Idempotency applies only to chat completions create
+
+- GIVEN a valid authenticated request to `POST /v1/chat/completions`
+- WHEN the request includes a valid idempotency header
+- THEN the gateway MUST evaluate the request under this idempotency slice
+
+#### Scenario: Admin API remains out of scope
+
+- GIVEN a valid authenticated request to `/api/accounts` with an `Idempotency-Key` header
+- WHEN the request is handled
+- THEN this slice MUST NOT create, read, or reject against a chat-completions idempotency record
+
+#### Scenario: Model listing remains out of scope
+
+- GIVEN a valid authenticated request to `GET /v1/models` with an `Idempotency-Key` header
+- WHEN the request is handled
+- THEN this slice MUST NOT create, read, or reject against a chat-completions idempotency record
+
+#### Scenario: Same raw key from different principals does not collide
+
+- GIVEN authenticated principal `A` sends `POST /v1/chat/completions` with `Idempotency-Key: rook-1`
+- AND authenticated principal `B` sends an equivalent `POST /v1/chat/completions` with the same
+  `Idempotency-Key: rook-1`
+- WHEN both requests are handled within the replay window
+- THEN the system MUST treat them as distinct idempotency scopes
+- AND the second request MUST NOT be rejected or replayed because of principal `A`'s record
+
+### Requirement: Idempotency Request Contract
+
+The system MUST use the `Idempotency-Key` request header as the only client-provided replay identity
+mechanism for this slice.
+
+The system MUST treat the `Idempotency-Key` value as an opaque, case-sensitive token.
+
+When a client omits `Idempotency-Key`, the gateway MAY process the request using the existing
+non-idempotent behavior, but it MUST NOT claim replay protection for that request.
+
+When a client provides `Idempotency-Key`, the value MUST be 1 to 255 visible ASCII characters and
+MUST NOT contain spaces or control characters.
+
+The system MUST reject an invalid `Idempotency-Key` before any upstream provider call.
+
+#### Scenario: Valid key participates in replay protection
+
+- GIVEN a valid authenticated `POST /v1/chat/completions` request with `Idempotency-Key: chat-123`
+- WHEN the gateway accepts the request
+- THEN the request MUST participate in idempotency evaluation for this route
+
+#### Scenario: Missing key does not enable replay protection
+
+- GIVEN a valid authenticated `POST /v1/chat/completions` request without `Idempotency-Key`
+- WHEN the gateway handles the request
+- THEN the gateway MUST process it using the normal route behavior
+- AND the gateway MUST NOT read or write a replay record for that request
+
+#### Scenario: Invalid key is rejected before upstream work
+
+- GIVEN a valid authenticated `POST /v1/chat/completions` request with `Idempotency-Key: "bad key"`
+- WHEN the gateway validates the header
+- THEN the gateway MUST return HTTP 400
+- AND the response body MUST be a `GatewayErrorResponse`
+- AND `error.code` MUST equal `"invalid_idempotency_key"`
+- AND the gateway MUST NOT start upstream execution
+
+### Requirement: Idempotency Equivalence and Mismatch Contract
+
+For requests that present `Idempotency-Key`, the system MUST determine equivalence using all of the
+following together: authenticated principal scope, HTTP method, request path, and a canonical JSON
+representation of the full request body.
+
+The canonical JSON representation MUST preserve array order and scalar values and MUST compare all
+body fields, including unknown passthrough fields.
+
+Two keyed requests MUST be treated as equivalent only when all equivalence inputs match exactly.
+
+If the same authenticated principal reuses the same `Idempotency-Key` for `POST /v1/chat/completions`
+within the replay window but the canonical request body differs, the system MUST reject the later
+request as a mismatch.
+
+#### Scenario: Same key and equivalent body is treated as the same logical request
+
+- GIVEN an authenticated principal sends `POST /v1/chat/completions` with `Idempotency-Key: chat-123`
+- AND the full JSON request body is recorded under that key
+- WHEN the same principal repeats `POST /v1/chat/completions` with `Idempotency-Key: chat-123`
+- AND the repeated request body is canonically identical to the original
+- THEN the gateway MUST treat the second request as a replay of the original logical request
+
+#### Scenario: Same key with different body is rejected
+
+- GIVEN an authenticated principal previously sent `POST /v1/chat/completions` with
+  `Idempotency-Key: chat-123` and body `{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}`
+- WHEN the same principal sends `POST /v1/chat/completions` with `Idempotency-Key: chat-123` and
+  body `{"model":"gpt-4o","messages":[{"role":"user","content":"Different"}]}`
+- THEN the gateway MUST return HTTP 409
+- AND the response body MUST be a `GatewayErrorResponse`
+- AND `error.code` MUST equal `"idempotency_key_reused"`
+- AND the gateway MUST NOT start a second upstream execution
+
+#### Scenario: Unknown passthrough fields participate in equivalence
+
+- GIVEN an authenticated principal previously sent `POST /v1/chat/completions` with
+  `Idempotency-Key: chat-123` and body containing `"logprobs": true`
+- WHEN the same principal repeats the request with the same key but omits `"logprobs"`
+- THEN the gateway MUST treat the request as a mismatch
+- AND the gateway MUST return HTTP 409
+
+### Requirement: Replay Behavior for Completed Work
+
+When a keyed `POST /v1/chat/completions` request has already produced a terminal gateway response,
+the gateway MUST store that terminal client-visible response for the remainder of the replay window.
+
+For an equivalent replay received within the replay window, the gateway MUST return the stored
+terminal response instead of starting a new upstream execution.
+
+The replayed response MUST preserve the original HTTP status code and JSON response body.
+
+The replayed response MUST include header `Idempotency-Replayed: true`.
+
+#### Scenario: Completed success response is replayed deterministically
+
+- GIVEN an authenticated principal sent `POST /v1/chat/completions` with `Idempotency-Key: chat-123`
+- AND the original keyed request completed with HTTP 200 and a JSON chat completion response body
+- WHEN the same principal repeats the equivalent request with `Idempotency-Key: chat-123` within the
+  replay window
+- THEN the gateway MUST return HTTP 200
+- AND the response body MUST equal the original response body
+- AND the response header `Idempotency-Replayed` MUST equal `true`
+- AND the gateway MUST NOT start a second upstream execution
+
+#### Scenario: Completed terminal error response is replayed deterministically
+
+- GIVEN an authenticated principal sent `POST /v1/chat/completions` with `Idempotency-Key: chat-123`
+- AND the original keyed request completed with HTTP 502 and a `GatewayErrorResponse`
+- WHEN the same principal repeats the equivalent request with `Idempotency-Key: chat-123` within the
+  replay window
+- THEN the gateway MUST return HTTP 502
+- AND the response body MUST equal the original error body
+- AND the response header `Idempotency-Replayed` MUST equal `true`
+- AND the gateway MUST NOT start a second upstream execution
+
+### Requirement: Replay Behavior for In-Progress Work
+
+When a keyed `POST /v1/chat/completions` request is still in progress and has not yet produced a
+terminal response, an equivalent replay MUST NOT start a second upstream execution.
+
+For such an equivalent replay, the gateway MUST return HTTP 409 with a `GatewayErrorResponse`.
+
+For such an in-progress replay, `error.code` MUST equal `"idempotency_request_in_progress"`.
+
+#### Scenario: In-progress replay is rejected without duplicate execution
+
+- GIVEN an authenticated principal sent `POST /v1/chat/completions` with `Idempotency-Key: chat-123`
+- AND the original keyed request has been accepted but has not yet produced a terminal response
+- WHEN the same principal repeats the equivalent request with `Idempotency-Key: chat-123`
+- THEN the gateway MUST return HTTP 409
+- AND the response body MUST be a `GatewayErrorResponse`
+- AND `error.code` MUST equal `"idempotency_request_in_progress"`
+- AND the gateway MUST NOT start a second upstream execution
+
+### Requirement: Replay Window and Retention
+
+The system MUST retain keyed chat-completions idempotency state for a bounded replay window.
+
+The replay window MUST be configurable.
+
+The default replay window SHALL be 24 hours.
+
+The replay window configuration MUST reject zero or negative durations.
+
+After the replay window expires, the gateway MAY treat reuse of the same `Idempotency-Key` as a new
+request.
+
+#### Scenario: Equivalent replay within the window uses stored state
+
+- GIVEN a keyed `POST /v1/chat/completions` request completed successfully
+- AND the replay window has not expired
+- WHEN an equivalent replay arrives
+- THEN the gateway MUST use the stored idempotency state for replay handling
+
+#### Scenario: Expired key may be treated as new work
+
+- GIVEN a keyed `POST /v1/chat/completions` request completed successfully
+- AND the replay window has expired
+- WHEN the same principal sends an equivalent request with the same `Idempotency-Key`
+- THEN the gateway MAY treat the request as new work
+- AND the gateway MAY start a new upstream execution
+
+### Requirement: Idempotency Error and Availability Semantics
+
+If the gateway cannot create or read required idempotency state for a request that presents
+`Idempotency-Key`, the gateway MUST fail the request closed.
+
+In that case, the gateway MUST return HTTP 503 with a `GatewayErrorResponse` and MUST NOT start
+upstream execution.
+
+In that case, `error.code` MUST equal `"idempotency_unavailable"`.
+
+All idempotency-specific rejections MUST use `GatewayErrorResponse` and `Content-Type:
+application/json`.
+
+#### Scenario: Storage or cache failure rejects keyed request before upstream call
+
+- GIVEN a valid authenticated `POST /v1/chat/completions` request with `Idempotency-Key: chat-123`
+- AND the gateway cannot reserve or retrieve the required idempotency state
+- WHEN the request is handled
+- THEN the gateway MUST return HTTP 503
+- AND the response body MUST be a `GatewayErrorResponse`
+- AND `error.code` MUST equal `"idempotency_unavailable"`
+- AND the gateway MUST NOT start upstream execution
+
+### Requirement: Composition Boundaries and Deferred Concerns
+
+This slice MUST compose with the existing gateway and inbound-auth specs without widening their
+responsibilities.
+
+This slice MUST NOT change authorization rules, RBAC, rate limiting, fairness, quota policy,
+TLS policy, streaming support, or outbound provider authentication behavior.
+
+This slice MUST NOT be interpreted as a general exactly-once guarantee across providers,
+process restarts, or unrelated endpoints.
+
+#### Scenario: Streaming remains outside this slice
+
+- GIVEN a `POST /v1/chat/completions` request with `stream: true` and a valid `Idempotency-Key`
+- WHEN the gateway validates the request
+- THEN the request MUST still be rejected under the existing streaming prohibition
+- AND this idempotency slice MUST NOT define partial-response replay behavior
+
+#### Scenario: Outbound vendor auth behavior remains unchanged
+
+- GIVEN a keyed `POST /v1/chat/completions` request routed to an upstream provider
+- WHEN the gateway constructs outbound provider authentication headers
+- THEN it MUST continue to follow the existing vendor-auth contract
+- AND this slice MUST NOT add or modify outbound provider auth requirements
+
+## MODIFIED Requirements
+
+### Requirement: `POST /v1/chat/completions` Endpoint Behavior
+
+The gateway MUST continue to expose a `POST /v1/chat/completions` endpoint with the existing
+routing, validation, proxying, response mapping, and health-feedback behavior.
+
+When the request includes a valid `Idempotency-Key`, the gateway MUST apply the chat-completions
+idempotency requirements in this delta before starting upstream execution.
+
+When the request omits `Idempotency-Key`, the gateway MUST preserve the existing non-idempotent
+behavior for this route.
+
+(Previously: R8 defined routing, validation, proxying, and error mapping for
+`POST /v1/chat/completions` without a route-specific idempotency contract.)
+
+#### Scenario: Existing route behavior is preserved for requests without a key
+
+- GIVEN a valid authenticated `POST /v1/chat/completions` request without `Idempotency-Key`
+- WHEN the gateway handles the request
+- THEN the gateway MUST continue to route and proxy the request according to the existing route
+  contract
+- AND this delta MUST NOT require replay storage for that request
+
+#### Scenario: Keyed route request evaluates idempotency before proxying
+
+- GIVEN a valid authenticated `POST /v1/chat/completions` request with `Idempotency-Key: chat-123`
+- WHEN the gateway handles the request
+- THEN the gateway MUST evaluate idempotency before starting upstream execution
+- AND any replay, mismatch, or availability outcome MUST follow this delta

--- a/openspec/changes/archive/2026-04-22-rook-591-chat-completions-idempotency/state.yaml
+++ b/openspec/changes/archive/2026-04-22-rook-591-chat-completions-idempotency/state.yaml
@@ -1,0 +1,12 @@
+change: rook-591-chat-completions-idempotency
+current_phase: archive
+completed:
+  - propose
+  - spec
+  - design
+  - tasks
+  - apply
+  - verify
+  - archive
+next: none
+updated: 2026-04-22T23:59:00Z

--- a/openspec/changes/archive/2026-04-22-rook-591-chat-completions-idempotency/tasks.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-chat-completions-idempotency/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Chat Completions Idempotency for Meaningful Replay Protection
+
+## Phase 1: Test Harness and Foundations
+
+- [x] 1.1 Add failing unit tests in `clients/rook/src/idempotency/canonical.rs` for canonical JSON equivalence: object key reordering matches, array reordering mismatches, and unknown passthrough fields affect the digest.
+- [x] 1.2 Add failing unit tests in `clients/rook/src/auth/` and `clients/rook/src/config/` for principal scoping and idempotency config validation: auth-enabled scope isolation, local fallback scope, valid key syntax, invalid key rejection, and zero replay-window rejection.
+- [x] 1.3 Create `clients/rook/src/idempotency/` module skeleton plus `clients/rook/src/lib.rs` / `clients/rook/src/gateway/types.rs` wiring for shared idempotency types, replay header constant, and OpenAI-shaped idempotency error helpers.
+
+## Phase 2: Persistence and State Machine
+
+- [x] 2.1 Add failing service/database tests in `clients/rook/src/services/idempotency.rs` and/or `clients/rook/src/db/idempotency.rs` covering reserve-new, replay-completed, replay-in-progress, mismatch, and expired-record overwrite using SQLite.
+- [x] 2.2 Create `clients/rook/migrations/0004_chat_completions_idempotency.sql` and update `clients/rook/src/db/mod.rs` for the replay table, indexes, and migration registration.
+- [x] 2.3 Implement `clients/rook/src/idempotency/types.rs`, `clients/rook/src/db/idempotency.rs`, and `clients/rook/src/services/idempotency.rs` so the store enforces scoped-key semantics, terminal response persistence, and opportunistic expiry pruning.
+- [x] 2.4 Update `clients/rook/src/registry/mod.rs` to construct and expose the SQLite-backed idempotency service without affecting unrelated surfaces.
+
+## Phase 3: Route-Local Middleware and Wiring
+
+- [x] 3.1 Add failing integration tests around `clients/rook/src/server/mod.rs` / gateway router composition proving idempotency applies only to `POST /v1/chat/completions` and does not touch `/api/*` or `GET /v1/models`.
+- [x] 3.2 Add failing integration tests in the existing gateway handler test area for completed replay, in-progress replay, mismatch rejection, availability failure, and expiry behavior, asserting one upstream execution where required.
+- [x] 3.3 Implement `clients/rook/src/idempotency/middleware.rs` and `clients/rook/src/idempotency/mod.rs` to validate `Idempotency-Key`, canonicalize the raw JSON body once, reserve/replay/fail-closed, and finalize stored terminal responses with `Idempotency-Replayed: true`.
+- [x] 3.4 Update `clients/rook/src/auth/middleware.rs`, `clients/rook/src/auth/types.rs`, `clients/rook/src/gateway/mod.rs`, `clients/rook/src/gateway/handlers.rs`, and `clients/rook/src/server/mod.rs` to provide `AuthenticatedPrincipal`, preserve existing handler behavior for unkeyed requests, and compose middleware only on the chat-completions route.
+
+## Phase 4: Config and Apply Readiness
+
+- [x] 4.1 Update `clients/rook/src/config/mod.rs` and `clients/rook/src/main.rs` with route-specific idempotency config defaults and startup validation, keeping operator tuning narrow and reversible.
+- [x] 4.2 Refactor touched code/tests for clarity, ensure tasks can be checked off in `openspec/changes/rook-591-chat-completions-idempotency/tasks.md`, and confirm no streaming, `/api/*`, `GET /v1/models`, rate-limit, RBAC, TLS, or vendor-auth scope creep.

--- a/openspec/changes/archive/2026-04-22-rook-591-chat-completions-idempotency/verify-report.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-chat-completions-idempotency/verify-report.md
@@ -1,0 +1,94 @@
+## Verification Report
+
+**Change**: rook-591-chat-completions-idempotency  
+**Date**: 2026-04-22
+
+---
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 10 |
+| Tasks complete | 10 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/rook-591-chat-completions-idempotency/tasks.md` are complete.
+
+---
+
+### Test Evidence
+
+Build was intentionally not run because the user explicitly required: **Do not build the project.**
+
+#### Targeted verification commands executed
+
+1. `cargo test --manifest-path "clients/rook/Cargo.toml" canonical_json_`
+   - Result: **3 passed / 0 failed**
+2. `cargo test --manifest-path "clients/rook/Cargo.toml" services::idempotency::tests::reserve_chat_completion_returns_reserved_new_for_new_scope -- --exact`
+   - Result: **1 passed / 0 failed**
+3. `cargo test --manifest-path "clients/rook/Cargo.toml" services::idempotency::tests::reserve_chat_completion_replays_completed_response_for_equivalent_request -- --exact`
+   - Result: **1 passed / 0 failed**
+4. `cargo test --manifest-path "clients/rook/Cargo.toml" services::idempotency::tests::reserve_chat_completion_rejects_in_progress_replay_and_mismatch_and_allows_expiry -- --exact`
+   - Result: **1 passed / 0 failed**
+5. `cargo test --manifest-path "clients/rook/Cargo.toml" services::idempotency::tests::reserve_chat_completion_scopes_same_raw_key_by_principal -- --exact`
+   - Result: **1 passed / 0 failed**
+6. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::chat_idempotency_is_route_local_and_does_not_touch_models_or_admin_routes -- --exact`
+   - Result: **1 passed / 0 failed**
+7. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::chat_idempotency_replays_completed_response_without_second_upstream_call -- --exact`
+   - Result: **1 passed / 0 failed**
+8. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::chat_idempotency_rejects_in_progress_and_mismatched_replays -- --exact`
+   - Result: **1 passed / 0 failed**
+9. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::chat_idempotency_fails_closed_when_storage_is_unavailable -- --exact`
+   - Result: **1 passed / 0 failed**
+10. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::chat_idempotency_missing_key_does_not_enable_replay_protection -- --exact`
+    - Result: **1 passed / 0 failed**
+11. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::chat_idempotency_replays_completed_terminal_error_response -- --exact`
+    - Result: **1 passed / 0 failed**
+12. `cargo test --manifest-path "clients/rook/Cargo.toml" --bin rook tests::build_server_config_keeps_inbound_auth_separate`
+    - Result: **1 passed / 0 failed**
+
+#### Broader suite signal collected
+
+13. `cargo test --manifest-path "clients/rook/Cargo.toml"`
+    - Result: full Rook suite still carries unrelated existing failures in:
+      - `db::account::tests::vendor_other_with_quotes_round_trips`
+      - `routing::tests::cycle_detection_returns_routing_error`
+
+Interpretation: targeted slice evidence is clean; crate-wide noise remains outside this slice.
+
+---
+
+### Verification Summary
+
+- Idempotency applies only to `POST /v1/chat/completions`.
+- `/api/*` and `GET /v1/models` remain out of scope even when `Idempotency-Key` is present.
+- Valid keyed equivalent requests replay deterministically.
+- In-progress keyed replays return conflict without a second execution.
+- Mismatched keyed replays return conflict.
+- Completed terminal error responses replay deterministically.
+- Missing key preserves non-idempotent behavior.
+- Store unavailability fails closed.
+- Principal scoping is enforced at the replay-store layer.
+- Existing streaming and vendor-auth boundaries remain unchanged.
+
+---
+
+### Issues Found
+
+**CRITICAL**
+
+- None for this slice.
+
+**WARNING**
+
+- Full `clients/rook` suite still has two unrelated existing failures outside this slice.
+- Principal-isolation evidence is strongest at the service/store layer because the current inbound auth model is a single configured bearer token, not a multi-principal production identity system.
+
+---
+
+### Verdict
+
+**PASS WITH WARNINGS**
+
+The `rook-591-chat-completions-idempotency` slice is implemented and verified against the approved scope with passing targeted evidence. Remaining warnings are repository-level noise or identity-model limitations outside this slice’s intended boundary.

--- a/openspec/changes/archive/2026-04-22-rook-591-chat-completions-streaming-transport/design.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-chat-completions-streaming-transport/design.md
@@ -1,0 +1,365 @@
+# Design: Chat Completions Streaming Transport for OpenAI-Compatible SSE
+
+## Technical Approach
+
+This change adds a route-local streaming transport path for `POST /v1/chat/completions` in
+`clients/rook` when `ChatCompletionRequest.stream == Some(true)`. The existing buffered JSON path
+remains the default for `None` and `Some(false)`.
+
+The implementation stays inside the Rook gateway surface:
+
+- request admission and cross-cutting middleware continue to be composed in
+  `clients/rook/src/server/mod.rs`
+- route mounting remains in `clients/rook/src/gateway/mod.rs`
+- mode selection happens in `clients/rook/src/gateway/handlers.rs`
+- upstream transport helpers live in `clients/rook/src/gateway/upstream.rs`
+- provider base URL and auth header logic stay in `clients/rook/src/gateway/vendor.rs`
+
+The key design constraint is narrowness: the new streaming behavior is only for
+`POST /v1/chat/completions` with `stream: true`. `/api/*`, `GET /v1/models`, global rate limiting,
+transport baseline ownership, inbound auth, and chat idempotency semantics remain in their existing
+modules and are not redesigned here.
+
+## Architecture Decisions
+
+### Decision: Keep streaming transport inside the existing Rook gateway package
+
+**Choice**: Extend `clients/rook/src/gateway/` with streaming-specific helpers rather than adding a
+new top-level transport subsystem.
+
+**Alternatives considered**:
+
+- Add generic SSE infrastructure under `clients/rook/src/transport/`
+- Add a new top-level `streaming/` package shared across surfaces
+
+**Rationale**: The slice is explicitly route-local and surface-local. Rook already keeps
+OpenAI-compatible HTTP behavior under `gateway/`, while `transport/` owns cross-cutting request
+metadata, forwarded-header sanitization, and request ID propagation. Putting SSE adaptation into
+`gateway/` avoids widening ownership and reduces rollback scope.
+
+### Decision: Use one route and branch inside the handler by `request.stream`
+
+**Choice**: Keep a single mounted route at `/v1/chat/completions`, deserialize once into
+`ChatCompletionRequest`, then dispatch to buffered or streaming handler branches.
+
+**Alternatives considered**:
+
+- Separate internal routers or paths for streaming and non-streaming
+- Middleware-based branching before the handler
+
+**Rationale**: The public contract is one OpenAI-compatible endpoint with two transport modes.
+Branching in `handle_chat_completions` preserves today’s router structure in
+`clients/rook/src/gateway/mod.rs`, keeps request validation centralized, and minimizes changes to
+`server/mod.rs` layering.
+
+### Decision: Treat upstream streaming as a proxied byte stream with route-local SSE normalization
+
+**Choice**: Add an upstream helper that opens the provider response as a streaming `reqwest`
+response, validates success before starting downstream emission, and then converts upstream bytes
+into downstream SSE `data:` frames that satisfy the OpenAI contract.
+
+**Alternatives considered**:
+
+- Buffer the full upstream response before re-emitting SSE
+- Blindly pipe upstream bytes to the client without validation/adaptation
+- Require all vendors to expose identical SSE framing before enabling the route
+
+**Rationale**: Buffering defeats streaming. Blind passthrough is unsafe because the spec explicitly
+forbids leaking incompatible provider-native framing. Route-local normalization keeps the downstream
+contract stable while still allowing direct passthrough of already-compatible `data:` events.
+
+### Decision: Distinguish setup failures from started-stream failures at the handler boundary
+
+**Choice**: Do all fail-fast work before constructing the `Sse` response: JSON decode, routing,
+upstream request construction, auth header setup, upstream connection, and upstream status check.
+Once the first downstream event is emitted, failures become abnormal stream termination.
+
+**Alternatives considered**:
+
+- Start SSE immediately and report all later failures as SSE messages
+- Attempt to switch back to JSON error envelopes after the stream begins
+
+**Rationale**: Axum response semantics and the spec both make setup-vs-mid-stream separation the
+clean boundary. Before the response starts, normal HTTP JSON errors remain possible. After headers
+and SSE bytes are sent, changing to a buffered JSON error body is not correct.
+
+### Decision: Leave idempotency middleware out of streaming completion persistence
+
+**Choice**: Do not include the existing chat idempotency middleware on the streaming branch.
+Preserve the archived idempotency slice by keeping its responsibilities unchanged and route-local to
+buffered responses only.
+
+**Alternatives considered**:
+
+- Reuse current idempotency middleware and buffer the entire SSE stream for replay
+- Store partial stream chunks in idempotency storage
+- Introduce special replay semantics for streaming in this slice
+
+**Rationale**: The current middleware in `clients/rook/src/idempotency/middleware.rs` reads the full
+response body with `to_bytes(...)` before persisting it. That implementation is built for terminal
+HTTP bodies, not long-lived SSE streams. Including it unchanged would either break streaming or
+quietly change idempotency semantics, both out of scope for this slice.
+
+## Data Flow
+
+### Request Admission and Mode Selection
+
+```text
+Client
+  │ POST /v1/chat/completions
+  ▼
+Server router (`server/mod.rs`)
+  │
+  ├─ transport baseline middleware
+  ├─ rate-limit middleware
+  ├─ inbound auth middleware
+  └─ chat handler (`gateway/handlers.rs`)
+         │
+         ├─ parse `ChatCompletionRequest`
+         ├─ if `stream != Some(true)` → existing buffered JSON proxy path
+         └─ if `stream == Some(true)` → streaming proxy path
+```
+
+### Streaming Happy Path
+
+```text
+Client
+  │ POST /v1/chat/completions { ..., "stream": true }
+  ▼
+handle_chat_completions
+  │ parse request
+  │ resolve model route
+  │ build upstream streaming request
+  │ connect + validate upstream success
+  ▼
+open downstream SSE response
+  │
+  ├─ read upstream byte chunks
+  ├─ parse upstream SSE/event boundaries
+  ├─ pass through OpenAI-compatible `data:` JSON chunks
+  ├─ adapt incompatible provider framing into OpenAI `data:` chunks when possible
+  └─ emit terminal `data: [DONE]` once on normal completion
+  ▼
+client consumes ordered SSE chunks
+```
+
+### Failure Boundary
+
+```text
+Before first downstream SSE byte
+  └─ return normal JSON gateway error with HTTP status
+
+After first downstream SSE byte
+  └─ log failure, close stream, do NOT emit false `[DONE]`, do NOT switch to JSON body
+```
+
+### Sequence Diagram
+
+```text
+Client -> Rook server: POST /v1/chat/completions (stream=true)
+Rook server -> Transport middleware: sanitize request metadata
+Transport middleware -> Rate-limit middleware: continue
+Rate-limit middleware -> Inbound auth middleware: continue
+Inbound auth middleware -> Chat handler: continue
+Chat handler -> Routing engine: resolve(model)
+Routing engine --> Chat handler: route decision + provider account
+Chat handler -> Upstream helper: open streaming request
+Upstream helper -> Provider API: POST /v1/chat/completions
+Provider API --> Upstream helper: 200 + streaming body
+Upstream helper --> Chat handler: stream handle
+Chat handler --> Client: HTTP 200 + Content-Type: text/event-stream
+loop per upstream event
+  Provider API --> Chat handler: bytes / SSE frame
+  Chat handler --> Client: data: {OpenAI chunk}\n\n
+end
+Provider API --> Chat handler: normal completion
+Chat handler --> Client: data: [DONE]\n\n
+Chat handler --> Client: close connection
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `clients/rook/src/gateway/handlers.rs` | Modify | Split `handle_chat_completions` into buffered vs streaming execution paths; add setup-failure vs mid-stream-failure shaping; keep `/models` unchanged. |
+| `clients/rook/src/gateway/upstream.rs` | Modify | Add streaming upstream request support that returns a live upstream response/byte stream instead of buffering the full body. |
+| `clients/rook/src/gateway/types.rs` | Modify | Add streaming-specific internal types for OpenAI chunk framing and possibly reusable SSE response helpers/constants. |
+| `clients/rook/src/gateway/mod.rs` | Modify | Export any new streaming submodule(s) while keeping the same public route mount for `/chat/completions`. |
+| `clients/rook/src/gateway/streaming.rs` | Create | Route-local SSE framing, upstream event parsing, OpenAI chunk adaptation, done-sentinel emission, and stream error utilities. |
+| `clients/rook/src/server/mod.rs` | Modify | Keep middleware ordering intact, but bypass idempotency for the streaming branch by composing chat middleware more narrowly around buffered execution only. |
+| `clients/rook/src/idempotency/middleware.rs` | No functional change expected | Existing middleware remains the buffered-response implementation baseline; design explicitly avoids extending it to streaming in this slice. |
+| `openspec/changes/rook-591-chat-completions-streaming-transport/design.md` | Create | This technical design artifact. |
+| `openspec/changes/rook-591-chat-completions-streaming-transport/state.yaml` | Modify | Mark design phase complete and advance to tasks. |
+
+## Interfaces / Contracts
+
+The design keeps the public request type intact and adds internal streaming-only contracts.
+
+### Handler split
+
+```rust
+pub async fn handle_chat_completions(
+    State(state): State<GatewayState>,
+    body: Bytes,
+) -> Response
+
+async fn handle_buffered_chat_completions(
+    state: &GatewayState,
+    request: ChatCompletionRequest,
+    raw_body: Bytes,
+) -> Response
+
+async fn handle_streaming_chat_completions(
+    state: &GatewayState,
+    request: ChatCompletionRequest,
+    raw_body: Bytes,
+) -> Response
+```
+
+### Upstream streaming contract
+
+```rust
+pub struct UpstreamStreamingResponse {
+    pub status: reqwest::StatusCode,
+    pub content_type: Option<String>,
+    pub stream: reqwest::Response,
+}
+
+pub async fn open_chat_completion_stream(
+    client: &reqwest::Client,
+    account: &ProviderAccount,
+    raw_body: Bytes,
+) -> Result<UpstreamStreamingResponse, UpstreamError>
+```
+
+Notes:
+
+- This is parallel to the existing buffered `proxy_chat_completion(...)` helper.
+- The helper MUST validate base URL, auth header, request send result, and upstream success status
+  before returning success.
+- For non-success upstream status, it should continue to map into `UpstreamError::UpstreamStatus`
+  before any downstream SSE is started.
+
+### Route-local streaming adapter contract
+
+```rust
+enum StreamingSetupError {
+    InvalidRequest,
+    RoutingFailed,
+    Upstream(UpstreamError),
+}
+
+enum StreamTermination {
+    Completed,
+    Aborted,
+}
+
+struct SseFrame {
+    data: String,
+}
+```
+
+Implementation notes:
+
+- `streaming.rs` owns parsing upstream bytes into event boundaries.
+- The adapter MUST support two downstream behaviors:
+  1. passthrough of already-compatible OpenAI `data:` frames
+  2. provider-local adaptation into OpenAI-compatible chunk JSON when upstream framing is not
+     already compliant
+- The adapter MUST preserve chunk ordering.
+
+### SSE response contract at the gateway boundary
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/event-stream
+Cache-Control: no-cache
+
+data: {json chunk}
+
+data: {json chunk}
+
+data: [DONE]
+
+```
+
+Implementation notes:
+
+- Use axum SSE response primitives rather than manual string concatenation in the handler body.
+- Ordinary chunk events MUST use unnamed SSE messages with `data:` payloads only.
+- `[DONE]` is emitted exactly once on normal completion and never on abnormal termination.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | SSE frame builder emits `data:` payloads and `[DONE]` exactly once | Add focused tests in `clients/rook/src/gateway/streaming.rs` for framing helpers and done-sentinel rules. |
+| Unit | Upstream event parser distinguishes compatible SSE, incomplete frames, and malformed payloads | Feed byte chunks that split across frame boundaries and verify ordered reconstructed events. |
+| Unit | Upstream helper maps setup failures before stream start | Extend `clients/rook/src/gateway/upstream.rs` tests for missing base URL, auth header, timeout, transport failure, and non-success HTTP status on the streaming path. |
+| Integration | `stream: false` and omitted `stream` keep existing buffered behavior | Extend `clients/rook/src/gateway/handlers.rs` tests using in-process axum upstream fixtures. |
+| Integration | `stream: true` returns `200` + `text/event-stream` + ordered SSE chunks + one `[DONE]` | Add a mock upstream that emits OpenAI-compatible SSE and assert the downstream body framing. |
+| Integration | Setup failures for `stream: true` still return JSON errors | Cover invalid JSON, unknown model, upstream unavailable-before-first-byte, and upstream non-success status. |
+| Integration | Mid-stream failure closes the connection without `[DONE]` | Use a mock upstream that sends one event then aborts; assert downstream stream begins, emits chunk(s), then terminates abnormally. |
+| Integration | Route boundary remains narrow | Confirm `/v1/models` stays JSON, `/api/*` stays unaffected, and only `POST /v1/chat/completions` reacts to `stream: true`. |
+| Integration | Middleware composition boundary stays intact | In `clients/rook/src/server/mod.rs` tests, verify auth and rate limits still apply to streaming requests while streaming requests are not forced through buffered idempotency replay behavior. |
+
+## Migration / Rollout
+
+No data migration required.
+
+Rollout is code-only and route-local:
+
+1. add streaming helper module and upstream streaming request support
+2. branch chat-completions handler on `request.stream`
+3. keep auth, rate limit, and transport middleware ordering unchanged
+4. exclude streaming from buffered idempotency persistence logic
+
+Rollback is simple: remove the streaming branch and helper module, restore the prior
+`unsupported_stream` response in `handle_chat_completions`, and leave all other routes and archived
+slice boundaries untouched.
+
+## Tradeoffs and Rejected Alternatives
+
+### Tradeoff: path-specific design over reusable SSE framework
+
+This repeats some transport logic inside `gateway/`, but it keeps the change narrow and low-risk.
+The rejected alternative was a generalized SSE framework for all Rook surfaces, which would expand
+scope into `/api/*` and future routes prematurely.
+
+### Tradeoff: bypass idempotency on streaming instead of inventing replay semantics
+
+This means `stream: true` will not get the current buffered replay behavior, but that is the safest
+way to preserve the archived idempotency boundary without redefining storage and replay semantics for
+partial streams.
+
+### Tradeoff: adapt downstream framing even when some providers are not OpenAI-native
+
+This adds complexity in `gateway/streaming.rs`, but it protects the client-facing contract. The
+rejected alternative was exposing provider-native framing, which would violate the spec.
+
+### Rejected alternative: always return SSE error events after stream starts
+
+We may emit an OpenAI-compatible in-stream error event if it is clearly compatible, but the default
+strategy is abnormal termination without `[DONE]`. That keeps client semantics conservative and does
+not pretend an interrupted stream finished normally.
+
+## Rollback
+
+Rollback is route-local and practical:
+
+1. remove the streaming branch from `handle_chat_completions`
+2. delete `clients/rook/src/gateway/streaming.rs`
+3. remove upstream streaming helper additions
+4. restore the current `unsupported_stream` JSON error path
+
+This rollback does not require changes to inbound auth, transport baseline middleware, rate limit
+policy, `/api/*`, `GET /v1/models`, or the archived idempotency slice.
+
+## Open Questions
+
+- [ ] Whether any supported non-OpenAI vendors already emit OpenAI-compatible SSE for
+      `/v1/chat/completions`, or whether the first implementation should intentionally scope runtime
+      support to OpenAI-compatible upstreams while keeping the adapter seam ready for others.
+- [ ] Whether the downstream SSE response should explicitly add `X-Accel-Buffering: no` in addition
+      to `Content-Type: text/event-stream`, or keep the first slice minimal and rely only on the
+      required SSE media type.

--- a/openspec/changes/archive/2026-04-22-rook-591-chat-completions-streaming-transport/proposal.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-chat-completions-streaming-transport/proposal.md
@@ -1,0 +1,130 @@
+# Proposal: Add Chat Completions Streaming Transport for OpenAI-Compatible SSE
+
+## Intent
+
+Rook issue #591 still needs one narrow transport follow-up after the archived inbound auth,
+transport middleware baseline, global surface rate limits, and chat-completions idempotency slices.
+The remaining gap for the gateway surface is streaming delivery for `POST /v1/chat/completions`
+when the request body sets `stream: true`.
+
+This slice exists to define OpenAI-compatible server-sent events (SSE) transport for streaming chat
+completions without widening scope into `/api/*`, `GET /v1/models`, fairness/rate limiting, TLS,
+RBAC, or unrelated provider-auth work. Here is the thing: the value is transport compatibility for
+one gateway route and one request mode, not a broad rewrite of Rook’s HTTP behavior.
+
+## Scope
+
+### In Scope
+
+- Define a dedicated #591 follow-up slice for `POST /v1/chat/completions` only when `stream: true`.
+- Define the gateway response contract as OpenAI-compatible SSE for streaming chat completions.
+- Define the minimum SSE event framing, media type, and stream termination expectations required for
+  OpenAI client compatibility.
+- Define how streaming transport composes with the archived inbound-auth boundary and transport
+  middleware baseline without changing their responsibilities.
+- Define route-local expectations for upstream streaming proxying or adaptation needed to preserve
+  OpenAI-compatible SSE on the Rook gateway response.
+- Define failure behavior for streaming setup or mid-stream transport failure at the gateway
+  boundary.
+- Identify the minimal server, gateway, transport, and spec areas that follow-on spec/design work
+  must cover.
+
+### Out of Scope
+
+- Any streaming behavior for `/api/*` admin routes.
+- Any streaming behavior for `GET /v1/models`.
+- Any streaming behavior for routes outside `POST /v1/chat/completions`.
+- Non-streaming `POST /v1/chat/completions` behavior, except where explicitly needed to preserve
+  route separation from this slice.
+- Idempotency, replay protection, duplicate suppression, or request-key semantics for streaming.
+- New fairness controls, quotas, rate limiting, abuse prevention, or scheduling behavior.
+- TLS, mTLS, certificate handling, or network-edge proxy policy.
+- RBAC, route scopes, tenancy policy, or authorization-model expansion.
+- Outbound provider authentication/header changes beyond what is already required for gateway
+  proxying.
+- Streaming semantics for dashboard, docs, marketing, or any other non-Rook HTTP surface.
+
+## Approach
+
+Treat this slice as a gateway transport contract for one route and one mode: when
+`POST /v1/chat/completions` receives `stream: true`, Rook should return an OpenAI-compatible SSE
+response instead of the standard buffered JSON completion payload. The follow-on spec/design should
+define the wire contract at the Rook boundary first, then identify the smallest internal transport
+changes needed to proxy or adapt upstream provider streaming into that contract.
+
+The core contract is simple:
+
+- Only `POST /v1/chat/completions` with `stream: true` participates in this slice.
+- The response MUST be emitted as OpenAI-compatible SSE.
+- `/api/*` remains unaffected.
+- `GET /v1/models` remains unaffected.
+- This slice MUST NOT introduce new fairness/rate-limit responsibilities.
+- This slice MUST remain transport-focused and SHOULD avoid changing archived auth, middleware,
+  rate-limit, or idempotency responsibilities.
+
+This proposal intentionally avoids promising broader streaming support across every surface. The
+design work should stay disciplined: preserve current route boundaries, keep rollback easy, and make
+the OpenAI-shaped SSE contract explicit enough that clients can consume streamed chat-completion
+deltas without relying on route-specific custom behavior.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `clients/rook/src/server/mod.rs` | Modified | Compose streaming handling only for `POST /v1/chat/completions` when `stream: true`, without widening behavior to `/api/*` or `GET /v1/models`. |
+| `clients/rook/src/gateway/` | Modified | Add or refine chat-completions streaming response handling so the gateway emits OpenAI-compatible SSE. |
+| `clients/rook/src/transport/` or gateway streaming helper modules | New or Modified | Add route-local streaming transport helpers, SSE framing utilities, and stream-failure shaping if needed. |
+| `clients/rook/src/gateway/vendor.rs` | Modified only if required for existing proxying | Preserve current outbound proxy responsibilities while enabling upstream streaming passthrough/adaptation; no broader auth-scope expansion. |
+| `openspec/specs/gateway/spec.md` | Modified (follow-on) | Add delta requirements for `POST /v1/chat/completions` streaming transport, OpenAI-compatible SSE framing, termination, and excluded surfaces. |
+| `openspec/changes/rook-591-chat-completions-streaming-transport/` | New | Proposal and follow-on spec/design/tasks artifacts for this slice. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Streaming behavior leaks onto `/api/*` or `GET /v1/models` because transport code is shared | High | State explicit route boundaries in spec/design and require route-level composition for `POST /v1/chat/completions` only. |
+| SSE emitted by Rook is not OpenAI-compatible enough for existing clients | High | Define explicit framing, media type, chunk/event shape, and termination requirements in follow-on spec/design. |
+| Mid-stream upstream failure produces ambiguous client-visible behavior | Medium | Define gateway failure handling for setup-time and in-flight failures, including what can and cannot be represented once streaming has started. |
+| Provider-specific streaming formats bleed through directly and break the gateway contract | Medium | Normalize or adapt upstream streaming to the OpenAI SSE shape at the gateway boundary rather than exposing provider-native framing. |
+| This slice accidentally reopens idempotency, rate-limit, or auth-scope debates | Medium | Keep proposal bounded to streaming transport only and explicitly defer adjacent concerns already handled by separate #591 slices. |
+| Long-lived streams interact awkwardly with existing transport middleware/tracing behavior | Medium | Reuse archived middleware baseline as-is where possible and let follow-on design document any stream-safe completion/tracing expectations without changing ownership. |
+
+## Rollback Plan
+
+If this slice causes regressions or interoperability problems, revert the route-local streaming
+transport changes for `POST /v1/chat/completions` with `stream: true`, remove any SSE helper wiring
+or gateway adaptation introduced for this feature, and restore the prior non-streaming behavior for
+that request mode. Because this slice is intentionally narrow, rollback should not require changes to
+`/api/*`, `GET /v1/models`, archived inbound auth behavior, transport middleware baseline,
+global rate limits, chat-completions idempotency, TLS policy, RBAC, or broader provider-auth logic.
+
+## Dependencies
+
+- The archived `rook-591-inbound-auth-boundary` slice remains a completed prerequisite and must stay
+  separate from this streaming transport slice.
+- The archived `rook-591-transport-middleware-baseline` slice remains the transport composition
+  baseline and should continue to own cross-cutting middleware concerns instead of pushing them into
+  streaming-specific business logic.
+- The archived `rook-591-global-surface-rate-limits` slice remains separate; this change must not
+  absorb fairness, quota, or admission-control responsibilities.
+- The archived `rook-591-chat-completions-idempotency` slice remains separate; streaming transport in
+  this slice must not redefine replay behavior or request-key semantics.
+- Existing gateway routing in `clients/rook/src/server/mod.rs` must continue to keep `/api/*`,
+  `GET /v1/models`, and `POST /v1/chat/completions` clearly separated by responsibility.
+- The gateway spec in `openspec/specs/gateway/spec.md` will need a follow-on delta for streaming
+  `POST /v1/chat/completions` semantics and OpenAI-compatible SSE behavior.
+- Follow-on design work must confirm whether upstream providers can be proxied directly as SSE or
+  require gateway-side adaptation to preserve the OpenAI wire contract.
+
+## Success Criteria
+
+- [ ] The change remains narrowly scoped to `POST /v1/chat/completions` when `stream: true`.
+- [ ] The proposal explicitly requires OpenAI-compatible SSE for the response transport.
+- [ ] The proposal explicitly excludes `/api/*` and `GET /v1/models` from this slice.
+- [ ] The proposal stays transport-focused and does not absorb fairness/rate limiting, TLS, RBAC, or
+      unrelated outbound provider-auth work.
+- [ ] The proposal makes setup-time and mid-stream failure behavior important follow-on design/spec
+      concerns.
+- [ ] The rollback plan is route-local and does not require undoing archived #591 slices.
+- [ ] The change is ready for `sdd-spec` and `sdd-design` to define concrete streaming requirements
+      and technical decisions.

--- a/openspec/changes/archive/2026-04-22-rook-591-chat-completions-streaming-transport/specs/gateway/spec.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-chat-completions-streaming-transport/specs/gateway/spec.md
@@ -1,0 +1,323 @@
+# Delta for gateway
+
+## MODIFIED Requirements
+
+### Requirement: OpenAI-Compatible Request Types
+
+The `ChatCompletionRequest` type defined by the gateway spec MUST continue to deserialize the
+OpenAI `POST /v1/chat/completions` request body shape.
+
+For this slice, `stream` MUST remain an optional boolean request field, but `stream: true` MUST be
+treated as a supported request mode only for `POST /v1/chat/completions`.
+
+When `stream` is `None` or `Some(false)`, the request MUST continue to follow the non-streaming
+behavior already defined by the main gateway spec.
+
+When `stream` is `Some(true)`, the request MUST follow the streaming transport contract defined by
+this delta spec and MUST NOT be rejected merely because streaming was requested.
+
+(Previously: the main gateway spec allowed `stream` as an optional field but required the gateway
+to reject `stream: true` before routing.)
+
+#### Scenario: `stream: true` selects the streaming transport mode
+
+- GIVEN a syntactically valid `POST /v1/chat/completions` request body
+- AND the body contains `"stream": true`
+- WHEN the gateway validates the request contract
+- THEN the request MUST be eligible for the streaming transport path
+- AND the gateway MUST NOT reject the request solely because `stream` is `true`
+
+#### Scenario: `stream: false` remains on the buffered JSON path
+
+- GIVEN a syntactically valid `POST /v1/chat/completions` request body
+- AND the body contains `"stream": false`
+- WHEN the gateway handles the request
+- THEN the request MUST continue to use the existing non-streaming chat completions behavior
+
+---
+
+### Requirement: `POST /v1/chat/completions` Endpoint Behavior
+
+The gateway MUST expose `POST /v1/chat/completions` with two route-local transport modes only for
+this endpoint:
+
+1. buffered JSON behavior when `stream` is `None` or `Some(false)`
+2. OpenAI-compatible SSE behavior when `stream` is `Some(true)`
+
+When `stream` is `Some(true)`, the gateway MUST:
+
+1. accept a JSON request body conforming to `ChatCompletionRequest`
+2. extract `model` for routing
+3. resolve routing using the existing gateway routing contract
+4. construct the upstream chat completions request for the routed provider
+5. preserve the original logical request semantics while adapting transport to the SSE response
+6. return an SSE response contract instead of the buffered JSON completion payload
+
+This streaming slice MUST apply only to `POST /v1/chat/completions` and MUST NOT widen streaming
+requirements to `/api/*`, `GET /v1/models`, or any other route.
+
+(Previously: the main gateway spec defined only buffered JSON behavior for this endpoint and
+required rejection when `stream: true`.)
+
+#### Scenario: streaming behavior is route-local to chat completions
+
+- GIVEN Rook serves `/api/*`, `GET /v1/models`, and `POST /v1/chat/completions`
+- WHEN a client requests streaming chat completions with `POST /v1/chat/completions` and
+  `"stream": true`
+- THEN this delta spec MUST apply to that request
+- AND this delta spec MUST NOT require SSE behavior for `/api/*`
+- AND this delta spec MUST NOT require SSE behavior for `GET /v1/models`
+
+#### Scenario: streaming request still uses existing routing inputs
+
+- GIVEN a valid `POST /v1/chat/completions` request body with `"model": "gpt-4o"` and
+  `"stream": true`
+- WHEN the gateway handles the request
+- THEN the gateway MUST resolve routing from the `model` field using the existing routing contract
+- AND the streaming mode MUST NOT bypass route resolution
+
+---
+
+### Requirement: Stream Rejection
+
+The gateway MUST NOT reject `POST /v1/chat/completions` merely because the request body contains
+`stream: true`.
+
+The gateway MAY still reject the request for ordinary pre-stream validation failures already covered
+by the gateway spec, including malformed JSON, missing required fields, authentication failure, no
+route, or other setup-time preconditions.
+
+(Previously: the gateway was required to return HTTP 400 with `unsupported_stream` whenever
+`stream: true` was present.)
+
+#### Scenario: valid streaming request is not rejected as unsupported
+
+- GIVEN any valid authenticated `POST /v1/chat/completions` request
+- AND the request body contains `"stream": true`
+- WHEN the gateway evaluates whether streaming is supported
+- THEN the gateway MUST NOT return `400 Bad Request` with `unsupported_stream`
+
+## ADDED Requirements
+
+### Requirement: Chat Completions Streaming Scope Boundary
+
+This slice MUST define streaming transport behavior only for `POST /v1/chat/completions` when the
+request body sets `stream: true`.
+
+This slice MUST NOT redefine:
+
+- `/api/*` behavior
+- `GET /v1/models` behavior
+- non-streaming `POST /v1/chat/completions` semantics except where needed to distinguish the
+  streaming path
+- fairness controls, quotas, or rate limiting
+- TLS or network-edge policy
+- RBAC or authorization-model expansion
+- chat-completions idempotency or replay behavior
+- unrelated outbound provider-auth responsibilities
+
+This slice MUST compose with the archived inbound-auth boundary, transport-middleware baseline,
+global-surface-rate-limit, and chat-completions idempotency slices without absorbing their
+responsibilities.
+
+#### Scenario: archived auth boundary remains separate
+
+- GIVEN the archived inbound-auth boundary defines who may call `POST /v1/chat/completions`
+- WHEN this streaming transport slice is evaluated
+- THEN acceptance for this slice MUST NOT require changing that auth boundary
+- AND the streaming contract MUST start only after ordinary request admission succeeds
+
+#### Scenario: archived middleware and rate-limit slices remain separate
+
+- GIVEN the archived transport-middleware and global-surface-rate-limit slices already define their
+  own boundary behavior
+- WHEN a streaming chat completion request is handled
+- THEN this slice MUST allow those slices to continue owning their existing concerns
+- AND this slice MUST NOT require new fairness, quota, or middleware ownership changes
+
+#### Scenario: archived idempotency slice remains separate
+
+- GIVEN the archived chat-completions idempotency slice defines replay behavior for
+  `POST /v1/chat/completions`
+- WHEN this streaming transport slice is accepted
+- THEN acceptance for this slice MUST NOT require redefining idempotency storage, replay, or key
+  semantics
+
+---
+
+### Requirement: Streaming Request Contract for `stream: true`
+
+When `POST /v1/chat/completions` receives `stream: true`, the request body MUST still satisfy the
+existing `ChatCompletionRequest` contract, including required `model` and `messages` fields.
+
+For this slice, `stream: true` MUST be interpreted as a request for an OpenAI-compatible streaming
+response over SSE.
+
+The gateway MUST preserve the same logical request payload for routing and upstream invocation,
+except for transport-local adaptation required to produce the downstream OpenAI-compatible SSE
+contract.
+
+The gateway MUST fail before starting the response stream if the request is invalid, unauthorized,
+unroutable, or otherwise unable to begin streaming safely.
+
+#### Scenario: valid `stream: true` request uses the normal chat request schema
+
+- GIVEN a request body containing `model`, `messages`, and `"stream": true`
+- WHEN the body satisfies the ordinary chat completions request contract
+- THEN the gateway MUST treat it as a valid streaming chat completions request
+
+#### Scenario: invalid `stream: true` request fails before streaming starts
+
+- GIVEN a `POST /v1/chat/completions` request body with `"stream": true`
+- AND the body is malformed or missing a required field
+- WHEN the gateway validates the request
+- THEN the gateway MUST return a non-SSE gateway error response
+- AND the gateway MUST NOT begin an SSE stream
+
+---
+
+### Requirement: Streaming SSE Response Contract
+
+When `POST /v1/chat/completions` is handled with `stream: true`, the gateway MUST return an
+OpenAI-compatible Server-Sent Events response.
+
+The response MUST:
+
+- use HTTP status `200 OK` when streaming setup succeeds
+- use `Content-Type: text/event-stream`
+- frame each streamed payload as SSE `data:` records separated according to SSE message framing
+- emit OpenAI-compatible chat completion chunk payloads as the SSE `data:` content
+- avoid requiring custom event names for ordinary completion chunks
+
+Each non-terminal chunk payload emitted by the gateway MUST be valid JSON representing an
+OpenAI-compatible chat completion chunk object for the streamed request.
+
+The gateway MUST preserve ordering of downstream chunk delivery.
+
+The gateway MUST NOT require clients to interpret provider-native framing that differs from the
+OpenAI SSE contract.
+
+#### Scenario: successful streaming response uses SSE media type and framing
+
+- GIVEN a valid authenticated `POST /v1/chat/completions` request with `"stream": true`
+- AND streaming setup succeeds
+- WHEN the gateway begins the response
+- THEN the HTTP response status MUST be `200 OK`
+- AND the `Content-Type` header MUST be `text/event-stream`
+- AND each streamed message delivered to the client MUST be framed as an SSE `data:` event
+
+#### Scenario: provider-native streaming must not leak through unchanged when incompatible
+
+- GIVEN an upstream provider emits a streaming format that is not already OpenAI-compatible SSE
+- WHEN the gateway forwards the stream downstream
+- THEN the gateway MUST adapt the downstream wire format to the OpenAI-compatible SSE contract
+- AND the client MUST NOT be required to parse provider-specific framing
+
+---
+
+### Requirement: Stream Termination and Done Sentinel
+
+For a successfully started streaming response, the gateway MUST terminate the downstream stream
+using the OpenAI-compatible done sentinel `data: [DONE]` before closing the SSE response when the
+upstream stream completes normally.
+
+The gateway MUST send the done sentinel at most once per successfully started stream.
+
+After emitting `data: [DONE]`, the gateway MUST close the SSE stream and MUST NOT emit additional
+chat completion chunk events.
+
+If the stream cannot complete normally after it has already started, the gateway MUST NOT emit a
+false done sentinel.
+
+#### Scenario: normal completion ends with one done sentinel
+
+- GIVEN a streaming chat completions response has started successfully
+- AND the upstream stream completes normally
+- WHEN the gateway finishes the downstream response
+- THEN the final terminal SSE payload MUST be `data: [DONE]`
+- AND the gateway MUST close the stream after that sentinel
+- AND the gateway MUST NOT emit a second done sentinel
+
+#### Scenario: no extra chunks after done sentinel
+
+- GIVEN the gateway has emitted `data: [DONE]`
+- WHEN the SSE response is considered complete
+- THEN the gateway MUST NOT emit any additional chunk payloads after the done sentinel
+
+---
+
+### Requirement: Setup Failure Versus Mid-Stream Failure Contract
+
+The gateway MUST distinguish setup-time failures from failures that occur after the SSE response has
+already started.
+
+Setup-time failures are failures detected before the gateway begins the SSE response, including but
+not limited to request validation failure, authentication failure, routing failure, upstream
+connection failure before the first downstream SSE event, and upstream refusal before streaming
+begins.
+
+For setup-time failures, the gateway MUST return the ordinary non-SSE gateway error response
+envelope with the appropriate HTTP status, and MUST NOT begin the SSE response.
+
+Mid-stream failures are failures detected after the gateway has begun emitting the SSE response.
+
+For mid-stream failures, the gateway:
+
+- MUST terminate the downstream connection promptly
+- MUST NOT switch the response into a non-SSE JSON error envelope after streaming has started
+- MUST NOT emit `data: [DONE]` unless the stream actually completed normally
+
+If the gateway can represent an in-stream failure without breaking OpenAI compatibility, it MAY emit
+an OpenAI-compatible SSE error event before terminating, but it MUST still treat the stream as
+abnormal termination rather than normal completion.
+
+#### Scenario: routing failure before stream starts returns normal gateway error
+
+- GIVEN a `POST /v1/chat/completions` request with `"stream": true`
+- AND no route exists for the requested model
+- WHEN the gateway handles the request
+- THEN the gateway MUST return a non-SSE gateway error response
+- AND the gateway MUST NOT begin the SSE response
+
+#### Scenario: upstream connection failure before first SSE event returns normal gateway error
+
+- GIVEN a valid streaming request
+- AND the upstream provider cannot be reached before streaming begins
+- WHEN the gateway attempts to start the stream
+- THEN the gateway MUST return a non-SSE gateway error response
+- AND the gateway MUST NOT emit any SSE chunk to the client
+
+#### Scenario: failure after streaming begins closes the stream without done sentinel
+
+- GIVEN a streaming chat completions response has already emitted at least one SSE chunk
+- AND a transport or upstream failure occurs before normal completion
+- WHEN the gateway terminates the response
+- THEN the gateway MUST close the downstream stream
+- AND the gateway MUST NOT emit `data: [DONE]`
+- AND the gateway MUST NOT replace the in-flight response with a buffered JSON error body
+
+---
+
+### Requirement: Streaming Slice Non-Goals and Deferred Concerns
+
+This slice MUST remain transport-focused and MUST treat the following as non-goals or deferred
+concerns:
+
+- `/api/*` streaming support
+- `GET /v1/models` streaming support
+- fairness, admission-control policy, quotas, or rate limiting changes
+- TLS, mTLS, edge proxying, or certificate behavior
+- RBAC, tenancy, or broader authorization changes
+- global transport middleware redesign
+- chat-completions idempotency semantics for streaming retries or replay
+- provider-auth redesign beyond what existing gateway proxying already requires
+- unrelated provider feature normalization outside the OpenAI-compatible downstream SSE contract
+
+Acceptance for this slice MUST NOT depend on solving those concerns.
+
+#### Scenario: acceptance does not require unrelated deferred work
+
+- GIVEN this streaming transport slice is implemented as specified
+- WHEN acceptance is evaluated
+- THEN acceptance MUST NOT require adding `/api/*` streaming, `GET /v1/models` streaming,
+  fairness controls, TLS changes, RBAC changes, or idempotency redesign

--- a/openspec/changes/archive/2026-04-22-rook-591-chat-completions-streaming-transport/state.yaml
+++ b/openspec/changes/archive/2026-04-22-rook-591-chat-completions-streaming-transport/state.yaml
@@ -1,0 +1,12 @@
+change: rook-591-chat-completions-streaming-transport
+current_phase: archive
+completed:
+  - propose
+  - spec
+  - design
+  - tasks
+  - apply
+  - verify
+  - archive
+next: none
+updated: 2026-04-22T00:00:00Z

--- a/openspec/changes/archive/2026-04-22-rook-591-chat-completions-streaming-transport/tasks.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-chat-completions-streaming-transport/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Chat Completions Streaming Transport for OpenAI-Compatible SSE
+
+## Phase 1: Red — Streaming transport tests
+
+- [x] 1.1 Add unit tests in `clients/rook/src/gateway/streaming.rs` for SSE frame building, ordered chunk reconstruction across split byte boundaries, malformed frame rejection, and single `[DONE]` emission.
+- [x] 1.2 Extend tests in `clients/rook/src/gateway/upstream.rs` for streaming setup failures: missing vendor base URL/auth, upstream transport failure, and non-success upstream status before any downstream SSE starts.
+- [x] 1.3 Extend integration tests in `clients/rook/src/gateway/handlers.rs` so `stream: false` or omitted `stream` stays on the existing buffered JSON path.
+- [x] 1.4 Add integration tests in `clients/rook/src/gateway/handlers.rs` for `stream: true`: `200 OK`, `Content-Type: text/event-stream`, ordered `data:` chunks, and exactly one terminal `data: [DONE]` on normal completion.
+- [x] 1.5 Add integration tests in `clients/rook/src/gateway/handlers.rs` and/or `clients/rook/src/server/mod.rs` for setup-time JSON errors, mid-stream abort without `[DONE]`, `/v1/models` and `/api/*` staying unchanged, and streaming requests still passing auth/rate-limit while bypassing buffered idempotency replay.
+
+## Phase 2: Green — Route-local streaming primitives
+
+- [x] 2.1 Create `clients/rook/src/gateway/streaming.rs` with route-local SSE helpers: upstream event parsing, OpenAI-compatible `data:` frame emission, ordered chunk adaptation/passthrough, normal completion sentinel, and abnormal termination utilities.
+- [x] 2.2 Update `clients/rook/src/gateway/types.rs` with the minimal internal streaming types/constants needed by the adapter and handler, without changing the public chat request schema.
+- [x] 2.3 Update `clients/rook/src/gateway/upstream.rs` to add `open_chat_completion_stream(...)` that opens a live upstream stream and fails fast on request-construction, auth, connection, timeout, or upstream-status errors before downstream SSE begins.
+
+## Phase 3: Green — Handler and server wiring
+
+- [x] 3.1 Update `clients/rook/src/gateway/handlers.rs` to branch `handle_chat_completions` on `request.stream`, keep buffered behavior for `None`/`Some(false)`, and route `Some(true)` into the streaming path with setup-vs-mid-stream failure separation.
+- [x] 3.2 Update `clients/rook/src/gateway/mod.rs` to expose the streaming module while preserving the single public `/v1/chat/completions` route mount and leaving `/v1/models` behavior untouched.
+- [x] 3.3 Update `clients/rook/src/server/mod.rs` so transport baseline, rate-limit, and inbound auth still wrap streaming requests, but buffered idempotency composition does not force body capture/replay for the streaming branch.
+
+## Phase 4: Refactor / finish
+
+- [x] 4.1 Refactor duplicated streaming/buffered helper code across `clients/rook/src/gateway/{handlers.rs,upstream.rs,streaming.rs}` only after tests pass, keeping ownership route-local and rollback simple.
+- [x] 4.2 Run the smallest relevant Rust test targets for the touched Rook gateway/server modules and record any follow-up gaps before handing off to `sdd-apply` completion verification.

--- a/openspec/changes/archive/2026-04-22-rook-591-chat-completions-streaming-transport/verify-report.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-chat-completions-streaming-transport/verify-report.md
@@ -1,0 +1,72 @@
+## Verification Report
+
+**Change**: rook-591-chat-completions-streaming-transport  
+**Date**: 2026-04-22
+
+---
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 8 |
+| Tasks complete | 8 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/rook-591-chat-completions-streaming-transport/tasks.md` are complete.
+
+---
+
+### Test Evidence
+
+Build was intentionally not run because the user explicitly required: **Do not build the project.**
+
+#### Targeted verification commands executed
+
+1. `cargo test --manifest-path "clients/rook/Cargo.toml" parser_reconstructs_ordered_events_across_split_boundaries`
+   - Result: **1 passed / 0 failed**
+2. `cargo test --manifest-path "clients/rook/Cargo.toml" gateway::handlers::tests::chat_completions_stream_true_returns_sse_chunks_and_done -- --exact`
+   - Result: **1 passed / 0 failed**
+3. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::streaming_chat_requests_bypass_buffered_idempotency_validation -- --exact`
+   - Result: **1 passed / 0 failed**
+4. `cargo test --manifest-path "clients/rook/Cargo.toml" gateway::handlers::tests::chat_completions_stream_true_midstream_abort_does_not_emit_done -- --exact`
+   - Result: **1 passed / 0 failed**
+
+#### Broader suite signal collected
+
+5. `cargo test --manifest-path "clients/rook/Cargo.toml"`
+   - Result: full Rook suite executes with existing unrelated repository-level failures outside this slice.
+
+---
+
+### Verification Summary
+
+- Streaming remains route-local to `POST /v1/chat/completions` with `stream: true`.
+- OpenAI-compatible SSE framing is emitted with the expected content type.
+- Ordered upstream `data:` frames are reconstructed and forwarded correctly.
+- `[DONE]` is emitted exactly once on normal completion.
+- Setup failures still return JSON gateway errors before streaming starts.
+- Mid-stream abnormal termination omits `[DONE]`.
+- Buffered idempotency replay logic is bypassed for streaming requests.
+- Existing auth, transport middleware, and rate limiting boundaries remain separate.
+
+---
+
+### Issues Found
+
+**CRITICAL**
+
+- None for this slice.
+
+**WARNING**
+
+- SSE normalization is intentionally narrow in this first pass and primarily targets already OpenAI-compatible upstream framing.
+- Full `clients/rook` suite still carries unrelated repository-level failures outside this slice.
+
+---
+
+### Verdict
+
+**PASS WITH WARNINGS**
+
+The `rook-591-chat-completions-streaming-transport` slice is implemented and verified against the approved scope with passing targeted evidence. Remaining warnings are intentionally narrow adaptation scope and unrelated crate-wide test noise.

--- a/openspec/changes/archive/2026-04-22-rook-591-global-surface-rate-limits/design.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-global-surface-rate-limits/design.md
@@ -1,0 +1,501 @@
+# Design: Add Global Surface Rate Limits for Rook Transport Entry Points
+
+## Technical Approach
+
+This slice adds a dedicated global-by-surface admission-control layer inside Rook's existing
+transport boundary composition in `clients/rook/src/server/mod.rs`. The rate-limit boundary sits in
+front of covered admin and gateway handlers, but remains separate from the archived inbound auth
+boundary and transport middleware baseline by extending the top-level `transport` module rather than
+mixing logic into `auth`, `admin`, or `gateway` business handlers.
+
+The implementation approach is:
+
+1. extend `ServerConfig` and `config/mod.rs` with a startup-validated rate-limit subtree that defines
+   one global policy per covered surface
+2. add a focused transport rate-limit component that owns shared in-memory counters/windows,
+   admission decisions, and `Retry-After` derivation
+3. compose that component as surface-specific middleware around only these covered surfaces:
+   - all `/api/*`
+   - `GET /v1/models`
+   - `POST /v1/chat/completions`
+4. return transport-boundary `429 Too Many Requests` responses without invoking downstream handler
+   logic when the applicable surface budget is exhausted
+5. preserve existing error-envelope contracts by shaping `/api/*` rejections with the admin error
+   body and `/v1/*` rejections with the gateway/OpenAI-style error body
+
+This matches the proposal and delta spec by keeping the slice intentionally coarse-grained:
+startup/config-driven, global-by-surface only, and limited to three covered HTTP surfaces. It does
+not introduce per-client partitioning, streaming behavior, idempotency, TLS, RBAC, or outbound
+provider-auth changes.
+
+## Architecture Decisions
+
+### Decision: Put the rate-limit boundary at server router composition, outside handlers
+
+**Choice**: Apply rate limiting in `clients/rook/src/server/mod.rs` where the combined axum server
+already nests `/api` and `/v1` routers.
+
+**Alternatives considered**:
+- add checks inside each admin and gateway handler
+- attach separate ad hoc middleware inside individual handler modules only
+
+**Rationale**:
+- `server/mod.rs` is already the shared composition point for covered transport surfaces.
+- The spec requires rejection before normal handler business logic executes.
+- Composition-level placement keeps dashboard routes and other uncovered routes out of scope by router
+  topology instead of fragile path checks spread across handlers.
+- It preserves rollback simplicity: remove the transport admission layer without redesigning admin or
+  gateway business code.
+
+### Decision: Keep rate limiting in the transport module, separate from archived auth and baseline slices
+
+**Choice**: Add rate-limit types/helpers under `clients/rook/src/transport/` and keep archived auth
+middleware unchanged except for composition order.
+
+**Alternatives considered**:
+- extend `clients/rook/src/auth/middleware.rs` to own throttling decisions
+- fold rate limiting into `gateway/handlers.rs` and duplicate admin behavior separately
+
+**Rationale**:
+- The archived inbound auth slice owns credential validation, not traffic shaping.
+- The archived transport baseline already established the correct home for cross-cutting transport
+  policy.
+- Separating modules keeps this slice independently reversible and avoids reopening unrelated auth,
+  request ID, forwarded-header, or vendor-auth concerns.
+
+### Decision: Model coverage as three distinct surface budgets, not one `/v1/*` budget
+
+**Choice**: Introduce a new covered-surface enum/value set for:
+- `AdminApi`
+- `GatewayModels`
+- `GatewayChatCompletions`
+
+and map requests to exactly one of those budgets when they are in scope.
+
+**Alternatives considered**:
+- reuse the existing `RouteSurface::{AdminApi, GatewayV1}` only
+- use one shared budget for all `/v1/*` traffic
+- key budgets by full request path string
+
+**Rationale**:
+- The spec requires `/v1/models` and `/v1/chat/completions` to have independent budgets.
+- Reusing `GatewayV1` would collapse two required policies into one.
+- Full-path keys would over-generalize the slice and create accidental behavior for future routes.
+- A narrow dedicated enum keeps scope explicit and testable.
+
+### Decision: Use fixed-window admission with integer-second `Retry-After`
+
+**Choice**: Represent each configured policy as `max_requests` within `window_seconds`, backed by an
+in-memory fixed window per surface. Rejections return `Retry-After` as the number of whole seconds
+until the current window resets, with a minimum emitted value of `1` on rejection.
+
+**Alternatives considered**:
+- token bucket / leaky bucket
+- sliding window with per-request timestamps
+- hard-coded `Retry-After` independent of remaining window time
+
+**Rationale**:
+- Startup-configured coarse surface protection does not need the complexity of token-bucket refill
+  math or timestamp queues.
+- Fixed windows are simple to validate, easy to explain to operators, and easy to test with a
+  controllable clock.
+- Deriving `Retry-After` from a known window reset time gives deterministic rejection guidance.
+- This slice values clarity and rollbackability over fairness smoothness.
+
+### Decision: Make configuration fail closed and explicit for all three covered surfaces
+
+**Choice**: Add a required `RateLimitConfig` subtree that includes explicit policies for all three
+covered surfaces and validate them during startup alongside existing inbound-auth and transport
+validation.
+
+**Alternatives considered**:
+- optional per-surface config with implicit defaults
+- enable rate limiting only for configured surfaces and silently skip missing ones
+- infer limits from unrelated gateway/admin settings
+
+**Rationale**:
+- The spec requires startup/config initialization to fail closed when the configuration is missing,
+  malformed, or contradictory.
+- Explicit per-surface entries prevent ambiguous partial protection.
+- Keeping config separate from auth and vendor credentials preserves slice boundaries.
+
+### Decision: Preserve existing surface-specific error envelopes for 429s
+
+**Choice**: Add rate-limit response helpers that reuse the established response shapes:
+- `/api/*` → `AdminErrorResponse`
+- `/v1/models` and `/v1/chat/completions` → `GatewayErrorResponse`
+
+Each helper sets status `429` and the `Retry-After` header.
+
+**Alternatives considered**:
+- one shared generic JSON error shape for all surfaces
+- plain-text `429` body
+- pushing 429 shaping down into handlers
+
+**Rationale**:
+- The delta spec explicitly requires different body contracts for `/api/*` and `/v1/*`.
+- Rook already centralizes those shapes in `admin/types.rs` and `gateway/types.rs`.
+- Middleware-owned shaping guarantees the rejection contract without invoking business handlers.
+
+### Decision: Place rate limiting outside auth so 429s can short-circuit before auth/handler work
+
+**Choice**: For covered routes, compose rate-limit middleware outside the archived inbound auth
+middleware and outside handler execution.
+
+**Alternatives considered**:
+- authenticate first, then rate limit
+- combine auth and rate limiting in one new middleware layer
+
+**Rationale**:
+- The proposal's goal is to shed excess request volume before admin or gateway handlers are
+  overloaded.
+- Keeping middleware separate avoids reinterpreting the archived auth slice.
+- The only behavioral change to auth ordering is earlier rejection by this slice's own `429`
+  contract, which the spec explicitly allows.
+
+## Data Flow
+
+### Covered Request Flow
+
+```text
+Client Request
+   |
+   v
+Combined Router (`server/mod.rs`)
+   |
+   +--> `/api/*`
+   |       |
+   |       v
+   |   transport baseline
+   |       |
+   |       v
+   |   admin global rate-limit middleware
+   |       |
+   |       +--> reject -> 429 admin error + Retry-After
+   |       |
+   |       v
+   |   archived inbound auth middleware
+   |       |
+   |       v
+   |   admin handler
+   |
+   +--> `/v1/models`
+   |       |
+   |       v
+   |   transport baseline
+   |       |
+   |       v
+   |   models global rate-limit middleware
+   |       |
+   |       +--> reject -> 429 gateway error + Retry-After
+   |       |
+   |       v
+   |   archived inbound auth middleware
+   |       |
+   |       v
+   |   gateway models handler
+   |
+   +--> `/v1/chat/completions`
+   |       |
+   |       v
+   |   transport baseline
+   |       |
+   |       v
+   |   chat global rate-limit middleware
+   |       |
+   |       +--> reject -> 429 gateway error + Retry-After
+   |       |
+   |       v
+   |   archived inbound auth middleware
+   |       |
+   |       v
+   |   gateway chat handler
+   |
+   \--> dashboard + other routes unchanged
+```
+
+### Rate-Limit State Flow
+
+```text
+Request enters covered surface
+   |
+   v
+Resolve covered surface key
+   |
+   v
+Load policy for that surface
+   |
+   v
+Read in-memory surface window state
+   |
+   +--> window expired --> reset count and window_start
+   |
+   +--> count < max_requests --> increment and admit
+   |
+   \--> count >= max_requests --> reject and derive Retry-After from window_end - now
+```
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as server/mod.rs
+    participant T as transport::middleware baseline
+    participant RL as transport::rate_limit middleware
+    participant A as auth::middleware
+    participant H as admin/gateway handler
+
+    C->>S: HTTP request to covered surface
+    S->>T: dispatch into covered router
+    T->>RL: forward request with transport context
+    RL->>RL: resolve surface policy
+    RL->>RL: read/reset/increment fixed window state
+    alt budget exhausted
+        RL-->>T: 429 + Retry-After + surface-specific error body
+        T-->>C: completed response with request ID header
+    else budget available
+        RL->>A: continue request
+        A->>H: invoke protected handler if auth passes
+        H-->>T: normal response
+        T-->>C: completed response with request ID header
+    end
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `clients/rook/src/lib.rs` | Modify | Export any new transport rate-limit module/types needed by server composition. |
+| `clients/rook/src/server/mod.rs` | Modify | Extend `ServerConfig`, validate rate-limit config at startup, create shared rate-limit state, and compose surface-specific middleware for `/api/*`, `/v1/models`, and `/v1/chat/completions`. |
+| `clients/rook/src/main.rs` | Modify | Populate `ServerConfig.rate_limits` with explicit startup values for all three covered surfaces in the current CLI-driven startup path. |
+| `clients/rook/src/config/mod.rs` | Modify | Add `RateLimitConfig` and validation helpers separate from inbound auth and transport baseline config. |
+| `clients/rook/src/transport/mod.rs` | Modify | Export new rate-limit state, policy, and middleware modules. |
+| `clients/rook/src/transport/context.rs` | Modify | Add or extend a dedicated covered-surface enum for global rate-limit routing without changing existing sanitized transport context responsibilities. |
+| `clients/rook/src/transport/middleware.rs` | Modify | Keep existing baseline middleware intact; optionally host the new rate-limit middleware state type if colocating transport middleware entrypoints is cleaner. |
+| `clients/rook/src/transport/rate_limit.rs` | Create | Own in-memory state model, policy types, decision logic, `Retry-After` derivation, surface-specific rejection helpers, and axum middleware adapters. |
+| `clients/rook/src/admin/types.rs` | Modify | Add an admin `429` helper built on `AdminErrorResponse` so `/api/*` rejections match existing admin error shape. |
+| `clients/rook/src/gateway/types.rs` | Modify | Add a gateway `429` helper built on `GatewayErrorResponse` so `/v1/*` rejections match existing OpenAI-style error shape. |
+| `clients/rook/src/admin/mod.rs` | No business redesign | Admin routes stay mounted as-is under `/api`; rate limiting applies at composition, not in handlers. |
+| `clients/rook/src/gateway/mod.rs` | Modify | Optionally split `/models` and `/chat/completions` route composition if needed so each gets its own middleware cleanly without widening coverage to future `/v1/*` routes. |
+| `clients/rook/src/admin/handlers.rs` | No business redesign | No handler logic change; requests rejected by this slice never reach these handlers. |
+| `clients/rook/src/gateway/handlers.rs` | No business redesign | No handler logic change; requests rejected by this slice never reach these handlers. |
+
+## Interfaces / Contracts
+
+### Startup Configuration
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SurfaceRateLimitPolicy {
+    pub max_requests: u32,
+    pub window_seconds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RateLimitConfig {
+    pub api: SurfaceRateLimitPolicy,
+    pub v1_models: SurfaceRateLimitPolicy,
+    pub v1_chat_completions: SurfaceRateLimitPolicy,
+}
+
+impl RateLimitConfig {
+    pub fn validate(&self) -> Result<(), RookError>;
+}
+```
+
+Validation rules for this slice:
+- all three surface policies are required
+- `max_requests > 0`
+- `window_seconds > 0`
+- no implicit inheritance between surfaces
+- config errors return `RookError::Config(...)`
+
+### Server Config Extension
+
+```rust
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
+    pub enable_tui: bool,
+    pub db_path: Option<String>,
+    pub inbound_auth: InboundAuthConfig,
+    pub transport: TransportConfig,
+    pub rate_limits: RateLimitConfig,
+}
+```
+
+### Covered Surface Model
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RateLimitedSurface {
+    AdminApi,
+    GatewayModels,
+    GatewayChatCompletions,
+}
+```
+
+This enum is intentionally narrower than generic route topology. It represents only the three
+surfaces covered by this slice.
+
+### Runtime State Model
+
+```rust
+#[derive(Debug, Clone)]
+pub struct RateLimitState {
+    pub policies: std::collections::HashMap<RateLimitedSurface, SurfaceRateLimitPolicy>,
+    pub windows: std::sync::Arc<tokio::sync::Mutex<
+        std::collections::HashMap<RateLimitedSurface, SurfaceWindowState>
+    >>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SurfaceWindowState {
+    pub window_started_at: std::time::Instant,
+    pub request_count: u32,
+}
+```
+
+Design notes:
+- state is process-local and reset on restart, which is acceptable for this startup/config-driven
+  slice
+- one mutable entry exists per covered surface, not per client/IP/identity
+- `tokio::sync::Mutex` matches the async server runtime and keeps state handling simple
+
+### Decision Contract
+
+```rust
+pub enum RateLimitDecision {
+    Allow,
+    Reject { retry_after_seconds: u64 },
+}
+
+pub fn evaluate_surface_limit(
+    now: std::time::Instant,
+    policy: &SurfaceRateLimitPolicy,
+    window: &mut SurfaceWindowState,
+) -> RateLimitDecision;
+```
+
+Decision algorithm:
+1. if `now - window_started_at >= window_seconds`, reset `request_count = 0` and
+   `window_started_at = now`
+2. if `request_count < max_requests`, increment and allow
+3. otherwise reject
+4. derive `retry_after_seconds` as `ceil((window_end - now).as_secs_f64())`, then clamp to at
+   least `1`
+
+This yields deterministic `Retry-After` values and avoids returning `0` on a rejected request.
+
+### Response Shaping Helpers
+
+```rust
+pub fn admin_rate_limited_response(retry_after_seconds: u64) -> axum::response::Response;
+
+pub fn gateway_rate_limited_response(retry_after_seconds: u64) -> axum::response::Response;
+```
+
+Expected body contracts:
+
+`/api/*`
+```json
+{
+  "error": {
+    "code": "rate_limited",
+    "message": "global rate limit exceeded for /api surface"
+  }
+}
+```
+
+`/v1/*`
+```json
+{
+  "error": {
+    "message": "global rate limit exceeded for this endpoint",
+    "type": "rate_limit_error",
+    "code": "rate_limited"
+  }
+}
+```
+
+Both helpers set:
+- status: `429 Too Many Requests`
+- header: `Retry-After: <seconds>`
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | `RateLimitConfig::validate` rejects missing/zero/invalid policies and accepts valid explicit per-surface config | Add focused tests in `clients/rook/src/config/mod.rs` following existing validation-test style. |
+| Unit | Fixed-window decision logic resets windows, admits within budget, rejects after exhaustion, and derives `Retry-After` deterministically | Add narrow tests in `clients/rook/src/transport/rate_limit.rs` using injected `Instant` values. |
+| Unit | `/api/*` and `/v1/*` 429 helpers preserve required error-envelope shapes and set `Retry-After` | Add response-shape tests in `clients/rook/src/admin/types.rs` and `clients/rook/src/gateway/types.rs`. |
+| Integration | Covered surfaces are independently limited | Extend `clients/rook/src/server/mod.rs` router tests to exhaust `/api/*`, `/v1/models`, and `/v1/chat/completions` separately and verify one surface does not consume another surface's budget. |
+| Integration | Covered requests are rejected before handler logic when budget is exhausted | Use lightweight probe routes or existing handlers in `server/mod.rs` tests to show 429s occur without downstream business execution. |
+| Integration | `Retry-After` is present on every 429 from this slice | Assert header presence and positive integer value in server composition tests for all three covered surfaces. |
+| Integration | Dashboard root and unrelated routes remain out of scope | Reuse existing `server/mod.rs` coverage to confirm `/` and assets are not rate-limited by this slice. |
+| Integration | Auth and rate limiting remain separate | Add server tests proving a covered route can return 429 from rate limiting without changing auth response shape expectations for non-exhausted requests. |
+| E2E | Not required for this slice | Scope stays inside Rook router/unit integration tests; no broader web or provider end-to-end coverage is needed. |
+
+## Migration / Rollout
+
+No data migration required.
+
+Rollout for this slice is startup-config driven:
+- add explicit per-surface settings in the Rook startup path
+- ship conservative defaults for local/dev startup if the current CLI path requires in-code values
+- if operators hit unacceptable throttling, rollback is a code/config reversion that removes the
+  rate-limit middleware composition and the new config subtree
+
+## Tradeoffs and Rejected Alternatives
+
+### Tradeoff: Global-by-surface protection is simple but not fair
+
+This design intentionally allows one noisy caller to consume the full budget for a surface. That is
+an accepted tradeoff for this slice because per-client/per-IP/per-identity partitioning is explicitly
+out of scope.
+
+### Tradeoff: In-memory state is restart-local
+
+Counters reset when the Rook process restarts and are not shared across replicas. That is acceptable
+because the slice is startup/config-driven, narrow, and local to the current standalone Rook
+deployment model.
+
+### Rejected: Token bucket or sliding-window algorithms
+
+Rejected because they increase implementation and test complexity without clear product value for the
+first global coarse-grained protection slice.
+
+### Rejected: One shared `/v1/*` limit
+
+Rejected because the spec explicitly requires `/v1/models` and `/v1/chat/completions` to have
+independent budgets.
+
+### Rejected: Path-prefix runtime inspection inside one generic middleware
+
+Rejected because it would make future `/v1/*` routes easier to accidentally throttle. Surface-
+specific composition in router topology is more explicit and safer.
+
+### Rejected: Database-backed or distributed rate-limit state
+
+Rejected because it expands the slice into persistence/distribution work and complicates rollback.
+
+## Rollback
+
+Rollback is straightforward and transport-boundary-only:
+
+1. remove rate-limit middleware composition from `clients/rook/src/server/mod.rs`
+2. remove `ServerConfig.rate_limits` and the related config validation in `clients/rook/src/config/mod.rs`
+3. remove the dedicated transport rate-limit module and 429 helper constructors
+4. keep archived inbound auth and transport baseline code intact
+
+After rollback, Rook returns to the previously archived auth-boundary + transport-baseline behavior
+with no global request throttling on `/api/*`, `/v1/models`, or `/v1/chat/completions`.
+
+## Open Questions
+
+- [ ] Whether the current CLI startup path should expose explicit `--rate-limit-*` flags now or keep
+      the first implementation wired through strict defaults until broader config loading lands.
+- [ ] Whether `GatewayState` route composition should be split into subrouters in `gateway/mod.rs`
+      or handled directly in `server/mod.rs` for the cleanest surface-specific middleware wiring.

--- a/openspec/changes/archive/2026-04-22-rook-591-global-surface-rate-limits/proposal.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-global-surface-rate-limits/proposal.md
@@ -1,0 +1,123 @@
+# Proposal: Add Global Surface Rate Limits for Rook Transport Entry Points
+
+## Intent
+
+Rook issue #591 still needs a narrow traffic-protection slice after the archived inbound auth
+boundary and transport middleware baseline work. The next follow-up should define global transport
+rate limiting by surface so Rook can shed excess request volume deterministically before admin or
+gateway handlers are overloaded.
+
+This slice is intentionally coarse-grained. It applies limits to shared HTTP surfaces rather than to
+individual clients, identities, API keys, or source IPs. The goal is to establish a simple,
+configurable startup-time policy for the most important Rook entry points now, without pulling in
+identity-aware throttling, idempotency, streaming, TLS, RBAC, or outbound provider-auth work.
+
+## Scope
+
+### In Scope
+
+- Define a dedicated #591 follow-up slice for global rate limiting on Rook HTTP entry points.
+- Define separate global policies for these three surfaces:
+  - `/api/*`
+  - `/v1/models`
+  - `/v1/chat/completions`
+- Define rate-limit exceed behavior as `429 Too Many Requests`.
+- Define `Retry-After` response-header requirements when a request is rejected for exceeding a
+  configured limit.
+- Define startup/config-driven limit inputs so operators can configure the per-surface policies for
+  this slice.
+- Define how rate limiting composes with the already-archived auth-boundary and transport-middleware
+  baseline slices without changing their responsibilities.
+- Identify the minimal server, transport/middleware, config, and spec areas that follow-on
+  spec/design work must cover.
+
+### Out of Scope
+
+- Any per-client, per-user, per-token, per-account, per-session, or per-IP rate limiting behavior.
+- Identity-aware quotas, fairness policies, abuse scoring, reputation systems, or WAF-style
+  controls.
+- Idempotency keys, replay protection, or duplicate-request suppression.
+- Streaming-specific rate limiting or partial-response behavior.
+- TLS, mTLS, reverse-proxy certificate policy, or network-edge deployment controls.
+- RBAC, route scopes, or any authorization-policy expansion.
+- Outbound provider authentication/header changes in `clients/rook/src/gateway/vendor.rs`.
+- Broad traffic-management work beyond the three named surfaces.
+
+## Approach
+
+Treat this slice as transport-boundary middleware or router-layer policy in `clients/rook`, applied
+before the target admin or gateway handlers execute. The design should define one global budget per
+named surface, not a keyed budget per caller identity.
+
+The core contract is simple:
+
+- `/api/*` has its own global limit policy.
+- `/v1/models` has its own global limit policy.
+- `/v1/chat/completions` has its own global limit policy.
+- Requests over the applicable budget MUST be rejected with HTTP `429 Too Many Requests`.
+- Rejected responses MUST include `Retry-After` so callers know when to retry.
+- Limits MUST be sourced from startup/config inputs in this slice rather than being hard-coded as the
+  only runtime behavior.
+
+This proposal intentionally avoids designing identity-aware throttling because that would expand the
+ slice into a different security and fairness problem. For now, the value is a predictable global
+back-pressure policy by surface that can be configured and rolled back easily.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `clients/rook/src/server/mod.rs` | Modified | Compose global per-surface rate-limiting policy in front of `/api/*`, `/v1/models`, and `/v1/chat/completions`. |
+| `clients/rook/src/admin/` | Modified | Ensure `/api/*` requests consume the admin-surface global policy without changing admin business semantics. |
+| `clients/rook/src/gateway/` | Modified | Ensure `/v1/models` and `/v1/chat/completions` consume distinct gateway-surface policies without changing OpenAI-shaped handler contracts. |
+| `clients/rook/src/config/` | Modified | Define startup/config inputs for per-surface global rate-limit settings and validation rules. |
+| `clients/rook/src/` transport/middleware module(s) | New or Modified | Add middleware/helpers for shared surface counters, limit evaluation, and `429` + `Retry-After` response shaping. |
+| `openspec/specs/gateway/spec.md` | Modified (follow-on) | Add delta requirements for global per-surface rate limiting and rejection behavior. |
+| `openspec/changes/rook-591-global-surface-rate-limits/` | New | Proposal and follow-on spec/design/tasks artifacts for this slice. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Global limits are mistaken for identity-aware fairness controls | High | State explicitly in spec/design that this slice is surface-wide only and does not distinguish callers. |
+| A single noisy caller can consume the entire surface budget | High | Document this tradeoff clearly and defer per-client/per-IP limiting to a later slice instead of silently expanding scope now. |
+| Misconfigured startup limits cause unnecessary `429` responses or operational lockout | Medium | Require explicit config validation, clear operator-facing configuration semantics, and a reversible rollback path. |
+| `Retry-After` semantics become inconsistent across the three surfaces | Medium | Define one rejection contract at shared transport composition points rather than per-handler custom logic. |
+| Rate limiting leaks into unrelated routes such as dashboard assets or other future endpoints | Medium | Bind enforcement only to `/api/*`, `/v1/models`, and `/v1/chat/completions` in this slice. |
+| The slice grows into idempotency, streaming, proxy, or broader traffic-shaping work | Medium | Keep proposal bounded to global-by-surface admission control and explicitly defer adjacent concerns. |
+
+## Rollback Plan
+
+If this slice causes regressions or unacceptable operational throttling, revert the global
+rate-limiting middleware/router composition for `/api/*`, `/v1/models`, and
+`/v1/chat/completions`, remove the startup/config entries introduced for per-surface limits, and
+restore the prior behavior from the archived inbound-auth and transport-middleware slices without
+global request throttling. Because this slice is transport-boundary-only, rollback should not
+require changes to auth semantics, business handlers, outbound vendor auth, or unrelated routes.
+
+## Dependencies
+
+- The archived `rook-591-inbound-auth-boundary` slice remains a completed prerequisite and must stay
+  separate from this rate-limiting slice.
+- The archived `rook-591-transport-middleware-baseline` slice remains the transport composition
+  baseline and should host this new policy cleanly rather than reworking unrelated middleware scope.
+- Existing server composition in `clients/rook/src/server/mod.rs` must continue to host `/api/*`,
+  `/v1/*`, and dashboard routes without widening this slice.
+- The gateway spec in `openspec/specs/gateway/spec.md` will need a follow-on delta for global
+  per-surface limits, `429` behavior, and `Retry-After` requirements.
+- Follow-on design work must confirm where startup/config values are parsed, validated, and exposed
+  to transport composition in `clients/rook`.
+
+## Success Criteria
+
+- [ ] The change remains narrowly scoped to global-by-surface rate limiting for Rook HTTP entry
+      points.
+- [ ] The proposal explicitly defines separate policies for `/api/*`, `/v1/models`, and
+      `/v1/chat/completions`.
+- [ ] The proposal explicitly requires HTTP `429 Too Many Requests` with `Retry-After` on limit
+      exceed.
+- [ ] The proposal explicitly requires startup/config-driven per-surface limits for this slice.
+- [ ] Per-client, per-IP, identity-aware, idempotency, streaming, TLS, RBAC, and outbound provider
+      auth work remain explicitly deferred.
+- [ ] The change is ready for `sdd-spec` and `sdd-design` to define concrete contracts and
+      implementation details.

--- a/openspec/changes/archive/2026-04-22-rook-591-global-surface-rate-limits/specs/gateway/spec.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-global-surface-rate-limits/specs/gateway/spec.md
@@ -1,0 +1,211 @@
+# Delta for gateway
+
+## ADDED Requirements
+
+### Requirement: Global Surface Rate-Limit Coverage and Scope
+
+Rook MUST define this slice as a transport-boundary, global-by-surface admission-control policy for
+the following HTTP entrypoints only:
+
+- all routes whose effective path is under `/api/*`
+- `GET /v1/models`
+- `POST /v1/chat/completions`
+
+For this slice, each covered surface MUST consume from its own independent global budget. The
+`/api/*` surface MUST NOT share a budget with `/v1/models`, and `/v1/models` MUST NOT share a
+budget with `/v1/chat/completions`.
+
+Routes outside those surfaces, including dashboard routes and assets outside `/api/*` and `/v1/*`,
+MUST remain out of scope for this slice.
+
+This slice MUST remain limited to transport-level surface protection. It MUST NOT define or imply
+per-client, per-IP, per-identity, per-token, or per-session limit partitioning.
+
+#### Scenario: covered surfaces are limited independently
+
+- GIVEN Rook is configured with a global rate-limit policy for `/api/*`, `/v1/models`, and `/v1/chat/completions`
+- WHEN traffic reaches each covered surface
+- THEN Rook MUST evaluate each request against the budget for that exact covered surface
+- AND exhausting one covered surface MUST NOT, by itself, exhaust either of the other covered surfaces
+
+#### Scenario: out-of-scope routes remain unaffected by this slice
+
+- GIVEN Rook also serves routes outside `/api/*`, `/v1/models`, and `/v1/chat/completions`
+- WHEN a client sends a request to an out-of-scope route
+- THEN this slice MUST NOT require global surface rate-limit evaluation for that route
+
+### Requirement: Global Rate-Limit Contract by Surface
+
+For each covered surface, Rook MUST support one configured global rate-limit policy that determines
+whether a request is admitted or rejected before the matched admin or gateway handler executes its
+business logic.
+
+The contract for this slice MUST allow operators to configure a distinct limit for:
+
+- `/api/*`
+- `/v1/models`
+- `/v1/chat/completions`
+
+When the applicable surface budget allows the request, Rook MUST continue normal request handling
+for that surface.
+
+When the applicable surface budget is exhausted, Rook MUST reject the request using the rejection
+contract defined by this slice.
+
+This slice MUST define the decision contract in terms of global admission control by covered
+surface. It MUST NOT require fairness guarantees among callers sharing a surface.
+
+#### Scenario: request within surface budget proceeds
+
+- GIVEN the configured global budget for `GET /v1/models` has remaining capacity
+- WHEN a client sends `GET /v1/models`
+- THEN Rook MUST admit the request
+- AND the request MUST continue to the normal gateway handling path
+
+#### Scenario: request over surface budget is rejected before handler logic
+
+- GIVEN the configured global budget for `POST /v1/chat/completions` is exhausted
+- WHEN a client sends `POST /v1/chat/completions`
+- THEN Rook MUST reject the request before normal gateway business logic executes
+
+### Requirement: Rate-Limit Rejection Semantics
+
+When a covered request is rejected because the applicable global surface budget is exhausted, Rook
+MUST return HTTP `429 Too Many Requests`.
+
+Every `429 Too Many Requests` response produced by this slice MUST include a `Retry-After` header.
+The header value MUST communicate when the caller may retry according to the applicable configured
+surface policy.
+
+For rejected `/v1/models` and `/v1/chat/completions` requests, the response body MUST use the
+documented gateway error response shape. The response MUST clearly indicate that the request was
+rate limited.
+
+For rejected `/api/*` requests, the response body MUST use the standard admin error response shape
+already used by the gateway domain for admin-surface errors. The response MUST clearly indicate
+that the request was rate limited.
+
+`429 Too Many Requests` responses from this slice MUST be transport-boundary rejections. They MUST
+be returned without invoking downstream business handlers for the rejected request.
+
+#### Scenario: gateway surface rejection returns 429 with retry guidance
+
+- GIVEN the configured global budget for `GET /v1/models` is exhausted
+- WHEN a client sends `GET /v1/models`
+- THEN Rook MUST return `429 Too Many Requests`
+- AND the response MUST include a `Retry-After` header
+- AND the response body MUST use the documented gateway error response shape
+- AND the response body MUST indicate that the request was rejected for rate limiting
+
+#### Scenario: admin surface rejection returns 429 with admin error shape
+
+- GIVEN the configured global budget for `/api/*` is exhausted
+- WHEN a client sends `GET /api/health`
+- THEN Rook MUST return `429 Too Many Requests`
+- AND the response MUST include a `Retry-After` header
+- AND the response body MUST use the standard admin error response shape
+- AND the response body MUST indicate that the request was rejected for rate limiting
+
+#### Scenario: retry-after is required on every rate-limit rejection
+
+- GIVEN a covered request is rejected by this slice for exceeding the configured surface budget
+- WHEN Rook produces the rejection response
+- THEN the response MUST include `Retry-After`
+- AND acceptance for this slice MUST fail if a `429` response is emitted without that header
+
+### Requirement: Startup and Configuration Contract for Surface Limits
+
+This slice MUST define explicit startup/config inputs for the global rate-limit policy of each
+covered surface.
+
+At minimum, the configuration contract for this slice MUST provide distinct operator-controlled
+entries for:
+
+- the `/api/*` global surface limit
+- the `/v1/models` global surface limit
+- the `/v1/chat/completions` global surface limit
+
+Configuration for this slice MUST be loaded and validated during startup or configuration
+initialization rather than being inferred only at request time.
+
+If the rate-limit configuration for any covered surface is missing, malformed, contradictory, or not
+resolvable under the chosen configuration shape, startup or configuration initialization MUST fail
+closed rather than starting with an ambiguous partial policy.
+
+Configuration for this slice MUST remain separate from inbound bearer-auth credentials, provider
+account credentials, outbound provider authentication, RBAC settings, and trusted-proxy transport
+settings.
+
+#### Scenario: valid per-surface configuration passes startup validation
+
+- GIVEN startup configuration provides valid global limit settings for `/api/*`, `/v1/models`, and `/v1/chat/completions`
+- WHEN Rook loads configuration for this slice
+- THEN configuration validation MUST succeed for the rate-limit contract
+
+#### Scenario: malformed covered-surface configuration fails closed
+
+- GIVEN startup configuration contains an invalid or incomplete rate-limit policy for one of the covered surfaces
+- WHEN Rook loads configuration for this slice
+- THEN startup or configuration initialization MUST fail
+- AND Rook MUST NOT start with that surface left in an undefined rate-limit state
+
+#### Scenario: rate-limit configuration remains separate from auth and vendor credentials
+
+- GIVEN inbound auth, vendor API keys, and transport middleware settings are also configured
+- WHEN Rook loads configuration for this slice
+- THEN the global surface rate-limit settings MUST be validated independently from those other configuration domains
+
+### Requirement: Composition with Existing Auth and Middleware Slices
+
+This slice MUST remain separate from the archived `rook-591-inbound-auth-boundary` and
+`rook-591-transport-middleware-baseline` changes.
+
+The global surface rate-limit policy defined here MUST compose at the transport boundary for covered
+surfaces without changing the credential contract, error semantics, or scope of the inbound auth
+slice except where a request is rejected earlier by this slice's own `429` contract.
+
+This slice MUST NOT weaken, replace, or reinterpret the existing inbound bearer-auth requirements
+for protected `/api/*` and `/v1/*` routes.
+
+This slice MUST build on the transport-middleware baseline rather than broadening that archived
+slice's requirements. Acceptance for this slice MUST NOT require reopening request ID, forwarded
+header trust, TLS, or unrelated middleware concerns.
+
+#### Scenario: rate-limit slice stays separate from inbound auth contract
+
+- GIVEN the archived inbound auth boundary still governs protected `/api/*` and `/v1/*` routes
+- WHEN this slice is accepted
+- THEN the inbound auth credential requirements MUST remain unchanged
+- AND this slice MUST define only the additional global surface rate-limit behavior for covered routes
+
+#### Scenario: rate-limit slice stays separate from transport baseline concerns
+
+- GIVEN the archived transport middleware baseline already governs request ID, sanitation, and forwarded-header behavior
+- WHEN this slice is accepted
+- THEN compliance with this slice MUST NOT require changing those baseline transport concerns
+
+### Requirement: Non-Goals and Deferred Concerns for Global Surface Limits
+
+This slice MUST remain narrow and MUST NOT require or imply implementation of:
+
+- per-client, per-IP, per-token, per-account, per-session, or per-identity rate limiting
+- identity-aware quotas, fairness controls, or abuse scoring
+- idempotency keys, replay protection, or duplicate-request suppression
+- streaming-specific rate limiting or partial-response behavior
+- TLS, mTLS, reverse-proxy certificate policy, or network-edge controls
+- RBAC, scopes, or broader authorization-model changes
+- outbound provider authentication changes
+
+These concerns MAY be specified later, but compliance with this slice MUST NOT depend on them.
+
+#### Scenario: acceptance does not require identity-aware throttling
+
+- GIVEN this global-by-surface rate-limit slice is implemented
+- WHEN acceptance is evaluated
+- THEN the slice MUST be satisfiable without introducing per-client, per-IP, or identity-aware rate limiting
+
+#### Scenario: acceptance does not require streaming or idempotency work
+
+- GIVEN this global-by-surface rate-limit slice is implemented
+- WHEN acceptance is evaluated
+- THEN the slice MUST be satisfiable without adding streaming-specific behavior, idempotency keys, or replay protection

--- a/openspec/changes/archive/2026-04-22-rook-591-global-surface-rate-limits/state.yaml
+++ b/openspec/changes/archive/2026-04-22-rook-591-global-surface-rate-limits/state.yaml
@@ -1,0 +1,12 @@
+change: rook-591-global-surface-rate-limits
+current_phase: archive
+completed:
+  - propose
+  - spec
+  - design
+  - tasks
+  - apply
+  - verify
+  - archive
+next: none
+updated: 2026-04-22T00:00:00Z

--- a/openspec/changes/archive/2026-04-22-rook-591-global-surface-rate-limits/tasks.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-global-surface-rate-limits/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Global Surface Rate Limits for Rook Transport Entry Points
+
+## Phase 1: Configuration Foundation
+
+- [x] 1.1 RED: Add config tests in `clients/rook/src/config/mod.rs` for valid explicit per-surface policies and fail-closed validation when any surface limit is missing, zero, or malformed.
+- [x] 1.2 GREEN: Add `SurfaceRateLimitPolicy` and `RateLimitConfig` to `clients/rook/src/config/mod.rs`, expose validation, and extend `clients/rook/src/server/mod.rs::ServerConfig` with `rate_limits`.
+- [x] 1.3 GREEN: Update `clients/rook/src/main.rs` tests first, then populate startup defaults/flags wiring so `build_server_config()` always supplies explicit `/api`, `/v1/models`, and `/v1/chat/completions` policies.
+
+## Phase 2: Rate-Limit Engine
+
+- [x] 2.1 RED: Create focused tests in `clients/rook/src/transport/rate_limit.rs` for fixed-window allow/reject behavior, window reset, independent surface budgets, and integer-second `Retry-After` clamped to at least `1`.
+- [x] 2.2 GREEN: Implement `RateLimitedSurface`, `RateLimitState`, `SurfaceWindowState`, `RateLimitDecision`, and `evaluate_surface_limit()` in `clients/rook/src/transport/rate_limit.rs`.
+- [x] 2.3 GREEN: Update `clients/rook/src/transport/context.rs`, `clients/rook/src/transport/mod.rs`, and `clients/rook/src/lib.rs` to export the narrow covered-surface model without changing baseline transport responsibilities.
+- [x] 2.4 RED/GREEN: Add tests, then implement `429` response helpers in `clients/rook/src/admin/types.rs` and `clients/rook/src/gateway/types.rs` that preserve existing error envelopes and always set `Retry-After`.
+
+## Phase 3: Router Composition
+
+- [x] 3.1 RED: Add server integration tests in `clients/rook/src/server/mod.rs` proving exhausted `/api/*`, `GET /v1/models`, and `POST /v1/chat/completions` reject before handler logic, while exhausting one surface does not affect the others.
+- [x] 3.2 GREEN: Implement axum middleware adapters in `clients/rook/src/transport/rate_limit.rs` and compose shared state in `clients/rook/src/server/mod.rs` so rate limiting runs outside inbound auth and only on covered surfaces.
+- [x] 3.3 GREEN: Adjust `clients/rook/src/gateway/mod.rs` route composition only if needed so `/v1/models` and `/v1/chat/completions` can receive distinct middleware without widening coverage to future `/v1/*` routes.
+- [x] 3.4 RED/GREEN: Add a regression test, then confirm out-of-scope dashboard/other routes in `clients/rook/src/server/mod.rs` bypass this slice entirely.
+
+## Phase 4: Verification
+
+- [x] 4.1 Add/finish acceptance-style tests in `clients/rook/src/server/mod.rs` covering `429 Too Many Requests`, required `Retry-After`, admin vs gateway error body shapes, and startup validation failure for incomplete config.
+- [x] 4.2 Refactor only for clarity: remove duplication across helpers/tests, keep auth-baseline behavior untouched, and document any operator-facing rate-limit defaults inline where configuration is defined.

--- a/openspec/changes/archive/2026-04-22-rook-591-global-surface-rate-limits/verify-report.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-global-surface-rate-limits/verify-report.md
@@ -1,0 +1,85 @@
+## Verification Report
+
+**Change**: rook-591-global-surface-rate-limits  
+**Date**: 2026-04-22
+
+---
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 9 |
+| Tasks complete | 9 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/rook-591-global-surface-rate-limits/tasks.md` are complete.
+
+---
+
+### Test Evidence
+
+Build was intentionally not run because the user explicitly required: **Do not build the project.**
+
+#### Targeted verification commands executed
+
+1. `cargo test --manifest-path "clients/rook/Cargo.toml" config::tests::rate_limit_config_validate_accepts_explicit_valid_surface_policies`
+   - Result: **1 passed / 0 failed**
+2. `cargo test --manifest-path "clients/rook/Cargo.toml" config::tests::rate_limit_config_validate_rejects_zero_or_malformed_surface_values -- --exact`
+   - Result: **1 passed / 0 failed**
+3. `cargo test --manifest-path "clients/rook/Cargo.toml" transport::rate_limit::tests::evaluate_surface_limit_allows_within_budget_then_rejects_with_retry_after`
+   - Result: **1 passed / 0 failed**
+4. `cargo test --manifest-path "clients/rook/Cargo.toml" admin::types::tests::admin_rate_limited_response_uses_admin_shape_and_retry_after_header`
+   - Result: **1 passed / 0 failed**
+5. `cargo test --manifest-path "clients/rook/Cargo.toml" gateway::types::tests::gateway_rate_limited_response_uses_gateway_shape_and_retry_after_header`
+   - Result: **1 passed / 0 failed**
+6. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::exhausted_surfaces_reject_with_429_retry_after_and_independent_budgets`
+   - Result: **1 passed / 0 failed**
+7. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::rate_limit_rejections_happen_before_auth_and_dashboard_routes_stay_out_of_scope`
+   - Result: **1 passed / 0 failed**
+8. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::build_app_fails_closed_when_rate_limit_config_is_incomplete`
+   - Result: **1 passed / 0 failed**
+9. `cargo test --manifest-path "clients/rook/Cargo.toml" --bin rook tests::serve_cli_parses_inbound_auth_flags`
+   - Result: **1 passed / 0 failed**
+10. `cargo test --manifest-path "clients/rook/Cargo.toml" --bin rook tests::build_server_config_keeps_inbound_auth_separate`
+    - Result: **1 passed / 0 failed**
+11. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::rate_limit_slice_acceptance_does_not_require_streaming_or_idempotency_work -- --exact`
+    - Result: **1 passed / 0 failed**
+
+#### Broader suite signal collected
+
+12. `cargo test --manifest-path "clients/rook/Cargo.toml"`
+    - Result: full Rook suite runs after this slice’s fixes; remaining failures, if any, are outside the rate-limit slice scope.
+
+---
+
+### Spec Compliance Summary
+
+- Covered surfaces are rate-limited independently: `/api/*`, `/v1/models`, and `/v1/chat/completions`.
+- Exhausted surfaces reject with `429 Too Many Requests` and a `Retry-After` header.
+- `/api/*` uses admin error shape; `/v1/*` uses gateway error shape.
+- Startup/config path now exposes explicit operator-controlled per-surface limit values.
+- Dashboard routes remain outside scope.
+- Rate-limit middleware composes before auth/handler execution.
+- Non-goals remain intact: no per-client/per-IP partitioning, no idempotency, no streaming, no TLS, no RBAC, no outbound provider-auth changes.
+
+---
+
+### Issues Found
+
+**CRITICAL**
+
+- None for this slice.
+
+**WARNING**
+
+- This slice is intentionally global-by-surface and therefore not fairness-oriented; one noisy caller can exhaust a surface-wide budget for all callers.
+- The limiter is process-local/in-memory and resets on restart; no cross-process coordination is provided in this slice.
+
+---
+
+### Verdict
+
+**PASS**
+
+The `rook-591-global-surface-rate-limits` slice is implemented and verified against the approved scope with passing targeted evidence and no slice-local critical gaps.

--- a/openspec/changes/archive/2026-04-22-rook-591-inbound-auth-boundary/design.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-inbound-auth-boundary/design.md
@@ -1,0 +1,410 @@
+# Design: Harden Rook Inbound Auth Boundary for `/api` and `/v1`
+
+## Technical Approach
+
+This slice adds a small, Rook-specific inbound authentication layer at the HTTP transport boundary in
+`clients/rook/src/server/mod.rs`, where the combined axum router currently nests `/api` and `/v1`
+routers. The design keeps authentication enforcement outside admin business handlers and outside
+gateway upstream/provider logic, so inbound client trust remains separate from outbound provider
+auth in `clients/rook/src/gateway/vendor.rs`.
+
+The implementation approach is:
+
+1. extend Rook server/runtime configuration with a dedicated inbound-auth section
+2. validate that configuration before router construction
+3. apply auth middleware only to the `/api/*` and `/v1/*` nested routers
+4. shape unauthorized responses per surface contract:
+   - `/api/*` → admin error envelope
+   - `/v1/*` → gateway/OpenAI-style error envelope
+5. leave dashboard routes (`/`, `/assets/*`) untouched
+
+This matches the proposal and gateway delta spec by enforcing auth before route handlers run,
+failing closed when auth is enabled but token configuration is invalid, and preserving the existing
+loopback-first bind posture as an additional exposure reduction measure rather than as the
+authenticator.
+
+## Architecture Decisions
+
+### Decision: Put the auth boundary at server router composition, not inside handlers
+
+**Choice**: Apply auth as router middleware/wrapper when `/api` and `/v1` are nested in
+`clients/rook/src/server/mod.rs`.
+
+**Alternatives considered**:
+- add auth checks to each admin and gateway handler
+- wrap only individual routes inside `admin::build_router()` and `gateway::build_router()`
+
+**Rationale**:
+- The spec requires auth to run before handler business logic.
+- `server/mod.rs` is already the composition point for `/api`, `/v1`, and dashboard routes.
+- Keeping auth at composition level minimizes changes to existing handler code and prevents drift
+  between protected routes.
+- It preserves dashboard routes outside scope with a clear, prefix-based boundary.
+
+### Decision: Keep inbound auth implementation in a new Rook-only module
+
+**Choice**: Introduce a dedicated module such as `clients/rook/src/auth/` for inbound bearer
+parsing, validation, middleware, and error helpers.
+
+**Alternatives considered**:
+- reuse `clients/agent-runtime/src/gateway/utils.rs` directly
+- place auth logic under `gateway/` because `/v1` is gateway-facing
+- place auth logic under `admin/` and duplicate for gateway
+
+**Rationale**:
+- Proposal/spec explicitly require separation from runtime pairing/onboarding trust assumptions.
+- Rook needs one shared inbound transport concern for both `/api/*` and `/v1/*`, not a gateway-only
+  or admin-only abstraction.
+- A dedicated module makes the boundary explicit and avoids accidental coupling to
+  `gateway/vendor.rs` outbound auth behavior.
+
+### Decision: Use surface-specific middleware constructors over one generic response adapter
+
+**Choice**: Build one shared token validation core plus two thin middleware entrypoints/helpers:
+one for `/api/*`, one for `/v1/*`.
+
+**Alternatives considered**:
+- one generic middleware that inspects path prefixes at runtime to choose an error shape
+- two fully separate auth implementations
+
+**Rationale**:
+- `/api/*` and `/v1/*` have different error contracts and should not negotiate that deep inside a
+  generic opaque middleware.
+- A shared core avoids duplicated parsing/validation logic.
+- Thin surface-specific adapters keep contracts explicit and reduce accidental response drift.
+
+### Decision: Keep auth config on `ServerConfig` for this slice
+
+**Choice**: Extend `clients/rook/src/server/mod.rs::ServerConfig` with inbound-auth settings and
+move validation into server startup/build-app flow.
+
+**Alternatives considered**:
+- fully implement `clients/rook/src/config/mod.rs::RookConfig` and wire all startup through it now
+- store inbound auth token in registry/settings tables
+
+**Rationale**:
+- Current executable path already constructs `ServerConfig` in `clients/rook/src/main.rs`.
+- This slice must stay narrow and should not expand into a broader config-system redesign.
+- Registry-backed settings are the wrong boundary for a transport secret needed before the server
+  starts accepting requests.
+- The placeholder `config/mod.rs` can still define reusable config types/helpers without requiring a
+  full config-loading feature in this slice.
+
+### Decision: Fail closed only when auth is enabled
+
+**Choice**: If inbound auth enforcement is enabled and the token is absent/blank/unresolvable,
+startup returns `RookError::Config(...)` and the server does not start.
+
+**Alternatives considered**:
+- silently disable auth when token is missing
+- allow startup and log a warning
+- always require a token regardless of enabled switch
+
+**Rationale**:
+- The delta spec requires fail-closed behavior for enabled auth.
+- Silent downgrade would create a partially protected state.
+- Always-on token enforcement would change the M1 posture more broadly than this slice requires.
+
+### Decision: Do not introduce 403 policy logic in this slice
+
+**Choice**: Design the auth layer so `403 Forbidden` can be added later, but implement only bearer
+validity decisions now (`401` on missing/malformed/invalid credentials).
+
+**Alternatives considered**:
+- add origin-based or route-based deny policies now
+- add placeholder RBAC/scope hooks now
+
+**Rationale**:
+- The spec says 403 should not be introduced unless a concrete policy exists.
+- Scope is strictly inbound auth boundary, not authorization policy.
+- Keeping the decision model binary for now reduces risk and keeps tests small.
+
+## Data Flow
+
+### Request Flow
+
+```text
+Client Request
+   |
+   v
+Combined Server Router (`server/mod.rs`)
+   |
+   +--> `/api/*` nested router -- auth middleware (admin adapter) -- admin handlers
+   |
+   +--> `/v1/*` nested router  -- auth middleware (gateway adapter) -- gateway handlers
+   |
+   \--> `/` + `/assets/*` dashboard routes (no auth in this slice)
+```
+
+### Auth Validation Flow
+
+```text
+Authorization header
+   |
+   v
+Rook auth extractor
+   |
+   +--> missing / invalid scheme / empty / malformed --> surface-specific 401 response
+   |
+   \--> parsed bearer token
+          |
+          v
+     compare against configured inbound token
+          |
+          +--> mismatch --> surface-specific 401 response
+          |
+          \--> match --> forward request to nested handler
+```
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as server/mod.rs
+    participant A as auth middleware
+    participant H as admin/gateway handler
+    participant V as gateway/vendor.rs
+
+    C->>S: HTTP request to /api/* or /v1/*
+    S->>A: Dispatch through protected nested router
+    A->>A: Extract Authorization: Bearer <token>
+    A->>A: Compare token with inbound auth config
+    alt invalid or missing token
+        A-->>C: 401 with admin or gateway error shape
+    else valid token
+        A->>H: Forward request
+        alt /v1 upstream call needed
+            H->>V: Build outbound provider auth/header
+            Note over A,V: inbound client auth and outbound provider auth stay separate
+        end
+        H-->>C: normal route response
+    end
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `clients/rook/src/lib.rs` | Modify | Export the new auth module. |
+| `clients/rook/src/server/mod.rs` | Modify | Extend `ServerConfig`, validate inbound auth settings, and compose `/api` + `/v1` routers with auth middleware while leaving dashboard routes unprotected. |
+| `clients/rook/src/main.rs` | Modify | Accept minimal CLI/env-facing auth inputs for `serve` and map them into `ServerConfig`. |
+| `clients/rook/src/config/mod.rs` | Modify | Add small inbound-auth config types/validation helpers if shared config structures are introduced for startup validation. Keep scope narrow; do not implement full config subsystem. |
+| `clients/rook/src/admin/mod.rs` | Optional Modify | If needed, expose a small surface identifier or helper for admin-protected router composition, but avoid moving business logic here. |
+| `clients/rook/src/admin/types.rs` | Optional Modify | Add a dedicated auth-failure helper constructor if keeping admin error shaping centralized here is cleaner. |
+| `clients/rook/src/admin/handlers.rs` | Optional Modify | Reuse/export existing `admin_error_response(...)` helper from middleware path; no business behavior changes. |
+| `clients/rook/src/gateway/mod.rs` | Optional Modify | Keep router contract stable; only minor adjustments if surface-specific middleware layering needs a helper. |
+| `clients/rook/src/gateway/types.rs` | Modify | Add a dedicated helper/constructor for unauthorized gateway errors using `invalid_request_error` + `unauthorized`. |
+| `clients/rook/src/gateway/handlers.rs` | Optional Modify | Reuse gateway error helper from middleware path; no outbound auth behavior changes. |
+| `clients/rook/src/gateway/vendor.rs` | No functional change | Remains the outbound provider auth boundary; design documents its non-involvement. |
+| `clients/rook/src/auth/mod.rs` | Create | Shared inbound auth entrypoint: config-facing types, validation core, and surface middleware constructors. |
+| `clients/rook/src/auth/bearer.rs` | Create | Rook-specific bearer extraction and parsing rules for `Authorization` headers. |
+| `clients/rook/src/auth/middleware.rs` | Create | Axum middleware/guard functions for admin and gateway protected routers. |
+| `clients/rook/src/auth/types.rs` | Create | Internal auth decision/error enums and possibly a validated config wrapper. |
+
+## Interfaces / Contracts
+
+The exact names may vary during implementation, but the design expects small interfaces close to the
+current code style.
+
+### Inbound Auth Configuration
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InboundAuthConfig {
+    pub enabled: bool,
+    pub bearer_token: Option<String>,
+}
+
+impl InboundAuthConfig {
+    pub fn validate(&self) -> Result<(), RookError>;
+}
+```
+
+This config remains independent from provider account credentials and `gateway/vendor.rs`.
+
+### Server Config Extension
+
+```rust
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
+    pub enable_tui: bool,
+    pub db_path: Option<String>,
+    pub inbound_auth: InboundAuthConfig,
+}
+```
+
+### Bearer Extraction Core
+
+```rust
+pub enum BearerExtractionError {
+    Missing,
+    InvalidScheme,
+    EmptyToken,
+    Malformed,
+}
+
+pub fn extract_bearer_token(headers: &axum::http::HeaderMap)
+    -> Result<&str, BearerExtractionError>;
+```
+
+Design notes:
+- Rook may adapt the parsing pattern from `clients/agent-runtime/src/gateway/utils.rs`
+  (`extract_bearer_token`) but MUST keep its own implementation and constraints.
+- This slice compares one configured token only.
+- If multiple/ambiguous authorization values are observed and cannot be interpreted
+  deterministically, extraction returns an error and the request is denied.
+
+### Validation Core
+
+```rust
+pub enum InboundAuthFailure {
+    Missing,
+    Malformed,
+    Invalid,
+}
+
+pub fn validate_inbound_request(
+    headers: &axum::http::HeaderMap,
+    config: &InboundAuthConfig,
+) -> Result<(), InboundAuthFailure>;
+```
+
+### Surface-Specific Unauthorized Responses
+
+```rust
+pub fn admin_unauthorized_response() -> (StatusCode, Json<AdminErrorResponse>);
+
+pub fn gateway_unauthorized_response() -> axum::response::Response;
+```
+
+Expected bodies:
+
+```json
+// /api/*
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "valid inbound bearer token required"
+  }
+}
+```
+
+```json
+// /v1/*
+{
+  "error": {
+    "message": "valid inbound bearer token required",
+    "type": "invalid_request_error",
+    "code": "unauthorized"
+  }
+}
+```
+
+The middleware should also set an HTTP `WWW-Authenticate: Bearer` header on `401` responses as a
+standard HTTP auth hint, because that does not conflict with either body contract.
+
+### Router Composition Sketch
+
+```rust
+let admin_router = admin::build_router(registry)
+    .route_layer(auth::middleware::admin_inbound_auth_layer(inbound_auth.clone()));
+
+let gateway_router = gateway::build_router(gateway_state)
+    .route_layer(auth::middleware::gateway_inbound_auth_layer(inbound_auth.clone()));
+
+Router::new()
+    .nest("/api", admin_router)
+    .nest("/v1", gateway_router)
+    .merge(dashboard::router())
+```
+
+If axum layering details make `route_layer(...)` awkward for nested routers, the acceptable
+equivalent is to wrap each nested router with `middleware::from_fn_with_state(...)`. The important
+contract is that auth runs before handlers and only for those two prefixes.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Bearer parsing rules | Add focused tests in `clients/rook/src/auth/bearer.rs` for missing header, non-bearer scheme, empty token, valid token, case-insensitive scheme, trailing whitespace, and ambiguous/malformed values. |
+| Unit | Config validation | Add focused tests for `InboundAuthConfig::validate()` covering enabled+missing token, enabled+blank token, enabled+valid token, and disabled+missing token. |
+| Unit | Error shaping | Add tests for admin and gateway unauthorized helpers to verify `401`, body shape, and `WWW-Authenticate` header without involving business handlers. |
+| Integration | `/api/*` boundary enforcement | Extend `clients/rook/src/server/mod.rs` tests to verify `/api/health` returns `401` without token when auth is enabled and `200` with valid token; dashboard root remains `200` without token. |
+| Integration | `/v1/*` boundary enforcement | Extend `clients/rook/src/server/mod.rs` and/or `clients/rook/src/gateway/handlers.rs` tests to verify `/v1/models` and `/v1/chat/completions` reject unauthorized requests using gateway error shape and allow authorized ones. |
+| Integration | Separation from outbound vendor auth | Add a targeted test proving inbound auth success does not alter `gateway/vendor.rs` behavior and that missing provider API key behavior remains whatever gateway tests already define. |
+| Integration | Startup fail-closed | Add tests around app/server construction to verify enabled auth with missing token returns `RookError::Config` and does not build the protected app. |
+| E2E | None for this slice | No browser/dashboard E2E needed because dashboard remains out of scope and the slice is transport-boundary-only. |
+
+Test scope intentionally excludes rate limiting, origin guard policy, TLS, streaming, and RBAC.
+
+## Migration / Rollout
+
+No data migration required.
+
+Rollout for this slice is configuration-gated:
+
+1. default behavior can remain loopback-first with inbound auth disabled
+2. operators can enable inbound auth by supplying the configured token
+3. once enabled, startup fails if the token is invalid/missing
+
+This makes the slice deployable without changing registry schema, dashboard assets, or provider
+config.
+
+## Tradeoffs and Rejected Alternatives
+
+### Tradeoff: config-gated enforcement vs always-on enforcement
+
+- **Chosen**: config-gated enforcement.
+- **Why**: smallest safe slice that satisfies the spec's coexistence language with the current M1
+  posture.
+- **Cost**: there is still an insecure mode when auth is disabled.
+- **Why acceptable now**: the spec explicitly allows current loopback-first behavior when auth is
+  inactive.
+
+### Tradeoff: plain configured token vs hashed/managed secret storage
+
+- **Chosen**: one configured bearer token value or secret reference for this slice.
+- **Rejected**: token hashing/pairing-state integration/secret lifecycle redesign.
+- **Why**: anything more is broader than this transport-boundary slice and would pull in runtime
+  trust-state concerns the proposal excludes.
+
+### Tradeoff: no origin guard in primary flow
+
+- **Chosen**: bearer auth is primary control; browser-origin filtering is not part of acceptance.
+- **Rejected**: making `Origin` validation mandatory for admin routes in this slice.
+- **Why**: proposal/spec allow origin guarding only as an adapted idea and explicitly forbid using it
+  as the primary authenticator.
+
+### Tradeoff: one token for both `/api/*` and `/v1/*`
+
+- **Chosen**: single inbound token for both protected surfaces in this slice.
+- **Rejected**: separate admin token and gateway token now.
+- **Why**: simpler configuration, smaller test surface, and sufficient for first boundary
+  establishment. Multi-token or scoped auth can be a later authorization slice.
+
+## Rollback Considerations
+
+Rollback is straightforward because the change is isolated to transport-boundary composition and
+startup config validation.
+
+To roll back:
+
+1. remove the new auth middleware from `/api` and `/v1` nesting in `clients/rook/src/server/mod.rs`
+2. remove inbound-auth fields added to `ServerConfig` and CLI/config plumbing
+3. delete the new `clients/rook/src/auth/` module and its tests
+4. revert any unauthorized error helper additions in admin/gateway types if they are only used by
+   this slice
+5. restore state to the previous loopback-first unauthenticated protected-route behavior
+
+Rollback does **not** require changes to:
+- `clients/rook/src/gateway/vendor.rs`
+- registry/database schema
+- admin business handlers
+- dashboard route handling
+
+## Open Questions
+
+- [ ] None blocking for this slice.

--- a/openspec/changes/archive/2026-04-22-rook-591-inbound-auth-boundary/proposal.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-inbound-auth-boundary/proposal.md
@@ -1,0 +1,117 @@
+# Proposal: Harden Rook Inbound Auth Boundary for `/api` and `/v1`
+
+## Intent
+
+Rook issue #591 starts from a verified security gap: `clients/rook` currently exposes both the
+operator-facing admin surface under `/api/*` and the client-facing gateway surface under `/v1/*`
+without any inbound authentication boundary. That is acceptable only under the current
+loopback-first M1 posture, but it is not sufficient for a transport surface that may later be
+reached by broader clients, automation, or proxied environments.
+
+This first slice is intentionally narrow and security-first. It establishes a dedicated inbound
+authentication boundary for requests entering Rook, while preserving the already-existing outbound
+provider authentication logic in `clients/rook/src/gateway/vendor.rs`. Inbound client trust and
+outbound provider credentials are different concerns and MUST remain separate.
+
+## Scope
+
+### In Scope
+
+- Define the first implementation slice of #591 as inbound authentication/authorization boundary
+  work for Rook HTTP entrypoints only.
+- Add an explicit auth boundary in front of `/api/*` admin routes.
+- Add an explicit auth boundary in front of `/v1/*` gateway routes.
+- Define a Rook-specific bearer-token request contract for inbound clients.
+- Define failure behavior for missing, malformed, or invalid inbound credentials.
+- Define how auth enforcement composes with the existing loopback-first default bind posture,
+  without relying on loopback alone as the only protection.
+- Reuse proven ideas such as bearer extraction and browser-origin guarding where appropriate, but
+  only after adapting them to Rook’s contracts and route model.
+- Preserve the separation between inbound client auth and outbound vendor auth/header generation.
+- Identify the minimal server, gateway, admin, and configuration areas that will need follow-on spec
+  and design work for this slice.
+
+### Out of Scope
+
+- Upstream provider authentication changes in `clients/rook/src/gateway/vendor.rs`.
+- Collapsing inbound and outbound auth into one shared abstraction.
+- Pairing-code flows, runtime onboarding, webhook secret hashing, or other `agent-runtime`
+  trust-state assumptions that do not already belong to Rook.
+- TLS termination, reverse-proxy deployment policy, or certificate management.
+- Rate limiting, quotas, abuse controls, IP allowlists, or WAF-style protections.
+- Role-based access control, per-route scopes, multi-tenant authorization, or fine-grained policy.
+- Dashboard UI changes, operator UX, or client SDK ergonomics.
+- Secret storage redesign, encryption-at-rest, or full credential lifecycle management beyond what
+  the inbound boundary minimally needs.
+
+## Approach
+
+Treat inbound access control as a dedicated transport concern in `clients/rook`, enforced at router
+composition and/or request middleware boundaries before admin and gateway handlers execute.
+
+The proposal assumes a simple bearer-token gate is the right first slice because it is narrower,
+testable, and easier to reason about than introducing pairing or broader trust orchestration. The
+existing runtime helpers in `clients/agent-runtime/src/gateway/utils.rs` provide evidence for two
+useful patterns: robust bearer extraction and a defensive admin origin guard. However, this change
+must not copy runtime-specific assumptions about pairing state, webhook secrets, or onboarding
+recovery. Instead, Rook should define its own transport contract, error shape expectations, and
+configuration inputs for validating inbound client credentials.
+
+The auth boundary should be applied consistently to both `/api/*` and `/v1/*`, while still allowing
+the repository to keep explicitly public/non-sensitive endpoints separate if later slices require
+that distinction. For this first slice, the safe default is deny-by-default for protected inbound
+routes unless valid credentials are present.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `clients/rook/src/server/mod.rs` | Modified | Compose inbound auth enforcement with the existing `/api` and `/v1` routers without disturbing dashboard routing. |
+| `clients/rook/src/admin/mod.rs` | Modified | Ensure admin routes sit behind the new inbound auth boundary and preserve route intent. |
+| `clients/rook/src/gateway/mod.rs` | Modified | Ensure gateway routes sit behind the new inbound auth boundary while keeping handler contracts stable. |
+| `clients/rook/src/gateway/vendor.rs` | No functional change expected | Explicitly preserve outbound provider auth/header generation as a separate concern. |
+| `clients/rook/src/config/` | Modified | Define minimal configuration inputs for Rook inbound auth enforcement. |
+| `clients/rook/src/` auth/support module(s) | New | Add Rook-specific bearer parsing/validation and optional origin-guard helpers if the design chooses dedicated modules. |
+| `openspec/specs/gateway/spec.md` | Modified (follow-on) | Update the M1 “no auth” posture language to reflect the new #591 inbound boundary slice. |
+| `openspec/changes/rook-591-inbound-auth-boundary/` | New | Proposal, and follow-on spec/design/tasks artifacts for this slice. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Inbound auth is coupled to outbound vendor auth by mistake | Medium | Keep route-entry auth logic separate from `gateway/vendor.rs`; document the boundary explicitly in spec/design. |
+| Borrowing `agent-runtime` helpers imports wrong assumptions (pairing, webhook, onboarding) | High | Reuse only small patterns, not full runtime auth flows; require Rook-specific contracts and tests. |
+| Over-scoping the first slice delays delivery | Medium | Keep this change limited to request-entry authentication and rejection behavior only. |
+| Misconfigured auth could lock out valid local clients | Medium | Specify deterministic config requirements, clear unauthorized responses, and a reversible rollback path. |
+| Browser-origin checks alone are mistaken for authentication | Medium | Treat origin checks only as an optional defense-in-depth measure, never as the primary auth control. |
+| Router-level auth changes accidentally break existing dashboard or health behavior | Low | Keep protection targeted to `/api/*` and `/v1/*`; add composition tests in the follow-on spec/tasks phases. |
+
+## Rollback Plan
+
+If this slice causes regressions or operational lockout, revert the inbound auth enforcement layer
+for `/api/*` and `/v1/*`, remove any Rook-specific inbound auth module/config additions introduced
+by #591, and restore the prior loopback-first unauthenticated behavior documented in the current
+gateway spec. Because this slice is intentionally transport-boundary-only, rollback should not
+require changes to outbound vendor auth, routing decisions, or admin business logic.
+
+## Dependencies
+
+- Existing Rook server composition in `clients/rook/src/server/mod.rs` must continue to host `/api`,
+  `/v1`, and dashboard routes together.
+- Existing outbound provider auth separation in `clients/rook/src/gateway/vendor.rs` must be
+  preserved.
+- Existing gateway spec language in `openspec/specs/gateway/spec.md` currently states that auth is
+  deferred to #591 and will need a follow-on delta spec.
+- A concrete source for inbound bearer credentials/configuration will be needed in follow-on spec and
+  design work.
+
+## Success Criteria
+
+- [ ] The change remains narrowly scoped to inbound auth enforcement for Rook HTTP entrypoints.
+- [ ] The proposal clearly separates inbound client auth from outbound provider auth.
+- [ ] `/api/*` and `/v1/*` are identified as protected surfaces for this slice, with clear rejection
+      behavior for unauthorized access to be defined in follow-on spec work.
+- [ ] Runtime helper reuse is constrained to adaptable patterns, not copied trust assumptions.
+- [ ] The proposal leaves TLS, RBAC, rate limiting, and other hardening work explicitly deferred.
+- [ ] The change is ready for `sdd-spec` and `sdd-design` to define precise contract and
+      implementation details.

--- a/openspec/changes/archive/2026-04-22-rook-591-inbound-auth-boundary/specs/gateway/spec.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-inbound-auth-boundary/specs/gateway/spec.md
@@ -1,0 +1,273 @@
+# Delta for gateway
+
+## ADDED Requirements
+
+### Requirement: Inbound Auth Protected Surfaces
+
+Rook MUST enforce an inbound authentication boundary for the HTTP entrypoints mounted under
+`/api/*` and `/v1/*`.
+
+For this slice, every request whose effective route is under `/api/*` or `/v1/*` MUST be treated as
+ protected unless a later requirement in this spec explicitly marks it public.
+
+This slice MUST cover at least the following already-documented surfaces:
+
+- `GET /api/health`
+- all admin routes under `/api/*`
+- `POST /v1/chat/completions`
+- `GET /v1/models`
+
+Dashboard routes outside those prefixes, including `/` and dashboard asset routes, MUST remain out
+of scope for this inbound auth boundary.
+
+Inbound route authentication MUST be enforced before the matched admin or gateway handler performs
+its business logic.
+
+#### Scenario: authenticated request reaches protected gateway route
+
+- GIVEN the server is configured with inbound auth enabled for this slice
+- AND a client sends `Authorization: Bearer valid-inbound-token`
+- WHEN the client requests `GET /v1/models`
+- THEN the request MUST be evaluated against the inbound auth boundary before the route handler runs
+- AND the request MAY proceed to normal route handling only after the token is accepted
+
+#### Scenario: authenticated request reaches protected admin route
+
+- GIVEN the server is configured with inbound auth enabled for this slice
+- AND a client sends `Authorization: Bearer valid-inbound-token`
+- WHEN the client requests `GET /api/health`
+- THEN the request MUST be evaluated against the inbound auth boundary before the route handler runs
+- AND the request MAY proceed to normal route handling only after the token is accepted
+
+#### Scenario: dashboard route remains outside inbound auth scope
+
+- GIVEN the server hosts dashboard routes at `/` alongside `/api/*` and `/v1/*`
+- WHEN a client requests `/`
+- THEN this inbound auth boundary spec MUST NOT require bearer-token enforcement for that route
+
+---
+
+### Requirement: Inbound Bearer-Token Contract
+
+Protected inbound requests MUST present credentials using the HTTP `Authorization` header with the
+exact scheme `Bearer` followed by a single configured token value.
+
+The inbound auth boundary MUST treat this credential as a Rook client-to-Rook transport credential.
+It MUST NOT be reused as, derived from, or forwarded as outbound provider authentication.
+
+Validation for this slice MUST compare the presented bearer token against Rook inbound auth
+configuration and MUST produce a deterministic allow/deny outcome.
+
+Requests to protected routes MUST be rejected when:
+
+- the `Authorization` header is missing
+- the auth scheme is not `Bearer`
+- the bearer token value is empty after parsing
+- more than one bearer credential is presented in a way the server cannot interpret deterministically
+- the bearer token does not match the configured inbound credential
+
+#### Scenario: valid bearer token is accepted
+
+- GIVEN inbound auth is configured with the token `rook-inbound-secret`
+- WHEN the client sends `Authorization: Bearer rook-inbound-secret` to `GET /v1/models`
+- THEN the inbound auth boundary MUST accept the credential
+- AND the request MUST continue to normal route handling
+
+#### Scenario: missing authorization header is rejected
+
+- GIVEN inbound auth is configured with the token `rook-inbound-secret`
+- WHEN the client sends `GET /v1/models` without an `Authorization` header
+- THEN the inbound auth boundary MUST reject the request
+
+#### Scenario: non-bearer authorization scheme is rejected
+
+- GIVEN inbound auth is configured with the token `rook-inbound-secret`
+- WHEN the client sends `Authorization: Basic abc123` to `GET /api/health`
+- THEN the inbound auth boundary MUST reject the request
+
+#### Scenario: wrong bearer token is rejected
+
+- GIVEN inbound auth is configured with the token `rook-inbound-secret`
+- WHEN the client sends `Authorization: Bearer wrong-token` to `POST /v1/chat/completions`
+- THEN the inbound auth boundary MUST reject the request
+
+---
+
+### Requirement: Unauthorized and Forbidden Error Semantics
+
+When a protected request fails inbound authentication because credentials are missing, malformed, or
+invalid, Rook MUST return `401 Unauthorized`.
+
+`401 Unauthorized` responses produced by the inbound auth boundary MUST be returned before admin or
+gateway business logic executes.
+
+For protected `/v1/*` routes, the response body MUST use the documented gateway error response
+shape, with:
+
+- `error.type` set to `invalid_request_error`
+- `error.code` set to `unauthorized`
+- `error.message` describing that a valid inbound bearer token is required
+
+For protected `/api/*` routes, the response body MUST use the standard admin error response shape
+defined by the gateway domain, and the body MUST clearly indicate that authentication failed.
+
+When a request presents a valid inbound bearer token but the route is disallowed by an explicit
+server-side policy added by this slice or a compatible follow-on slice, the server MUST return
+`403 Forbidden` instead of `401 Unauthorized`.
+
+This slice SHOULD NOT introduce `403 Forbidden` behavior unless a concrete policy beyond token
+validity is configured.
+
+#### Scenario: gateway route missing token returns 401 gateway error
+
+- GIVEN inbound auth is configured with the token `rook-inbound-secret`
+- WHEN the client sends `GET /v1/models` without credentials
+- THEN the server MUST return `401 Unauthorized`
+- AND the response body MUST use the gateway error response shape
+- AND `error.code` MUST be `unauthorized`
+
+#### Scenario: admin route invalid token returns 401 admin error
+
+- GIVEN inbound auth is configured with the token `rook-inbound-secret`
+- WHEN the client sends `GET /api/health` with `Authorization: Bearer wrong-token`
+- THEN the server MUST return `401 Unauthorized`
+- AND the response body MUST use the standard admin error response shape
+
+#### Scenario: explicit deny policy returns 403
+
+- GIVEN inbound auth accepts the presented bearer token
+- AND an explicit server-side authorization policy denies access to the requested protected route
+- WHEN the client sends the request
+- THEN the server MUST return `403 Forbidden`
+- AND the response MUST identify that the request was authenticated but not permitted
+
+---
+
+### Requirement: Inbound Auth Configuration Contract
+
+This slice MUST define explicit configuration required for inbound auth enforcement.
+
+At minimum, Rook configuration for this slice MUST provide:
+
+- a boolean or equivalent explicit switch that determines whether inbound auth enforcement is active
+- a bearer-token value or secret reference used to validate inbound client credentials
+
+When inbound auth enforcement is active, startup or config loading MUST fail closed if the inbound
+bearer token is absent, empty, or not resolvable.
+
+When inbound auth enforcement is inactive, the server MAY retain the existing loopback-first M1
+behavior until a stricter default is adopted by a later slice.
+
+The configuration contract for inbound auth MUST remain separate from provider account credentials,
+vendor API keys, and outbound header construction in `clients/rook/src/gateway/vendor.rs`.
+
+#### Scenario: enabled auth without token fails closed
+
+- GIVEN server configuration enables inbound auth enforcement
+- AND the inbound bearer token value is missing or empty
+- WHEN the server loads configuration for startup
+- THEN startup or configuration initialization MUST fail
+- AND the server MUST NOT start in a partially protected state
+
+#### Scenario: enabled auth with token is valid configuration
+
+- GIVEN server configuration enables inbound auth enforcement
+- AND the inbound bearer token value is present and non-empty
+- WHEN the server loads configuration for startup
+- THEN configuration validation MUST succeed for this slice
+
+#### Scenario: inbound config is separate from vendor auth config
+
+- GIVEN a provider account has an outbound `api_key`
+- AND inbound auth is configured with a different bearer token
+- WHEN the server validates inbound auth configuration
+- THEN it MUST NOT treat the provider account `api_key` as the inbound credential source
+
+---
+
+### Requirement: Coexistence with Loopback-First Posture
+
+This slice MUST preserve Rook's loopback-first posture as a deployment default while making clear
+that loopback binding is not a substitute for inbound authentication on protected routes.
+
+The spec MUST treat loopback binding as an exposure-reduction measure and inbound bearer validation
+as the transport authentication control for `/api/*` and `/v1/*`.
+
+If the server is bound only to loopback, protected routes MUST still honor the same inbound auth
+contract whenever inbound auth enforcement is active.
+
+This slice MUST NOT rely on browser-origin checks, local-network assumptions, pairing state, or
+runtime onboarding trust flows as the primary authenticator for protected Rook routes.
+
+#### Scenario: loopback binding does not bypass active auth
+
+- GIVEN the server is bound only to `127.0.0.1` or equivalent loopback interfaces
+- AND inbound auth enforcement is active
+- WHEN the client requests `GET /api/health` without credentials
+- THEN the server MUST still return `401 Unauthorized`
+
+#### Scenario: loopback posture remains an additional safety layer
+
+- GIVEN the server is configured for loopback-first binding
+- WHEN inbound auth for this slice is enabled
+- THEN the effective protection model MUST combine loopback exposure reduction with inbound bearer validation
+- AND the spec MUST NOT describe loopback binding as sufficient authentication by itself
+
+---
+
+### Requirement: Non-Goals and Deferred Security Concerns
+
+This slice MUST remain narrow.
+
+The inbound auth boundary defined here MUST NOT require or imply implementation of:
+
+- outbound provider authentication changes in `clients/rook/src/gateway/vendor.rs`
+- shared trust state with `clients/agent-runtime`
+- pairing-code or onboarding recovery flows
+- TLS termination or reverse-proxy certificate policy
+- RBAC, scopes, multi-tenant authorization, or per-route permission models
+- rate limiting, quotas, abuse prevention, IP allowlists, or WAF controls
+- secret storage redesign beyond the minimal inbound token configuration this slice requires
+
+These concerns MAY be specified in later changes, but MUST NOT be prerequisites for satisfying this
+slice.
+
+#### Scenario: slice acceptance does not require outbound auth changes
+
+- GIVEN this inbound auth slice is implemented
+- WHEN `clients/rook/src/gateway/vendor.rs` constructs outbound provider headers
+- THEN its outbound auth behavior MUST remain governed by the existing vendor auth requirements
+- AND compliance with this slice MUST NOT depend on changing that behavior
+
+## MODIFIED Requirements
+
+### Requirement: Loopback-First and No-Auth M1 Safety Posture
+
+Rook MUST preserve the current loopback-first deployment posture for M1, but authentication for
+protected `/api/*` and `/v1/*` entrypoints is no longer entirely out of scope.
+
+This change replaces the previous "no auth" posture for those protected entrypoints with the inbound
+bearer-token boundary defined in change `rook-591-inbound-auth-boundary`.
+
+Dashboard routes outside `/api/*` and `/v1/*` remain outside this slice unless a later change says
+otherwise.
+
+Inbound auth for protected Rook routes MUST remain independent from runtime trust flows, pairing
+state, webhook secrets, and outbound provider auth.
+
+(Previously: Authentication and authorization were explicitly out of scope for this spec and the
+admin API contract was described as unauthenticated local-admin only.)
+
+#### Scenario: protected surfaces no longer use unauthenticated M1 contract
+
+- GIVEN the gateway domain after applying change `rook-591-inbound-auth-boundary`
+- WHEN a client interacts with `/api/*` or `/v1/*`
+- THEN the contract MUST require the inbound auth behavior defined by this delta spec
+- AND the spec MUST NOT describe those protected surfaces as unauthenticated
+
+#### Scenario: runtime trust flows remain out of scope for Rook inbound auth
+
+- GIVEN the inbound auth boundary for protected Rook routes
+- WHEN the design reuses ideas from `clients/agent-runtime/src/gateway/utils.rs`
+- THEN it MUST adapt only general patterns such as bearer extraction or defensive request filtering
+- AND it MUST NOT import runtime-specific pairing or onboarding trust requirements into this contract

--- a/openspec/changes/archive/2026-04-22-rook-591-inbound-auth-boundary/state.yaml
+++ b/openspec/changes/archive/2026-04-22-rook-591-inbound-auth-boundary/state.yaml
@@ -1,0 +1,12 @@
+change: rook-591-inbound-auth-boundary
+current_phase: archive
+completed:
+  - propose
+  - spec
+  - design
+  - tasks
+  - apply
+  - verify
+  - archive
+next: none
+updated: 2026-04-22T00:00:00Z

--- a/openspec/changes/archive/2026-04-22-rook-591-inbound-auth-boundary/tasks.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-inbound-auth-boundary/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Harden Rook Inbound Auth Boundary for `/api` and `/v1`
+
+## Phase 1: Foundation and RED tests
+
+- [x] 1.1 In `clients/rook/src/auth/bearer.rs`, add failing unit tests for missing header, non-Bearer scheme, empty token, valid token, case-insensitive scheme, trimmed token, and ambiguous/malformed authorization values.
+- [x] 1.2 In `clients/rook/src/config/mod.rs` or `clients/rook/src/auth/types.rs`, add failing tests for `InboundAuthConfig::validate()` covering enabled+missing token, enabled+blank token, enabled+valid token, and disabled+missing token.
+- [x] 1.3 In `clients/rook/src/gateway/types.rs` and the admin error-shaping location (`clients/rook/src/admin/types.rs` or `clients/rook/src/admin/handlers.rs`), add failing tests for `401` unauthorized helpers, expected body shape, and `WWW-Authenticate: Bearer`.
+
+## Phase 2: Core auth implementation
+
+- [x] 2.1 Create `clients/rook/src/auth/mod.rs`, `clients/rook/src/auth/types.rs`, and `clients/rook/src/auth/bearer.rs` with Rook-only inbound auth types, bearer extraction, and validation core; export the module from `clients/rook/src/lib.rs`.
+- [x] 2.2 Add the minimal inbound-auth config type and validation helper in `clients/rook/src/config/mod.rs` and wire it into `clients/rook/src/server/mod.rs::ServerConfig` as a separate inbound concern.
+- [x] 2.3 Add unauthorized response helpers for `/api/*` and `/v1/*` in the existing admin/gateway type helpers so middleware can return surface-specific `401` bodies without touching business logic.
+- [x] 2.4 Create `clients/rook/src/auth/middleware.rs` with shared token-check logic plus thin admin and gateway middleware adapters that emit the correct `401` response and `WWW-Authenticate` header.
+
+## Phase 3: Wiring and integration RED→GREEN
+
+- [x] 3.1 In `clients/rook/src/server/mod.rs`, add failing integration tests proving `/api/health`, `/v1/models`, and `/v1/chat/completions` return `401` without/with wrong token when auth is enabled, succeed with the valid token, and `/` stays `200` without auth.
+- [x] 3.2 In `clients/rook/src/server/mod.rs`, implement router composition so only `/api` and `/v1` are wrapped with inbound auth middleware; keep dashboard routes untouched.
+- [x] 3.3 Add failing startup tests in `clients/rook/src/server/mod.rs` for enabled auth with missing/blank token returning `RookError::Config`, then implement fail-closed validation in app/server construction.
+- [x] 3.4 In `clients/rook/src/main.rs`, add/adjust tests for `serve` auth inputs, then plumb minimal CLI/env-facing inbound auth settings into `ServerConfig` without mixing them with provider credentials.
+
+## Phase 4: Separation and cleanup
+
+- [x] 4.1 Add a targeted regression test near `clients/rook/src/server/mod.rs` or `clients/rook/src/gateway/handlers.rs` proving successful inbound auth does not change outbound provider-auth behavior in `clients/rook/src/gateway/vendor.rs`.
+- [x] 4.2 Do a small cleanup pass across touched files to remove duplication, keep inbound vs outbound auth naming explicit, and add short comments only where the boundary would otherwise be unclear.

--- a/openspec/changes/archive/2026-04-22-rook-591-inbound-auth-boundary/verify-report.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-inbound-auth-boundary/verify-report.md
@@ -1,0 +1,148 @@
+## Verification Report
+
+**Change**: rook-591-inbound-auth-boundary
+**Date**: 2026-04-22
+
+---
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 10 |
+| Tasks complete | 10 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/rook-591-inbound-auth-boundary/tasks.md` are marked complete.
+
+---
+
+### Behavioral and Structural Verification Evidence
+
+#### Targeted verification commands executed
+
+1. `cargo test --manifest-path "clients/rook/Cargo.toml" auth::bearer::tests::`
+   - Result: **7 passed / 0 failed**
+2. `cargo test --manifest-path "clients/rook/Cargo.toml" config::tests::inbound_auth_config_`
+   - Result: **4 passed / 0 failed**
+3. `cargo test --manifest-path "clients/rook/Cargo.toml" admin::types::tests::admin_unauthorized_response_uses_admin_shape_and_bearer_header`
+   - Result: **1 passed / 0 failed**
+4. `cargo test --manifest-path "clients/rook/Cargo.toml" gateway::types::tests::gateway_unauthorized_response_uses_gateway_shape_and_bearer_header`
+   - Result: **1 passed / 0 failed**
+5. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::protected_routes_require_valid_bearer_when_auth_enabled`
+   - Result: **1 passed / 0 failed**
+6. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::protected_routes_reach_handlers_with_valid_bearer_and_dashboard_stays_public`
+   - Result: **1 passed / 0 failed**
+7. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::build_app_fails_closed_when_enabled_auth_token_is_missing_or_blank`
+   - Result: **1 passed / 0 failed**
+8. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::valid_inbound_auth_does_not_replace_outbound_provider_auth`
+   - Result: **1 passed / 0 failed**
+9. `cargo test --manifest-path "clients/rook/Cargo.toml" --bin rook tests::serve_cli_parses_inbound_auth_flags`
+   - Result: **1 passed / 0 failed**
+10. `cargo test --manifest-path "clients/rook/Cargo.toml" --bin rook tests::build_server_config_keeps_inbound_auth_separate`
+    - Result: **1 passed / 0 failed**
+
+**Targeted evidence summary**: **19 passed / 0 failed / 0 skipped**
+
+#### Broader suite signal collected
+
+`cargo test --manifest-path "clients/rook/Cargo.toml"`
+
+- Result: **178 passed / 2 failed / 0 skipped**
+- Failing tests:
+  - `db::account::tests::vendor_other_with_quotes_round_trips`
+  - `routing::tests::cycle_detection_returns_routing_error`
+
+These failures are outside the inbound-auth files and scenarios for this change, but they mean the
+full Rook crate test suite is not currently clean.
+
+#### Build / type-check
+
+Not run. The user explicitly required: **Do not build the project.**
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test / Evidence | Result |
+|-------------|----------|-----------------|--------|
+| Inbound Auth Protected Surfaces | authenticated request reaches protected gateway route | `server::tests::protected_routes_reach_handlers_with_valid_bearer_and_dashboard_stays_public` (`GET /v1/models` with valid bearer) | ✅ COMPLIANT |
+| Inbound Auth Protected Surfaces | authenticated request reaches protected admin route | `server::tests::protected_routes_reach_handlers_with_valid_bearer_and_dashboard_stays_public` (`GET /api/health` with valid bearer) | ✅ COMPLIANT |
+| Inbound Auth Protected Surfaces | dashboard route remains outside inbound auth scope | `server::tests::protected_routes_reach_handlers_with_valid_bearer_and_dashboard_stays_public` (`GET /`) | ✅ COMPLIANT |
+| Inbound Bearer-Token Contract | valid bearer token is accepted | `server::tests::protected_routes_reach_handlers_with_valid_bearer_and_dashboard_stays_public` | ✅ COMPLIANT |
+| Inbound Bearer-Token Contract | missing authorization header is rejected | `auth::bearer::tests::extract_bearer_token_rejects_missing_header` only; no direct `/v1/models` route-level runtime test | ⚠️ PARTIAL |
+| Inbound Bearer-Token Contract | non-bearer authorization scheme is rejected | `auth::bearer::tests::extract_bearer_token_rejects_non_bearer_scheme` only; no direct route-level runtime test | ⚠️ PARTIAL |
+| Inbound Bearer-Token Contract | wrong bearer token is rejected | `server::tests::protected_routes_require_valid_bearer_when_auth_enabled` (`POST /v1/chat/completions` wrong token) | ✅ COMPLIANT |
+| Unauthorized and Forbidden Error Semantics | gateway route missing token returns 401 gateway error | No direct runtime test for `GET /v1/models` without credentials | ❌ UNTESTED |
+| Unauthorized and Forbidden Error Semantics | admin route invalid token returns 401 admin error | No direct runtime test for `GET /api/health` with wrong bearer token | ❌ UNTESTED |
+| Unauthorized and Forbidden Error Semantics | explicit deny policy returns 403 | No explicit deny policy or behavioral test in this slice; design intentionally defers 403 policy logic | ⚠️ PARTIAL |
+| Inbound Auth Configuration Contract | enabled auth without token fails closed | `server::tests::build_app_fails_closed_when_enabled_auth_token_is_missing_or_blank` | ✅ COMPLIANT |
+| Inbound Auth Configuration Contract | enabled auth with token is valid configuration | `config::tests::inbound_auth_config_validate_accepts_enabled_valid_token` | ✅ COMPLIANT |
+| Inbound Auth Configuration Contract | inbound config is separate from vendor auth config | `server::tests::valid_inbound_auth_does_not_replace_outbound_provider_auth` and `tests::build_server_config_keeps_inbound_auth_separate` | ✅ COMPLIANT |
+| Coexistence with Loopback-First Posture | loopback binding does not bypass active auth | Uses default loopback host in config and verifies protected routes reject/require auth, but no bound-listener runtime test | ⚠️ PARTIAL |
+| Coexistence with Loopback-First Posture | loopback posture remains an additional safety layer | Structural evidence in proposal/design/server config; no dedicated runtime test | ⚠️ PARTIAL |
+| Non-Goals and Deferred Security Concerns | slice acceptance does not require outbound auth changes | `server::tests::valid_inbound_auth_does_not_replace_outbound_provider_auth`; `clients/rook/src/gateway/vendor.rs` unchanged functionally | ✅ COMPLIANT |
+| Loopback-First and No-Auth M1 Safety Posture (modified) | protected surfaces no longer use unauthenticated M1 contract | `server::tests::protected_routes_require_valid_bearer_when_auth_enabled` | ✅ COMPLIANT |
+| Loopback-First and No-Auth M1 Safety Posture (modified) | runtime trust flows remain out of scope for Rook inbound auth | Structural evidence only: dedicated `clients/rook/src/auth/*`; no `agent-runtime` trust-flow reuse detected | ⚠️ PARTIAL |
+
+**Compliance summary**: 10 compliant / 6 partial / 2 untested
+
+---
+
+### Correctness (Static — Structural Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Protect `/api/*` and `/v1/*` only | ✅ Implemented | `clients/rook/src/server/mod.rs` layers `admin_inbound_auth` and `gateway_inbound_auth` only on nested `/api` and `/v1` routers; dashboard router remains merged separately. |
+| Dedicated inbound bearer contract | ✅ Implemented | `clients/rook/src/auth/bearer.rs` enforces single `Authorization` header, `Bearer` scheme, empty-token rejection, and malformed/ambiguous rejection. |
+| Unauthorized error semantics | ✅ Implemented | `clients/rook/src/admin/types.rs::admin_unauthorized_response()` and `clients/rook/src/gateway/types.rs::gateway_unauthorized_response()` return `401` plus `WWW-Authenticate: Bearer` with distinct body contracts. |
+| Inbound config contract | ✅ Implemented | `clients/rook/src/config/mod.rs::InboundAuthConfig` has `enabled` + `bearer_token`; `validate()` fails closed when enabled and token missing/blank. |
+| Separation from outbound vendor auth | ✅ Implemented | `clients/rook/src/auth/*` is separate; `clients/rook/src/gateway/vendor.rs` still owns outbound provider headers; regression test confirms provider bearer remains `sk-provider`, not inbound token. |
+| Dashboard routes out of scope | ✅ Implemented | `dashboard::router()` is merged outside auth-wrapped nests and dashboard root test stays `200`. |
+| 403 explicit deny extension point | ⚠️ Partial | This slice intentionally does not implement explicit deny policy logic, which matches the design's scope choice, but there is no exercised 403 behavior. |
+
+---
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Put auth boundary at server router composition | ✅ Yes | Auth middleware is applied in `clients/rook/src/server/mod.rs` before nested routers execute. |
+| Keep inbound auth in a new Rook-only module | ✅ Yes | New `clients/rook/src/auth/` module exists and is exported from `clients/rook/src/lib.rs`. |
+| Use shared validation core with surface-specific adapters | ✅ Yes | Shared `validate_inbound_request(...)` plus `admin_inbound_auth` and `gateway_inbound_auth`. |
+| Keep auth config on `ServerConfig` | ✅ Yes | `ServerConfig` now includes `inbound_auth: InboundAuthConfig`; `main.rs` maps CLI inputs into it. |
+| Fail closed only when auth is enabled | ✅ Yes | `config.inbound_auth.validate()?` is called during app construction; disabled config still defaults to prior behavior. |
+| Do not introduce 403 policy logic in this slice | ✅ Yes | No deny policy or `403` implementation was introduced. |
+
+File-change coherence is strong overall. One small deviation from the design table: `clients/rook/src/config/mod.rs` owns `InboundAuthConfig` directly instead of splitting config-facing types across `auth/types.rs`; this is still aligned with the design's allowed narrow-config approach.
+
+---
+
+### Issues Found
+
+**CRITICAL**
+
+- None in the implemented inbound-auth code path that was targeted for this change.
+
+**WARNING**
+
+- The full `clients/rook` crate test suite is not clean: `cargo test --manifest-path "clients/rook/Cargo.toml"` failed 2 unrelated tests (`db::account::tests::vendor_other_with_quotes_round_trips`, `routing::tests::cycle_detection_returns_routing_error`).
+- Two spec scenarios lack direct runtime proof at the route boundary:
+  - gateway `401` shape for `GET /v1/models` with **missing** credentials
+  - admin `401` shape for `GET /api/health` with **invalid** bearer token
+- Several spec scenarios are only partially proven through unit-level parser/config tests or static structure rather than dedicated route-level runtime tests (non-Bearer rejection, loopback coexistence wording, runtime trust-flow separation, deferred 403 path).
+
+**SUGGESTION**
+
+- Add two explicit integration tests in `clients/rook/src/server/mod.rs` for:
+  1. `GET /v1/models` without credentials → `401` with gateway error shape
+  2. `GET /api/health` with wrong bearer token → `401` with admin error shape
+- Consider adding one explicit documentation/test comment around the deferred `403` behavior so future slices do not mistake its absence for an omission.
+
+---
+
+### Verdict
+
+**PASS WITH WARNINGS**
+
+The inbound auth boundary is implemented in the correct place, uses a dedicated Rook-only contract, preserves dashboard and outbound vendor-auth separation, and has passing targeted behavioral tests. Verification is not fully clean because some spec scenarios still lack direct runtime coverage and the broader Rook crate suite currently has unrelated failing tests.

--- a/openspec/changes/archive/2026-04-22-rook-591-transport-middleware-baseline/design.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-transport-middleware-baseline/design.md
@@ -1,0 +1,510 @@
+# Design: Establish Rook Transport Middleware Baseline
+
+## Technical Approach
+
+This slice adds a dedicated transport middleware layer at the Rook HTTP composition boundary in
+`clients/rook/src/server/mod.rs`, where the combined axum server already nests `/api/*`, `/v1/*`,
+and dashboard routes. The middleware baseline is shared by the admin surface (`/api/*`) and the
+gateway surface (`/v1/*`), but remains separate from the archived inbound auth boundary by keeping
+transport concerns in a new top-level transport module instead of mixing them into
+`clients/rook/src/auth/` or into handler code.
+
+The implementation approach is:
+
+1. add a `TransportConfig` subtree to Rook startup configuration, defaulting to strict mode
+2. create a transport module that owns request ID validation/generation, trusted-proxy evaluation,
+   sanitized transport context, and observability hooks
+3. compose that transport layer around the existing `/api` and `/v1` nested routers so it runs for
+   both success and error paths, including auth failures
+4. expose only a sanitized request-scoped transport context to downstream code through request
+   extensions
+5. return the effective request ID in the configured response header without changing admin or
+   gateway business contracts
+
+This matches the proposal and delta spec by keeping the slice narrow: request IDs,
+tracing/logging hooks, header sanitation, and forwarded-header trust policy only. It does not
+change inbound bearer auth semantics, rate limiting, streaming, TLS, or outbound provider auth.
+
+## Architecture Decisions
+
+### Decision: Put the transport baseline at server router composition, outside handlers
+
+**Choice**: Apply the transport middleware baseline in `clients/rook/src/server/mod.rs` when the
+server nests the admin and gateway routers under `/api` and `/v1`.
+
+**Alternatives considered**:
+- add request ID and header handling inside each admin and gateway handler
+- place middleware separately inside `admin::build_router()` and `gateway::build_router()` with
+  duplicated setup logic
+
+**Rationale**:
+- `server/mod.rs` is already the shared composition point for the covered surfaces.
+- The spec requires one baseline contract across both `/api/*` and `/v1/*`.
+- Keeping transport behavior outside handlers prevents drift and avoids leaking transport policy into
+  business code.
+- Dashboard routes remain out of scope by simple router topology rather than ad hoc conditionals.
+
+### Decision: Keep transport middleware separate from archived auth-boundary code
+
+**Choice**: Introduce a new top-level module such as `clients/rook/src/transport/` instead of
+adding this behavior to `clients/rook/src/auth/`.
+
+**Alternatives considered**:
+- extend `clients/rook/src/auth/middleware.rs` to also own request IDs and forwarded-header policy
+- fold transport helpers into `gateway/` because `/v1/*` is the OpenAI-compatible surface
+
+**Rationale**:
+- The archived `rook-591-inbound-auth-boundary` slice already owns bearer-auth enforcement.
+- Request correlation, header sanitation, and trusted-proxy policy are transport-boundary concerns,
+  not auth concerns.
+- A dedicated module keeps this slice independently rollbackable and prevents accidental scope creep
+  into auth semantics.
+
+### Decision: Transport middleware wraps auth middleware so 401s still get request IDs and hooks
+
+**Choice**: Compose middleware so the transport baseline executes before the existing auth layer and
+observes the final response after auth or handler execution.
+
+**Alternatives considered**:
+- run auth first, then transport only for authenticated requests
+- create one combined transport+auth middleware and retire the auth layer
+
+**Rationale**:
+- The spec requires request IDs and observability hooks on both success and error responses.
+- Auth failures on `/api/*` and `/v1/*` should still carry the effective request ID for support and
+  operations.
+- Replacing the archived auth middleware would blur slice boundaries and increase rollback risk.
+
+### Decision: Expose a sanitized transport context through request extensions instead of mutating all headers
+
+**Choice**: Store a `SanitizedTransportContext` in request extensions and require downstream
+transport-aware code to read that context rather than raw transport/proxy headers.
+
+**Alternatives considered**:
+- physically remove or rewrite forwarded headers in the inbound `HeaderMap`
+- let downstream code inspect raw headers and merely document which ones are trusted
+
+**Rationale**:
+- This slice must govern trusted interpretation, not globally rewrite unrelated application header
+  behavior.
+- Leaving the raw header map intact avoids unintended side effects for generic request handling.
+- A dedicated sanitized context makes the trusted view explicit and testable.
+
+### Decision: Use strict request ID validation with server generation fallback
+
+**Choice**: Treat an inbound request ID as valid only when exactly one configured header value is
+present, non-empty after trimming, ASCII-visible, and within a bounded length; otherwise generate a
+new UUID v4 request ID.
+
+**Alternatives considered**:
+- accept any non-empty string verbatim
+- require inbound IDs to already be UUIDs
+- reject the request on malformed inbound request ID
+
+**Rationale**:
+- Accept-anything risks log injection and poor correlation hygiene.
+- UUID-only would reject common upstream correlation formats unnecessarily.
+- Generating a replacement preserves deterministic correlation without expanding this slice into a
+  client-error policy.
+
+### Decision: Trusted proxy opt-in is allowlist-based and fail-closed
+
+**Choice**: Model trusted-proxy behavior as an explicit allowlist of proxy source CIDRs plus an
+explicit allowlist of forwarded header families that may be honored.
+
+**Alternatives considered**:
+- a single boolean like `behind_proxy = true`
+- trust all `X-Forwarded-*` headers whenever Rook binds to a private address
+- trust forwarded metadata if any reverse proxy is “expected” in deployment docs
+
+**Rationale**:
+- The spec requires more than a vague “behind a proxy” assumption.
+- CIDR/source allowlists are concrete, auditable, and fail closed when missing or malformed.
+- Header-family allowlists prevent opt-in from silently widening trust to all proxy-provided data.
+
+### Decision: Use custom middleware hooks, not a generic `TraceLayer`, for this baseline
+
+**Choice**: Implement a small custom transport middleware in Rook that emits structured tracing
+events and injects response headers itself.
+
+**Alternatives considered**:
+- rely entirely on `tower_http::trace::TraceLayer`
+- add logging directly in each handler
+
+**Rationale**:
+- This slice needs request ID adoption/generation, response header propagation, forwarded trust
+  decisions, and header redaction boundaries in one place.
+- Generic trace layers do not express the full trusted/untrusted forwarded metadata contract by
+  themselves.
+- Handler-level logging would duplicate logic and miss auth failures.
+
+## Data Flow
+
+### Covered Request Flow
+
+```text
+Client Request
+   |
+   v
+Combined Router (`server/mod.rs`)
+   |
+   +--> `/api/*` nested router
+   |       |
+   |       v
+   |   transport middleware baseline
+   |       |
+   |       v
+   |   archived auth middleware
+   |       |
+   |       v
+   |   admin handlers
+   |
+   +--> `/v1/*` nested router
+   |       |
+   |       v
+   |   transport middleware baseline
+   |       |
+   |       v
+   |   archived auth middleware
+   |       |
+   |       v
+   |   gateway handlers
+   |
+   \--> dashboard router (`/`, assets) unchanged
+```
+
+### Request ID + Transport Context Flow
+
+```text
+Inbound request
+   |
+   +--> read configured request ID header
+   |       |
+   |       +--> valid single value ----> adopt as effective request ID
+   |       |
+   |       \--> missing / empty / malformed / multi-value ---> generate UUID v4
+   |
+   +--> inspect direct peer address (if available)
+   |
+   +--> sanitize forwarded/proxy headers
+   |       |
+   |       +--> trusted proxy match + allowed header family + valid syntax --> trusted view
+   |       |
+   |       \--> otherwise --> ignored for canonical transport interpretation
+   |
+   +--> store `SanitizedTransportContext` in request extensions
+   |
+   +--> call next middleware / handler
+   |
+   +--> emit structured completion hook
+   |
+   \--> set response request ID header
+```
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as server/mod.rs
+    participant T as transport::middleware
+    participant A as auth::middleware
+    participant H as admin/gateway handler
+
+    C->>S: HTTP request to /api/* or /v1/*
+    S->>T: dispatch into covered nested router
+    T->>T: adopt or generate request ID
+    T->>T: sanitize request ID + forwarded headers
+    T->>T: evaluate trusted-proxy policy from direct peer address
+    T->>A: forward request with sanitized transport context
+    alt auth fails
+        A-->>T: 401 response
+    else auth passes
+        A->>H: invoke matched handler
+        H-->>T: success or handler error response
+    end
+    T->>T: emit structured completion log/span fields
+    T-->>C: response with effective request ID header
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `clients/rook/src/lib.rs` | Modify | Export the new `transport` module. |
+| `clients/rook/src/server/mod.rs` | Modify | Extend `ServerConfig`, validate transport config, and compose `/api` + `/v1` routers with the shared transport baseline outside the existing auth middleware. |
+| `clients/rook/src/main.rs` | Modify | Populate `ServerConfig.transport` with strict defaults and any minimal startup wiring needed for explicit transport settings. |
+| `clients/rook/src/config/mod.rs` | Modify | Add `TransportConfig`, `RequestIdConfig`, `TrustedProxyConfig`, and validation helpers separate from inbound auth config. |
+| `clients/rook/src/auth/middleware.rs` | No functional redesign | Existing auth middleware stays in place; only composition order changes around it. |
+| `clients/rook/src/admin/mod.rs` | No handler logic change | Admin routes remain mounted as-is; transport context becomes available through request extensions if later consumed. |
+| `clients/rook/src/gateway/mod.rs` | No handler logic change | Gateway routes remain mounted as-is; transport context becomes available through request extensions if later consumed. |
+| `clients/rook/src/gateway/handlers.rs` | Optional narrow modify | Replace ad hoc request logs with transport-context-backed fields only if needed to avoid duplicated correlation logging. |
+| `clients/rook/src/admin/handlers.rs` | Optional narrow modify | No business contract changes; only optional use of request ID in error logging if implementation chooses. |
+| `clients/rook/src/transport/mod.rs` | Create | Public entrypoint for transport baseline types and middleware helpers. |
+| `clients/rook/src/transport/context.rs` | Create | Request-scoped sanitized transport context and trust-status enums stored in request extensions. |
+| `clients/rook/src/transport/request_id.rs` | Create | Request ID parsing, syntax validation, generation, and response-header propagation helpers. |
+| `clients/rook/src/transport/forwarded.rs` | Create | `X-Forwarded-*` / `X-Real-IP` sanitation, `Via` diagnostics, and trusted-proxy evaluation helpers for this slice. |
+| `clients/rook/src/transport/middleware.rs` | Create | Axum middleware that assembles request ID handling, sanitized context injection, completion hooks, and response header propagation. |
+| `clients/rook/Cargo.toml` | Modify | Add a small IP/CIDR parsing dependency if needed for trusted-proxy allowlist validation (for example `ipnet`), while keeping the slice transport-only. |
+
+## Interfaces / Contracts
+
+### Startup Configuration
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestIdConfig {
+    pub inbound_header_name: String,
+    pub response_header_name: String,
+    pub max_length: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustedProxyConfig {
+    pub enabled: bool,
+    pub trusted_cidrs: Vec<String>,
+    pub allowed_headers: TrustedForwardedHeaders,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustedForwardedHeaders {
+    pub x_forwarded_for: bool,
+    pub x_forwarded_host: bool,
+    pub x_forwarded_proto: bool,
+    pub x_forwarded_port: bool,
+    pub x_real_ip: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransportConfig {
+    pub request_id: RequestIdConfig,
+    pub trusted_proxy: TrustedProxyConfig,
+}
+
+impl TransportConfig {
+    pub fn validate(&self) -> Result<(), RookError>;
+}
+```
+
+Design notes:
+- `TransportConfig::default()` is strict by default:
+  - inbound request ID header = `x-request-id`
+  - response request ID header = `x-request-id`
+  - `max_length = 128`
+  - trusted proxy disabled
+  - all forwarded header families disallowed unless explicitly enabled
+- if trusted proxy is enabled, validation must reject empty CIDR lists or invalid CIDR syntax
+- inbound auth config remains separate and unchanged in meaning
+
+### Server Wiring
+
+```rust
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
+    pub enable_tui: bool,
+    pub db_path: Option<String>,
+    pub inbound_auth: InboundAuthConfig,
+    pub transport: TransportConfig,
+}
+```
+
+The server build path validates `config.transport` before composing routers. The production `run`
+path is updated to preserve direct peer information via axum connect-info so trusted-proxy
+evaluation can compare the actual remote socket against the configured allowlist.
+
+### Request-Scoped Sanitized Transport Context
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SanitizedTransportContext {
+    pub request_id: String,
+    pub route_surface: RouteSurface,
+    pub direct_peer_addr: Option<std::net::SocketAddr>,
+    pub forwarded: SanitizedForwardedContext,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteSurface {
+    AdminApi,
+    GatewayV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SanitizedForwardedContext {
+    pub trust: ForwardedTrust,
+    pub client_ip: Option<std::net::IpAddr>,
+    pub host: Option<String>,
+    pub proto: Option<String>,
+    pub port: Option<u16>,
+    pub ignored_headers: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForwardedTrust {
+    Absent,
+    Ignored,
+    Trusted,
+}
+```
+
+Downstream code sees:
+- exactly one effective request ID
+- direct peer socket when available
+- canonical forwarded metadata only when it was both syntactically valid and allowed under the
+  trusted-proxy policy
+- an explicit trust status telling the difference between absent, ignored, and trusted metadata
+
+Downstream code does **not** see through this API:
+- malformed or empty request ID candidates
+- raw `X-Forwarded-*`, `X-Real-IP`, or `Via` values that failed validation
+- untrusted forwarded metadata promoted into canonical host/proto/client-IP fields
+- secret-bearing headers or cookies in logging/tracing hooks
+
+Raw headers remain on the request because this slice is not a global header-rewrite feature, but
+transport-aware consumers must treat `SanitizedTransportContext` as the only trusted source.
+
+### Request ID Rules
+
+```rust
+pub enum RequestIdAdoption {
+    Adopted(String),
+    Generated(String),
+}
+
+pub fn resolve_request_id(
+    headers: &axum::http::HeaderMap,
+    config: &RequestIdConfig,
+) -> RequestIdAdoption;
+```
+
+Validation rules for request ID adoption in this slice:
+- only one effective header value may be adopted
+- value must be non-empty after trimming
+- value must contain only visible ASCII characters
+- value must not contain whitespace, commas, or control characters
+- value length must be `<= max_length`
+- otherwise the middleware generates a lowercase hyphenated UUID v4 string via the existing `uuid`
+  dependency
+
+### Forwarded-Header Policy Enforcement
+
+For this slice, the trusted forwarded/proxy families are limited to `X-Forwarded-*` and
+`X-Real-IP`. `Via` remains diagnostic-only and is never elevated into canonical transport context.
+The standard `Forwarded` header is intentionally deferred to a future slice so this change stays
+narrow and aligned with the implemented scope.
+
+```rust
+pub struct ForwardedResolution {
+    pub context: SanitizedForwardedContext,
+    pub forwarded_present: bool,
+}
+
+pub fn resolve_forwarded_context(
+    headers: &axum::http::HeaderMap,
+    direct_peer_addr: Option<std::net::SocketAddr>,
+    config: &TrustedProxyConfig,
+) -> ForwardedResolution;
+```
+
+Enforcement rules:
+- if trusted proxy is disabled, all forwarded metadata is ignored for canonical interpretation
+- if trusted proxy is enabled but direct peer info is absent, behave as strict default (`Ignored`)
+- if direct peer does not match the trusted CIDR allowlist, behave as strict default (`Ignored`)
+- if the header family is not enabled in `allowed_headers`, ignore it even when the proxy source is
+  trusted
+- if a header value is empty or malformed, ignore it and record that family in `ignored_headers`
+- `Via` is sanitized for diagnostics only; it is never elevated into canonical host/proto/client-IP
+
+### Logging / Tracing Hook Contract
+
+The middleware emits one structured completion event per covered request with fields equivalent to:
+
+```rust
+tracing::info!(
+    request_id = %context.request_id,
+    surface = ?context.route_surface,
+    method = %method,
+    route = %matched_route_or_fallback,
+    status = status.as_u16(),
+    duration_ms = duration_ms,
+    forwarded_trust = ?context.forwarded.trust,
+    forwarded_present = forwarded_present,
+    ignored_forwarded_headers = ?context.forwarded.ignored_headers,
+    "completed rook transport request",
+);
+```
+
+Redaction boundaries:
+- never log raw values for `Authorization`, `Proxy-Authorization`, `Cookie`, or `Set-Cookie`
+- never log provider API keys, bearer tokens, or token-like values from arbitrary headers
+- do not log request bodies in this slice
+- if diagnostics include header information, log only sanitized/trusted derived values or header
+  names, never raw secret-bearing values
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Request ID validation/generation rules | Add focused tests in `transport/request_id.rs` for absent, valid inbound, malformed inbound, multi-value, whitespace, and oversized values. |
+| Unit | Trusted-proxy config validation | Add tests in `config/mod.rs` for strict default, enabled-with-empty-list rejection, invalid CIDR rejection, and allowed-header validation. |
+| Unit | Forwarded-header sanitation | Add tests in `transport/forwarded.rs` for disabled trust, non-trusted source fallback, trusted source + allowed header family, empty/malformed forwarded values, and `Via` staying diagnostic-only. |
+| Integration | Router composition for `/api/*` and `/v1/*` | Extend `clients/rook/src/server/mod.rs` tests to assert covered routes receive response request IDs, dashboard routes remain out of scope, and auth failures still include request ID headers. |
+| Integration | Sanitized context availability before handler business logic | Add a narrow test-only probe route or middleware harness in `server/mod.rs`/`transport/middleware.rs` tests that reads request extensions and verifies request ID + forwarded trust state are present before handler execution. |
+| Integration | Trusted proxy enforcement | Build request tests that manually attach direct peer info via request extensions for `oneshot` requests, then verify trusted vs ignored forwarded metadata without requiring real sockets. |
+| Integration | Logging/tracing hooks redaction | Use a test subscriber or captured tracing output to verify request completion events include request ID/status/duration fields and never include raw `Authorization` or `Cookie` values. |
+| E2E | Not required for this slice | The baseline is transport-local to `clients/rook`; targeted integration tests are sufficient and keep scope narrow. |
+
+## Migration / Rollout
+
+No data migration required.
+
+Rollout is runtime-only and strict by default:
+- existing deployments get generated/adopted request IDs and transport completion hooks on `/api/*`
+  and `/v1/*`
+- forwarded metadata remains untrusted unless explicit trusted-proxy configuration is added
+- dashboard routes remain unchanged
+
+## Tradeoffs and Rejected Alternatives
+
+### Tradeoff: Trusted interpretation via request extensions instead of destructive header rewriting
+
+This keeps the slice narrow and reduces compatibility risk, but it means downstream code must follow
+the new transport context contract instead of casually reading raw forwarded headers.
+
+### Tradeoff: Request ID generation fallback instead of request rejection
+
+This is more operationally forgiving and preserves correlation on malformed input, but it does mean
+clients are not explicitly told that their supplied request ID was rejected.
+
+### Rejected: Generic “trust proxy” boolean
+
+Rejected because it weakens the strict-by-default posture and cannot prove which sources or header
+families are trusted.
+
+### Rejected: Put transport policy into the archived auth middleware
+
+Rejected because it would blur responsibilities, complicate rollback, and make future auth changes
+harder to separate from transport work.
+
+### Rejected: Apply the baseline to dashboard routes now
+
+Rejected because the spec is explicit that this slice only covers `/api/*` and `/v1/*`. Expanding
+to `/` would widen scope and create unnecessary risk.
+
+## Rollback
+
+Rollback is straightforward because the slice is isolated at the transport boundary:
+
+1. remove the transport middleware composition from `clients/rook/src/server/mod.rs`
+2. remove the `transport` module and `ServerConfig.transport` wiring
+3. remove any trusted-proxy configuration fields added for this slice
+4. keep archived auth middleware and handler routing unchanged
+
+After rollback, `/api/*` and `/v1/*` return to their prior direct-request behavior with the inbound
+auth boundary still intact and dashboard routes still unaffected.
+
+## Open Questions
+
+- [ ] None blocking for this slice.

--- a/openspec/changes/archive/2026-04-22-rook-591-transport-middleware-baseline/proposal.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-transport-middleware-baseline/proposal.md
@@ -1,0 +1,111 @@
+# Proposal: Establish Rook Transport Middleware Baseline
+
+## Intent
+
+Rook issue #591 still has a narrow but important follow-up slice after the inbound auth boundary was
+completed: the HTTP transport layer needs a baseline middleware contract before later hardening work
+can be added safely. Today, transport concerns such as request correlation, tracing/logging hooks,
+header sanitation, and proxy-header trust boundaries are not yet defined as a cohesive baseline for
+`/api/*` and `/v1/*`.
+
+This slice defines that baseline and keeps it explicitly separate from the archived inbound auth
+boundary work. The goal is to make request handling more observable and safer by default, while
+preserving the chosen security posture: Rook MUST default to strict handling and MUST NOT trust
+`X-Forwarded-*` headers unless an explicit trusted-proxy policy is configured.
+
+## Scope
+
+### In Scope
+
+- Define a dedicated #591 follow-up slice for transport middleware baseline concerns on Rook HTTP
+  entrypoints only.
+- Define request ID generation and propagation expectations for inbound `/api/*` and `/v1/*`
+  requests.
+- Define tracing/logging hook requirements at the transport boundary so requests can be correlated
+  without changing downstream business contracts.
+- Define inbound header sanitation requirements for transport-layer and proxy-related headers before
+  handlers rely on them.
+- Define a strict-by-default forwarded-header trust policy.
+- Define the explicit opt-in conditions under which `X-Forwarded-*` or similar forwarded metadata MAY
+  be honored.
+- Identify the minimal server, middleware, configuration, and spec areas that follow-on spec/design
+  work must cover for this slice.
+
+### Out of Scope
+
+- Any changes already covered by `rook-591-inbound-auth-boundary`.
+- Inbound bearer auth semantics, token parsing, or authorization policy changes.
+- Rate limiting, quotas, abuse controls, or IP throttling.
+- Idempotency keys or replay-protection behavior.
+- Streaming request/response transport behavior.
+- TLS termination, certificate handling, or mTLS policy.
+- RBAC, route scopes, multi-tenant authorization, or permission models.
+- Outbound provider authentication/header changes in `clients/rook/src/gateway/vendor.rs`.
+- Response-shaping work unrelated to request correlation or middleware observability.
+
+## Approach
+
+Treat this slice as transport-boundary middleware policy for `clients/rook`, applied before admin or
+gateway handlers execute. The baseline should establish deterministic request metadata handling,
+sanitized header views, and observability hooks without changing Rook’s existing route intent.
+
+The key design constraint is trust: forwarded headers are attacker-controlled unless a trusted proxy
+boundary is explicitly configured. For that reason, the proposal sets a strict default posture where
+Rook ignores untrusted `X-Forwarded-*` inputs for security-sensitive interpretation and relies on the
+direct connection context unless configuration says otherwise. Any future proxy-aware behavior must be
+ opt-in, narrowly scoped, and testable.
+
+Request IDs and tracing hooks should be defined as middleware-level concerns so that later slices can
+reuse the same correlation model across auth, diagnostics, and operational analysis. Header
+sanitation should likewise be defined at entry so downstream code does not need to re-implement
+transport hygiene inconsistently.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `clients/rook/src/server/mod.rs` | Modified | Compose a transport middleware baseline in front of `/api/*` and `/v1/*` routing. |
+| `clients/rook/src/admin/` | Modified | Consume sanitized transport context and request-correlation behavior without changing admin business semantics. |
+| `clients/rook/src/gateway/` | Modified | Consume sanitized transport context and request-correlation behavior without changing gateway business semantics. |
+| `clients/rook/src/config/` | Modified | Define minimal configuration for request ID behavior, transport logging hooks, and trusted forwarded-header policy. |
+| `clients/rook/src/` transport/middleware module(s) | New | Add middleware or helpers for request IDs, tracing/logging hooks, header sanitation, and forwarded-header policy enforcement. |
+| `openspec/specs/gateway/spec.md` | Modified (follow-on) | Add delta requirements for the transport middleware baseline and strict forwarded-header trust posture. |
+| `openspec/changes/rook-591-transport-middleware-baseline/` | New | Proposal and follow-on spec/design/tasks artifacts for this slice. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Forwarded headers are trusted implicitly through framework defaults or convenience APIs | High | Make strict-by-default trust policy explicit in spec/design and require opt-in trusted-proxy configuration before honoring forwarded metadata. |
+| Header sanitation removes data needed by existing local integrations | Medium | Limit this slice to transport and proxy metadata hygiene, document exact sanitation rules, and preserve rollback to previous pass-through behavior if needed. |
+| Request ID propagation becomes inconsistent across `/api/*` and `/v1/*` | Medium | Define one baseline correlation contract at shared middleware composition points rather than per-router custom behavior. |
+| Logging/tracing hooks accidentally capture sensitive headers or credentials | Medium | Require redaction/sanitization boundaries in follow-on spec/design and keep hooks metadata-focused. |
+| Slice expands into broader traffic-management or security work | Medium | Keep proposal bounded to correlation, sanitation, and forwarded-header trust policy only; explicitly defer rate limiting, idempotency, TLS, and RBAC. |
+
+## Rollback Plan
+
+If this slice causes regressions, revert the transport middleware layer introduced for request IDs,
+tracing/logging hooks, header sanitation, and forwarded-header policy, remove any new trusted-proxy
+configuration added by this slice, and restore the prior direct-request handling behavior for
+`/api/*` and `/v1/*`. Because this slice is transport-boundary-only, rollback should not require
+changes to auth boundary semantics, admin business logic, gateway routing, or outbound provider auth.
+
+## Dependencies
+
+- The archived `rook-591-inbound-auth-boundary` slice remains the completed prerequisite security
+  baseline and must stay separate from this transport-middleware slice.
+- Existing server composition in `clients/rook/src/server/mod.rs` must continue to host `/api/*`,
+  `/v1/*`, and dashboard routes without widening scope into unrelated surfaces.
+- The gateway spec in `openspec/specs/gateway/spec.md` will need a follow-on delta to capture request
+  correlation, transport observability hooks, header sanitation, and forwarded-header trust policy.
+- Any framework or library defaults around proxy-header parsing must be reviewed in follow-on spec and
+  design work so strict-by-default behavior is not undermined accidentally.
+
+## Success Criteria
+
+- [ ] The change remains narrowly scoped to the transport middleware baseline for Rook HTTP entrypoints.
+- [ ] The proposal explicitly states that `X-Forwarded-*` headers are NOT trusted unless explicitly configured.
+- [ ] In-scope transport concerns are limited to request IDs, tracing/logging hooks, header sanitation, and forwarded-header policy.
+- [ ] Auth boundary work already completed under `rook-591-inbound-auth-boundary` remains separate and unmodified by scope.
+- [ ] Rate limiting, idempotency, streaming, TLS, RBAC, and outbound provider auth changes remain explicitly deferred.
+- [ ] The change is ready for `sdd-spec` and `sdd-design` to define concrete contracts and implementation details.

--- a/openspec/changes/archive/2026-04-22-rook-591-transport-middleware-baseline/specs/gateway/spec.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-transport-middleware-baseline/specs/gateway/spec.md
@@ -1,0 +1,336 @@
+# Delta for gateway
+
+## ADDED Requirements
+
+### Requirement: Transport Middleware Covered Surfaces
+
+Rook MUST apply this transport middleware baseline to every inbound HTTP request whose effective
+route is mounted under `/api/*` or `/v1/*` before the matched admin or gateway handler executes
+business logic.
+
+This slice MUST cover at least the following transport surfaces:
+
+- `GET /api/health`
+- all other admin routes under `/api/*`
+- `GET /v1/models`
+- `POST /v1/chat/completions`
+
+The baseline defined by this slice MUST be limited to request ID handling, tracing/logging hooks,
+header sanitation, and forwarded-header trust policy.
+
+Routes outside `/api/*` and `/v1/*`, including dashboard routes at `/` and dashboard asset routes,
+MUST remain out of scope for this slice.
+
+This slice MUST remain distinct from the archived `rook-591-inbound-auth-boundary` change. Meeting
+this slice MUST NOT require changing inbound bearer-auth semantics.
+
+#### Scenario: middleware baseline applies to protected gateway route
+
+- GIVEN the server hosts routes under `/v1/*`
+- WHEN a client sends `GET /v1/models`
+- THEN the transport middleware baseline MUST execute before the matched handler's business logic
+- AND request ID, sanitation, and transport observability behavior MUST be available to the route
+
+#### Scenario: middleware baseline applies to protected admin route
+
+- GIVEN the server hosts routes under `/api/*`
+- WHEN a client sends `GET /api/health`
+- THEN the transport middleware baseline MUST execute before the matched handler's business logic
+
+#### Scenario: dashboard routes remain out of scope
+
+- GIVEN the server also hosts dashboard routes outside `/api/*` and `/v1/*`
+- WHEN a client requests `/`
+- THEN this slice MUST NOT require the transport middleware baseline defined here to govern that route
+
+---
+
+### Requirement: Request ID Generation and Propagation Contract
+
+Every inbound request covered by this slice MUST have exactly one transport request identifier for
+the lifetime of that request.
+
+If the inbound request already contains a syntactically valid request ID in the configured inbound
+request ID header, Rook MUST adopt that value as the request's transport request ID.
+
+If the inbound request does not contain a valid request ID in the configured inbound request ID
+header, Rook MUST generate a new request ID before invoking downstream handlers.
+
+Rook MUST make the effective request ID available to downstream middleware, handlers, and transport
+observability hooks as request-scoped metadata.
+
+Rook MUST return the effective request ID to the client in the configured response request ID
+header on both success and error responses for covered routes.
+
+Request ID handling in this slice MUST be transport-scoped only. The request ID MUST NOT be used as
+an authentication credential, authorization decision input, or substitute for provider account
+identity.
+
+#### Scenario: server generates request ID when absent
+
+- GIVEN a covered inbound request without the configured request ID header
+- WHEN the request enters the transport middleware baseline
+- THEN Rook MUST generate a request ID before handler execution
+- AND the same request ID MUST be exposed to downstream request context
+- AND the response MUST include that request ID in the configured response header
+
+#### Scenario: server propagates valid inbound request ID
+
+- GIVEN a covered inbound request with a syntactically valid request ID in the configured inbound header
+- WHEN the request enters the transport middleware baseline
+- THEN Rook MUST reuse that inbound request ID as the effective request ID
+- AND the response MUST include the same request ID value
+
+#### Scenario: invalid inbound request ID is replaced deterministically
+
+- GIVEN a covered inbound request with a malformed or empty value in the configured inbound request ID header
+- WHEN the request enters the transport middleware baseline
+- THEN Rook MUST reject that value for transport correlation purposes
+- AND Rook MUST generate a new effective request ID
+- AND the response MUST include the generated request ID instead of the malformed inbound value
+
+---
+
+### Requirement: Transport Tracing and Logging Hooks
+
+Rook MUST emit transport-level tracing or structured logging hooks for every request covered by this
+slice.
+
+At minimum, transport observability hooks for a covered request MUST be able to record:
+
+- the effective request ID
+- the matched route or route template when available
+- the HTTP method
+- the response status code
+- request handling duration
+- whether forwarded metadata was ignored or trusted under the configured policy
+
+Transport observability hooks MUST use structured fields rather than relying only on interpolated
+message strings.
+
+Transport observability hooks MUST execute for both successful and error responses on covered
+routes.
+
+Transport observability hooks MUST NOT log or attach raw secret-bearing header values. At minimum,
+values for `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`, and provider or bearer
+token-like credentials MUST be redacted or omitted.
+
+If header metadata is logged for diagnostics, the implementation MUST log only sanitized header
+views consistent with this slice's header sanitation rules.
+
+#### Scenario: successful request emits correlated transport fields
+
+- GIVEN a covered request with an effective request ID
+- WHEN the request completes successfully
+- THEN transport tracing or logging MUST include the request ID, method, route metadata, status code, and duration
+
+#### Scenario: error response still emits transport correlation data
+
+- GIVEN a covered request that terminates with an error response
+- WHEN the response is produced
+- THEN transport tracing or logging MUST still include the effective request ID and response status code
+
+#### Scenario: secret-bearing headers are redacted from observability output
+
+- GIVEN a covered request containing `Authorization` and `Cookie` headers
+- WHEN transport tracing or logging hooks capture header-related diagnostics
+- THEN the raw values of those headers MUST NOT appear in logs or spans
+- AND only redacted or omitted representations MAY be emitted
+
+---
+
+### Requirement: Inbound Header Sanitation Rules
+
+Before downstream handlers rely on inbound transport metadata, Rook MUST sanitize inbound
+transport-layer and proxy-related headers for every request covered by this slice.
+
+For this slice, sanitation MUST apply at least to:
+
+- the configured request ID header when used for request correlation
+- `X-Forwarded-For`
+- `X-Forwarded-Host`
+- `X-Forwarded-Proto`
+- `X-Forwarded-Port`
+- `X-Real-IP`
+- `Via` (diagnostic-only; never trusted as canonical client/host/proto metadata)
+
+Sanitation for these headers MUST reject empty values and syntactically malformed values from
+security-sensitive interpretation.
+
+When a covered header is rejected for security-sensitive interpretation, Rook MUST prevent
+downstream transport consumers from treating the rejected value as trusted transport metadata.
+
+Header sanitation in this slice MUST NOT rewrite or remove unrelated application headers outside the
+transport/proxy concerns listed here unless another requirement explicitly defines that behavior.
+
+#### Scenario: empty forwarded header value is sanitized out of trusted view
+
+- GIVEN a covered request with `X-Forwarded-Proto: ` as an empty value
+- WHEN header sanitation runs
+- THEN the empty value MUST be rejected for trusted transport interpretation
+- AND downstream transport context MUST NOT expose it as trusted forwarded metadata
+
+#### Scenario: malformed request ID header does not survive as effective correlation ID
+
+- GIVEN a covered request with a malformed configured request ID header value
+- WHEN header sanitation runs
+- THEN that value MUST be rejected for request ID adoption
+- AND the effective request ID MUST come from generated server-side correlation data instead
+
+#### Scenario: unrelated application headers remain outside this sanitation contract
+
+- GIVEN a covered request with both `X-Forwarded-For` and a domain-specific application header
+- WHEN header sanitation runs
+- THEN this slice MUST govern the `X-Forwarded-For` handling
+- AND it MUST NOT require rewriting the unrelated application header
+
+---
+
+### Requirement: Strict-by-Default Forwarded Header Trust Policy
+
+Rook MUST treat inbound forwarded metadata as untrusted by default.
+
+Unless explicit trusted-proxy configuration is enabled for this slice, Rook MUST NOT trust
+`X-Forwarded-*`, `X-Real-IP`, or similar proxy-provided metadata for security-sensitive or
+canonical transport interpretation.
+
+When trusted-proxy configuration is not enabled, Rook MUST derive canonical transport context from
+the direct connection context and server-local request properties instead of forwarded headers.
+
+When forwarded metadata is ignored under the default strict posture, observability hooks SHOULD be
+able to indicate that forwarded metadata was present but not trusted.
+
+This strict default MUST apply equally to `/api/*` and `/v1/*` surfaces covered by this slice.
+
+#### Scenario: default policy ignores untrusted forwarded host and proto
+
+- GIVEN trusted-proxy configuration is not enabled
+- AND a client sends `X-Forwarded-Host: public.example.com` and `X-Forwarded-Proto: https`
+- WHEN a covered request is processed
+- THEN Rook MUST NOT treat those headers as canonical host or scheme metadata
+- AND downstream transport context MUST rely on direct connection or server-local request metadata
+
+#### Scenario: default policy ignores untrusted client IP metadata
+
+- GIVEN trusted-proxy configuration is not enabled
+- AND a client sends `X-Forwarded-For: 203.0.113.9` and `X-Real-IP: 203.0.113.9`
+- WHEN a covered request is processed
+- THEN Rook MUST NOT treat those values as trusted client address metadata for this slice
+
+---
+
+### Requirement: Explicit Trusted-Proxy Opt-In Behavior
+
+Rook MAY honor supported forwarded metadata only when an explicit trusted-proxy policy is configured
+for this slice.
+
+The trusted-proxy policy MUST be explicit enough to distinguish trusted proxy paths from untrusted
+clients; a bare assumption that the deployment is "behind a proxy" is insufficient.
+
+When trusted-proxy behavior is enabled, Rook MUST honor only the supported forwarded header families
+for this slice (`X-Forwarded-*` and `X-Real-IP`) and only for proxy sources covered by the
+configured policy.
+
+If a covered request arrives from a source that does not satisfy the trusted-proxy policy, Rook
+MUST fall back to the strict default behavior and ignore forwarded metadata for canonical transport
+interpretation.
+
+The standard `Forwarded` header is explicitly out of scope for this slice and MAY be specified in a
+later change.
+
+Trusted-proxy opt-in for this slice MUST affect only inbound transport interpretation. It MUST NOT,
+by itself, change auth policy, rate limiting, TLS policy, or outbound provider authentication.
+
+#### Scenario: trusted proxy policy allows configured forwarded metadata
+
+- GIVEN trusted-proxy configuration is enabled for a covered request path
+- AND the connection source satisfies the configured trusted-proxy policy
+- AND the request includes allowed forwarded metadata
+- WHEN the request is processed
+- THEN Rook MAY use that forwarded metadata for canonical transport interpretation within the configured scope
+
+#### Scenario: opt-in policy does not trust headers from non-trusted source
+
+- GIVEN trusted-proxy configuration is enabled
+- AND a covered request includes forwarded headers
+- AND the connection source does not satisfy the trusted-proxy policy
+- WHEN the request is processed
+- THEN Rook MUST ignore the forwarded headers for canonical transport interpretation
+- AND the request MUST fall back to the strict default behavior
+
+#### Scenario: trusted-proxy opt-in does not widen unrelated security behavior
+
+- GIVEN trusted-proxy configuration is enabled
+- WHEN a covered request is processed
+- THEN this slice MUST NOT treat that opt-in as enabling rate limiting, TLS termination policy, or outbound provider auth changes
+
+---
+
+### Requirement: Transport Middleware Configuration Contract
+
+This slice MUST define explicit configuration for transport middleware behavior on covered Rook HTTP
+entrypoints.
+
+At minimum, the configuration contract for this slice MUST provide:
+
+- whether the transport middleware baseline is enabled for covered `/api/*` and `/v1/*` surfaces if the implementation makes it configurable
+- the inbound request ID header name used for request ID adoption checks
+- the response request ID header name used to return the effective request ID
+- the strict forwarded-header trust posture as the default behavior when no trusted-proxy policy is configured
+- an explicit trusted-proxy policy shape or equivalent configuration entry required before forwarded metadata MAY be honored
+- any validation constraints necessary so invalid trusted-proxy configuration cannot silently weaken the strict default posture
+
+If trusted-proxy behavior is enabled but the trusted-proxy policy is missing, malformed, or not
+resolvable, configuration loading or startup MUST fail closed, or the server MUST deterministically
+fall back to the strict default behavior without partially trusting forwarded metadata.
+
+Configuration for this slice MUST remain separate from inbound bearer-auth secrets, provider account
+API keys, and outbound vendor authentication settings.
+
+#### Scenario: strict default requires no proxy trust configuration
+
+- GIVEN no trusted-proxy policy is configured
+- WHEN the server loads configuration for this slice
+- THEN the effective behavior MUST remain strict by default
+- AND forwarded metadata MUST remain untrusted
+
+#### Scenario: malformed trusted-proxy configuration cannot enable partial trust
+
+- GIVEN trusted-proxy behavior is configured with an invalid or incomplete policy
+- WHEN the server loads configuration for this slice
+- THEN the server MUST fail closed or deterministically revert to strict default behavior
+- AND it MUST NOT start in a partially trusted forwarded-header state
+
+#### Scenario: transport configuration is separate from auth and provider credentials
+
+- GIVEN inbound auth and provider account credentials are also configured
+- WHEN transport middleware configuration is loaded
+- THEN request ID and trusted-proxy settings MUST be validated independently from bearer-auth and provider API key settings
+
+---
+
+### Requirement: Non-Goals and Deferred Concerns for Transport Middleware Baseline
+
+This slice MUST remain narrow and MUST NOT require or imply implementation of:
+
+- rate limiting, quotas, or abuse controls
+- idempotency keys or replay protection
+- streaming request or streaming response transport behavior
+- TLS termination, certificate handling, or mTLS policy
+- RBAC, scopes, or multi-tenant authorization models
+- outbound provider authentication changes
+- changes to the archived `rook-591-inbound-auth-boundary` scope
+
+These concerns MAY be specified later, but compliance with this slice MUST NOT depend on them.
+
+#### Scenario: baseline acceptance does not require rate limiting or TLS work
+
+- GIVEN this transport middleware baseline slice is implemented
+- WHEN acceptance is evaluated
+- THEN the slice MUST be satisfiable without adding rate limiting, idempotency, streaming, or TLS policy changes
+
+#### Scenario: baseline acceptance remains separate from archived inbound auth work
+
+- GIVEN the archived `rook-591-inbound-auth-boundary` change already defines inbound bearer-auth behavior
+- WHEN this slice is accepted
+- THEN it MUST remain valid without changing that archived auth contract

--- a/openspec/changes/archive/2026-04-22-rook-591-transport-middleware-baseline/state.yaml
+++ b/openspec/changes/archive/2026-04-22-rook-591-transport-middleware-baseline/state.yaml
@@ -1,0 +1,12 @@
+change: rook-591-transport-middleware-baseline
+current_phase: archive
+completed:
+  - propose
+  - spec
+  - design
+  - tasks
+  - apply
+  - verify
+  - archive
+next: none
+updated: 2026-04-22T00:00:00Z

--- a/openspec/changes/archive/2026-04-22-rook-591-transport-middleware-baseline/tasks.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-transport-middleware-baseline/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Establish Rook Transport Middleware Baseline
+
+## Phase 1: Configuration and type scaffolding
+
+- [x] 1.1 Add RED tests in `clients/rook/src/config/mod.rs` for `TransportConfig` strict defaults, enabled-with-empty-CIDRs rejection, and invalid CIDR fail-closed behavior.
+- [x] 1.2 Implement `TransportConfig`, `RequestIdConfig`, `TrustedProxyConfig`, and validation in `clients/rook/src/config/mod.rs`; wire exports in `clients/rook/src/lib.rs`.
+- [x] 1.3 Create `clients/rook/src/transport/mod.rs` and `clients/rook/src/transport/context.rs` with `SanitizedTransportContext`, `SanitizedForwardedContext`, `RouteSurface`, and `ForwardedTrust`.
+
+## Phase 2: Request ID and forwarded policy units
+
+- [x] 2.1 Add RED unit tests in `clients/rook/src/transport/request_id.rs` for absent, valid inbound, empty, whitespace, malformed, multi-value, and oversized request ID inputs.
+- [x] 2.2 Implement request ID resolution/generation and response-header helpers in `clients/rook/src/transport/request_id.rs` using configured header names and UUID fallback.
+- [x] 2.3 Add RED unit tests in `clients/rook/src/transport/forwarded.rs` for disabled trust, missing peer address, untrusted source, trusted allowed headers, malformed values, and `Via` staying diagnostic-only.
+- [x] 2.4 Implement forwarded-header parsing, sanitation, ignored-header tracking, and CIDR-based trust evaluation in `clients/rook/src/transport/forwarded.rs`; add `clients/rook/Cargo.toml` dependency only if required.
+
+## Phase 3: Middleware wiring on covered routes
+
+- [x] 3.1 Add RED integration tests in `clients/rook/src/server/mod.rs` proving `/api/*` and `/v1/*` responses include the effective request ID, auth failures still include it, and `/` stays out of scope.
+- [x] 3.2 Add RED middleware/integration tests in `clients/rook/src/transport/middleware.rs` or `clients/rook/src/server/mod.rs` using a probe route/harness to verify request extensions contain sanitized transport context before handler logic.
+- [x] 3.3 Implement `clients/rook/src/transport/middleware.rs` to resolve request IDs, sanitize forwarded metadata, inject `SanitizedTransportContext`, emit completion hooks, and set the response request ID header.
+- [x] 3.4 Update `clients/rook/src/server/mod.rs` and `clients/rook/src/main.rs` to validate `ServerConfig.transport`, preserve direct peer info, and wrap only `/api` and `/v1` router composition around existing auth middleware.
+
+## Phase 4: Observability and completion checks
+
+- [x] 4.1 Add RED tracing tests around the transport middleware to assert completion events include request ID/method/route/status/duration/trust fields and omit raw `Authorization` and `Cookie` values.
+- [x] 4.2 Implement structured completion logging/tracing in `clients/rook/src/transport/middleware.rs`, keeping diagnostics limited to sanitized/trusted derived values.
+- [ ] 4.3 Refactor narrow duplicates only if needed in `clients/rook/src/gateway/handlers.rs` or `clients/rook/src/admin/handlers.rs`, without changing business contracts or widening scope.

--- a/openspec/changes/archive/2026-04-22-rook-591-transport-middleware-baseline/verify-report.md
+++ b/openspec/changes/archive/2026-04-22-rook-591-transport-middleware-baseline/verify-report.md
@@ -1,0 +1,118 @@
+## Verification Report
+
+**Change**: rook-591-transport-middleware-baseline  
+**Date**: 2026-04-22
+
+---
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 11 |
+| Tasks complete | 10 |
+| Tasks incomplete | 1 |
+
+Remaining unchecked task:
+
+- [ ] 4.3 Refactor narrow duplicates only if needed in `clients/rook/src/gateway/handlers.rs` or `clients/rook/src/admin/handlers.rs`, without changing business contracts or widening scope.
+
+Assessment: the remaining unchecked item is optional cleanup. Core implementation tasks for this slice are complete.
+
+---
+
+### Test Evidence
+
+Build was intentionally not run because the user explicitly required: **Do not build the project.**
+
+#### Targeted verification commands executed
+
+1. `cargo test --manifest-path "clients/rook/Cargo.toml" transport::`
+   - Result: **16 passed / 0 failed**
+
+2. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::covered_routes_include_effective_request_id_and_dashboard_root_stays_out_of_scope`
+   - Result: **1 passed / 0 failed**
+
+3. `cargo test --manifest-path "clients/rook/Cargo.toml" server::tests::auth_failures_still_include_effective_request_id_on_covered_routes`
+   - Result: **1 passed / 0 failed**
+
+#### Broader suite signal collected
+
+4. `cargo test --manifest-path "clients/rook/Cargo.toml"`
+   - Result: **199 passed / 2 failed / 0 skipped**
+   - Remaining unrelated failing tests:
+     - `db::account::tests::vendor_other_with_quotes_round_trips`
+     - `routing::tests::cycle_detection_returns_routing_error`
+
+Interpretation: the transport middleware slice is clean in targeted evidence and no longer contributes a failing full-suite test. The crate-wide suite remains red due to unrelated existing failures.
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Evidence | Result |
+|-------------|----------|----------|--------|
+| Transport Middleware Covered Surfaces | middleware baseline applies to protected gateway route | `server::tests::covered_routes_include_effective_request_id_and_dashboard_root_stays_out_of_scope` | ✅ COMPLIANT |
+| Transport Middleware Covered Surfaces | middleware baseline applies to protected admin route | `server::tests::covered_routes_include_effective_request_id_and_dashboard_root_stays_out_of_scope` | ✅ COMPLIANT |
+| Transport Middleware Covered Surfaces | dashboard routes remain out of scope | `server::tests::covered_routes_include_effective_request_id_and_dashboard_root_stays_out_of_scope` | ✅ COMPLIANT |
+| Request ID Generation and Propagation Contract | server generates request ID when absent | `transport::request_id::tests::resolves_generated_request_id_when_header_absent`; covered-route response header test | ⚠️ PARTIAL |
+| Request ID Generation and Propagation Contract | server propagates valid inbound request ID | `transport::request_id::tests::resolves_adopted_request_id_for_valid_inbound_value`; covered-route response header test | ✅ COMPLIANT |
+| Request ID Generation and Propagation Contract | invalid inbound request ID is replaced deterministically | `transport::request_id::*generated*` malformed/empty/whitespace/multi/oversized tests | ⚠️ PARTIAL |
+| Transport Tracing and Logging Hooks | successful request emits correlated transport fields | `transport::middleware::tests::middleware_completion_log_fields_remain_structured_and_secret_free` | ✅ COMPLIANT |
+| Transport Tracing and Logging Hooks | error response still emits transport correlation data | `server::tests::auth_failures_still_include_effective_request_id_on_covered_routes` | ⚠️ PARTIAL |
+| Transport Tracing and Logging Hooks | secret-bearing headers are redacted from observability output | `transport::middleware::tests::middleware_completion_log_fields_remain_structured_and_secret_free` | ✅ COMPLIANT |
+| Inbound Header Sanitation Rules | empty forwarded header value is sanitized out of trusted view | `transport::forwarded::tests::malformed_values_are_ignored_and_tracked`; `...enabled_policy_without_peer_address_falls_back_to_strict_default` | ✅ COMPLIANT |
+| Inbound Header Sanitation Rules | malformed request ID header does not survive as effective correlation ID | `transport::request_id::tests::resolves_generated_request_id_for_malformed_inbound_value` | ✅ COMPLIANT |
+| Inbound Header Sanitation Rules | unrelated application headers remain outside this sanitation contract | Structural evidence: transport context derives only from configured request ID / `X-Forwarded-*` / `X-Real-IP` / `Via` and does not rewrite unrelated headers | ⚠️ PARTIAL |
+| Strict-by-Default Forwarded Header Trust Policy | default policy ignores untrusted forwarded host and proto | `transport::forwarded::tests::disabled_trust_policy_ignores_forwarded_metadata`; `...untrusted_source_ignores_forwarded_headers`; `...enabled_policy_without_peer_address_falls_back_to_strict_default` | ✅ COMPLIANT |
+| Strict-by-Default Forwarded Header Trust Policy | default policy ignores untrusted client IP metadata | `transport::forwarded::tests::disabled_trust_policy_ignores_forwarded_metadata`; `...untrusted_source_ignores_forwarded_headers` | ✅ COMPLIANT |
+| Explicit Trusted-Proxy Opt-In Behavior | trusted proxy policy allows configured forwarded metadata | `transport::forwarded::tests::trusted_source_adopts_allowed_forwarded_headers` | ✅ COMPLIANT |
+| Explicit Trusted-Proxy Opt-In Behavior | opt-in policy does not trust headers from non-trusted source | `transport::forwarded::tests::untrusted_source_ignores_forwarded_headers` | ✅ COMPLIANT |
+| Explicit Trusted-Proxy Opt-In Behavior | trusted-proxy opt-in does not widen unrelated security behavior | Structural evidence: no auth/rate-limit/TLS/provider-auth branching in transport module | ⚠️ PARTIAL |
+| Transport Middleware Configuration Contract | strict default requires no proxy trust configuration | `config::tests::transport_config_defaults_to_strict_request_id_and_disabled_proxy_trust` | ✅ COMPLIANT |
+| Transport Middleware Configuration Contract | malformed trusted-proxy configuration cannot enable partial trust | `config::tests::transport_config_validate_rejects_enabled_proxy_without_cidrs`; `...rejects_invalid_trusted_proxy_cidr` | ✅ COMPLIANT |
+| Transport Middleware Configuration Contract | transport configuration is separate from auth and provider credentials | `main.rs::tests::build_server_config_keeps_inbound_auth_separate`; `server::tests::valid_inbound_auth_does_not_replace_outbound_provider_auth` | ✅ COMPLIANT |
+| Non-Goals and Deferred Concerns | baseline acceptance does not require rate limiting or TLS work | Structural evidence: no rate limiting/idempotency/streaming/TLS/RBAC/outbound provider auth changes in transport implementation | ⚠️ PARTIAL |
+| Non-Goals and Deferred Concerns | baseline acceptance remains separate from archived inbound auth work | `server::tests::auth_failures_still_include_effective_request_id_on_covered_routes`; separate `transport/` module | ✅ COMPLIANT |
+
+Summary: compliant on core scope; remaining partial items are evidence-depth warnings, not functional blockers.
+
+---
+
+### Correctness (Structural Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Covered surfaces only `/api/*` and `/v1/*` | ✅ Implemented | `server/mod.rs` layers transport middleware only on nested `/api` and `/v1`, dashboard merged separately. |
+| Request ID generation/propagation | ✅ Implemented | `transport/request_id.rs` plus response header propagation in `transport/middleware.rs`. |
+| Tracing/logging hooks | ✅ Implemented | Transport middleware emits structured completion fields for request ID, surface, method, route, status, duration, trust state, ignored headers. |
+| Secret redaction/omission | ✅ Implemented | Completion logging uses derived/sanitized fields only. |
+| Header sanitation scope | ✅ Implemented | Current slice explicitly covers `X-Forwarded-*`, `X-Real-IP`, and `Via` diagnostics; `Forwarded` is out of scope by updated spec/design. |
+| Strict-by-default trust | ✅ Implemented | Untrusted/missing peer/default-disabled proxy trust falls back to ignored forwarded metadata. |
+| Trusted-proxy opt-in | ✅ Implemented | CIDR allowlist plus allowed header families; fail-closed validation. |
+| Separation from auth boundary | ✅ Implemented | `transport/` module remains separate from archived auth slice. |
+| Non-goals preserved | ✅ Implemented | No rate limiting, idempotency, streaming, TLS, RBAC, or outbound provider auth changes in this slice. |
+
+---
+
+### Issues Found
+
+**CRITICAL**
+
+- None for the transport middleware slice itself.
+
+**WARNING**
+
+- Full `clients/rook` suite is still not clean due to two unrelated existing failures:
+  - `db::account::tests::vendor_other_with_quotes_round_trips`
+  - `routing::tests::cycle_detection_returns_routing_error`
+- One optional cleanup task remains unchecked (`tasks.md` item 4.3), but it is explicitly non-blocking.
+- Some scenarios rely on strong structural/helper evidence rather than dedicated covered-route integration tests.
+
+---
+
+### Verdict
+
+**PASS WITH WARNINGS**
+
+The `rook-591-transport-middleware-baseline` slice is implemented and behaviorally supported by passing targeted evidence. The only remaining issues are unrelated crate-wide test failures and a small amount of evidence-depth debt, so this slice can proceed under PASS WITH WARNINGS if the team accepts that repository-level noise remains outside the slice.

--- a/openspec/specs/gateway/spec.md
+++ b/openspec/specs/gateway/spec.md
@@ -1159,22 +1159,948 @@ The shape MUST distinguish at least:
 
 ### R27: Loopback-First and No-Auth M1 Safety Posture
 
-This change MUST preserve the current M1 safety posture.
+Rook MUST preserve the current loopback-first deployment posture for M1, but authentication for
+protected `/api/*` and `/v1/*` entrypoints is no longer entirely out of scope.
 
-The admin API defined here MUST NOT expand exposure beyond the existing loopback/local-admin
-assumption.
+This change replaces the previous "no auth" posture for those protected entrypoints with the
+inbound bearer-token boundary defined in change `rook-591-inbound-auth-boundary`.
 
-Authentication and authorization are explicitly out of scope for this spec and belong to #591.
+Dashboard routes outside `/api/*` and `/v1/*` remain outside this slice unless a later change says
+otherwise.
 
-The admin API contract MUST therefore be specified without bearer-token, pairing, or role-based
-authorization requirements.
+Inbound auth for protected Rook routes MUST remain independent from runtime trust flows, pairing
+state, webhook secrets, and outbound provider auth.
 
-#### Scenario: admin API remains unauthenticated in M1 contract
+#### Scenario: protected surfaces no longer use unauthenticated M1 contract
 
-- GIVEN the M1 admin API defined by this spec
-- WHEN a client interacts with `/api/*`
-- THEN the contract MUST NOT require auth features from #591
-- AND the spec MUST continue to describe this surface as local-admin only
+- GIVEN the gateway domain after applying change `rook-591-inbound-auth-boundary`
+- WHEN a client interacts with `/api/*` or `/v1/*`
+- THEN the contract MUST require the inbound auth behavior defined by this delta spec
+- AND the spec MUST NOT describe those protected surfaces as unauthenticated
+
+#### Scenario: runtime trust flows remain out of scope for Rook inbound auth
+
+- GIVEN the inbound auth boundary for protected Rook routes
+- WHEN the design reuses ideas from `clients/agent-runtime/src/gateway/utils.rs`
+- THEN it MUST adapt only general patterns such as bearer extraction or defensive request filtering
+- AND it MUST NOT import runtime-specific pairing or onboarding trust requirements into this contract
+
+---
+
+### R28: Inbound Auth Protected Surfaces
+
+Rook MUST enforce an inbound authentication boundary for the HTTP entrypoints mounted under
+`/api/*` and `/v1/*`.
+
+For this slice, every request whose effective route is under `/api/*` or `/v1/*` MUST be treated as
+protected unless a later requirement in this spec explicitly marks it public.
+
+This slice MUST cover at least the following already-documented surfaces:
+
+- `GET /api/health`
+- all admin routes under `/api/*`
+- `POST /v1/chat/completions`
+- `GET /v1/models`
+
+Dashboard routes outside those prefixes, including `/` and dashboard asset routes, MUST remain out
+of scope for this inbound auth boundary.
+
+Inbound route authentication MUST be enforced before the matched admin or gateway handler performs
+its business logic.
+
+#### Scenario: authenticated request reaches protected gateway route
+
+- GIVEN the server is configured with inbound auth enabled for this slice
+- AND a client sends `Authorization: Bearer valid-inbound-token`
+- WHEN the client requests `GET /v1/models`
+- THEN the request MUST be evaluated against the inbound auth boundary before the route handler runs
+- AND the request MAY proceed to normal route handling only after the token is accepted
+
+#### Scenario: authenticated request reaches protected admin route
+
+- GIVEN the server is configured with inbound auth enabled for this slice
+- AND a client sends `Authorization: Bearer valid-inbound-token`
+- WHEN the client requests `GET /api/health`
+- THEN the request MUST be evaluated against the inbound auth boundary before the route handler runs
+- AND the request MAY proceed to normal route handling only after the token is accepted
+
+#### Scenario: dashboard route remains outside inbound auth scope
+
+- GIVEN the server hosts dashboard routes at `/` alongside `/api/*` and `/v1/*`
+- WHEN a client requests `/`
+- THEN this inbound auth boundary spec MUST NOT require bearer-token enforcement for that route
+
+---
+
+### R29: Inbound Bearer-Token Contract
+
+Protected inbound requests MUST present credentials using the HTTP `Authorization` header with the
+exact scheme `Bearer` followed by a single configured token value.
+
+The inbound auth boundary MUST treat this credential as a Rook client-to-Rook transport credential.
+It MUST NOT be reused as, derived from, or forwarded as outbound provider authentication.
+
+Validation for this slice MUST compare the presented bearer token against Rook inbound auth
+configuration and MUST produce a deterministic allow/deny outcome.
+
+Requests to protected routes MUST be rejected when:
+
+- the `Authorization` header is missing
+- the auth scheme is not `Bearer`
+- the bearer token value is empty after parsing
+- more than one bearer credential is presented in a way the server cannot interpret deterministically
+- the bearer token does not match the configured inbound credential
+
+#### Scenario: valid bearer token is accepted
+
+- GIVEN inbound auth is configured with the token `rook-inbound-secret`
+- WHEN the client sends `Authorization: Bearer rook-inbound-secret` to `GET /v1/models`
+- THEN the inbound auth boundary MUST accept the credential
+- AND the request MUST continue to normal route handling
+
+#### Scenario: missing authorization header is rejected
+
+- GIVEN inbound auth is configured with the token `rook-inbound-secret`
+- WHEN the client sends `GET /v1/models` without an `Authorization` header
+- THEN the inbound auth boundary MUST reject the request
+
+#### Scenario: non-bearer authorization scheme is rejected
+
+- GIVEN inbound auth is configured with the token `rook-inbound-secret`
+- WHEN the client sends `Authorization: Basic abc123` to `GET /api/health`
+- THEN the inbound auth boundary MUST reject the request
+
+#### Scenario: wrong bearer token is rejected
+
+- GIVEN inbound auth is configured with the token `rook-inbound-secret`
+- WHEN the client sends `Authorization: Bearer wrong-token` to `POST /v1/chat/completions`
+- THEN the inbound auth boundary MUST reject the request
+
+---
+
+### R30: Unauthorized and Forbidden Error Semantics
+
+When a protected request fails inbound authentication because credentials are missing, malformed, or
+invalid, Rook MUST return `401 Unauthorized`.
+
+`401 Unauthorized` responses produced by the inbound auth boundary MUST be returned before admin or
+gateway business logic executes.
+
+For protected `/v1/*` routes, the response body MUST use the documented gateway error response
+shape, with:
+
+- `error.type` set to `invalid_request_error`
+- `error.code` set to `unauthorized`
+- `error.message` describing that a valid inbound bearer token is required
+
+For protected `/api/*` routes, the response body MUST use the standard admin error response shape
+defined by the gateway domain, and the body MUST clearly indicate that authentication failed.
+
+When a request presents a valid inbound bearer token but the route is disallowed by an explicit
+server-side policy added by this slice or a compatible follow-on slice, the server MUST return
+`403 Forbidden` instead of `401 Unauthorized`.
+
+This slice SHOULD NOT introduce `403 Forbidden` behavior unless a concrete policy beyond token
+validity is configured.
+
+#### Scenario: gateway route missing token returns 401 gateway error
+
+- GIVEN inbound auth is configured with the token `rook-inbound-secret`
+- WHEN the client sends `GET /v1/models` without credentials
+- THEN the server MUST return `401 Unauthorized`
+- AND the response body MUST use the gateway error response shape
+- AND `error.code` MUST be `unauthorized`
+
+#### Scenario: admin route invalid token returns 401 admin error
+
+- GIVEN inbound auth is configured with the token `rook-inbound-secret`
+- WHEN the client sends `GET /api/health` with `Authorization: Bearer wrong-token`
+- THEN the server MUST return `401 Unauthorized`
+- AND the response body MUST use the standard admin error response shape
+
+#### Scenario: explicit deny policy returns 403
+
+- GIVEN inbound auth accepts the presented bearer token
+- AND an explicit server-side authorization policy denies access to the requested protected route
+- WHEN the client sends the request
+- THEN the server MUST return `403 Forbidden`
+- AND the response MUST identify that the request was authenticated but not permitted
+
+---
+
+### R31: Inbound Auth Configuration Contract
+
+This slice MUST define explicit configuration required for inbound auth enforcement.
+
+At minimum, Rook configuration for this slice MUST provide:
+
+- a boolean or equivalent explicit switch that determines whether inbound auth enforcement is active
+- a bearer-token value or secret reference used to validate inbound client credentials
+
+When inbound auth enforcement is active, startup or config loading MUST fail closed if the inbound
+bearer token is absent, empty, or not resolvable.
+
+When inbound auth enforcement is inactive, the server MAY retain the existing loopback-first M1
+behavior until a stricter default is adopted by a later slice.
+
+The configuration contract for inbound auth MUST remain separate from provider account credentials,
+vendor API keys, and outbound header construction in `clients/rook/src/gateway/vendor.rs`.
+
+#### Scenario: enabled auth without token fails closed
+
+- GIVEN server configuration enables inbound auth enforcement
+- AND the inbound bearer token value is missing or empty
+- WHEN the server loads configuration for startup
+- THEN startup or configuration initialization MUST fail
+- AND the server MUST NOT start in a partially protected state
+
+#### Scenario: enabled auth with token is valid configuration
+
+- GIVEN server configuration enables inbound auth enforcement
+- AND the inbound bearer token value is present and non-empty
+- WHEN the server loads configuration for startup
+- THEN configuration validation MUST succeed for this slice
+
+#### Scenario: inbound config is separate from vendor auth config
+
+- GIVEN a provider account has an outbound `api_key`
+- AND inbound auth is configured with a different bearer token
+- WHEN the server validates inbound auth configuration
+- THEN it MUST NOT treat the provider account `api_key` as the inbound credential source
+
+---
+
+### R32: Coexistence with Loopback-First Posture
+
+This slice MUST preserve Rook's loopback-first posture as a deployment default while making clear
+that loopback binding is not a substitute for inbound authentication on protected routes.
+
+The spec MUST treat loopback binding as an exposure-reduction measure and inbound bearer validation
+as the transport authentication control for `/api/*` and `/v1/*`.
+
+If the server is bound only to loopback, protected routes MUST still honor the same inbound auth
+contract whenever inbound auth enforcement is active.
+
+This slice MUST NOT rely on browser-origin checks, local-network assumptions, pairing state, or
+runtime onboarding trust flows as the primary authenticator for protected Rook routes.
+
+#### Scenario: loopback binding does not bypass active auth
+
+- GIVEN the server is bound only to `127.0.0.1` or equivalent loopback interfaces
+- AND inbound auth enforcement is active
+- WHEN the client requests `GET /api/health` without credentials
+- THEN the server MUST still return `401 Unauthorized`
+
+#### Scenario: loopback posture remains an additional safety layer
+
+- GIVEN the server is configured for loopback-first binding
+- WHEN inbound auth for this slice is enabled
+- THEN the effective protection model MUST combine loopback exposure reduction with inbound bearer validation
+- AND the spec MUST NOT describe loopback binding as sufficient authentication by itself
+
+---
+
+### R33: Non-Goals and Deferred Security Concerns
+
+This slice MUST remain narrow.
+
+The inbound auth boundary defined here MUST NOT require or imply implementation of:
+
+- outbound provider authentication changes in `clients/rook/src/gateway/vendor.rs`
+- shared trust state with `clients/agent-runtime`
+- pairing-code or onboarding recovery flows
+- TLS termination or reverse-proxy certificate policy
+- RBAC, scopes, multi-tenant authorization, or per-route permission models
+- rate limiting, quotas, abuse prevention, IP allowlists, or WAF controls
+- secret storage redesign beyond the minimal inbound token configuration this slice requires
+
+These concerns MAY be specified in later changes, but MUST NOT be prerequisites for satisfying this
+slice.
+
+#### Scenario: slice acceptance does not require outbound auth changes
+
+- GIVEN this inbound auth slice is implemented
+- WHEN `clients/rook/src/gateway/vendor.rs` constructs outbound provider headers
+- THEN its outbound auth behavior MUST remain governed by the existing vendor auth requirements
+- AND compliance with this slice MUST NOT depend on changing that behavior
+
+---
+
+### R34: Transport Middleware Covered Surfaces
+
+Rook MUST apply this transport middleware baseline to every inbound HTTP request whose effective
+route is mounted under `/api/*` or `/v1/*` before the matched admin or gateway handler executes
+business logic.
+
+This slice MUST cover at least the following transport surfaces:
+
+- `GET /api/health`
+- all other admin routes under `/api/*`
+- `GET /v1/models`
+- `POST /v1/chat/completions`
+
+The baseline defined by this slice MUST be limited to request ID handling, tracing/logging hooks,
+header sanitation, and forwarded-header trust policy.
+
+Routes outside `/api/*` and `/v1/*`, including dashboard routes at `/` and dashboard asset routes,
+MUST remain out of scope for this slice.
+
+This slice MUST remain distinct from the archived `rook-591-inbound-auth-boundary` change.
+Meeting this slice MUST NOT require changing inbound bearer-auth semantics.
+
+#### Scenario: middleware baseline applies to protected gateway route
+
+- GIVEN the server hosts routes under `/v1/*`
+- WHEN a client sends `GET /v1/models`
+- THEN the transport middleware baseline MUST execute before the matched handler's business logic
+- AND request ID, sanitation, and transport observability behavior MUST be available to the route
+
+#### Scenario: middleware baseline applies to protected admin route
+
+- GIVEN the server hosts routes under `/api/*`
+- WHEN a client sends `GET /api/health`
+- THEN the transport middleware baseline MUST execute before the matched handler's business logic
+
+#### Scenario: dashboard routes remain out of scope
+
+- GIVEN the server also hosts dashboard routes outside `/api/*` and `/v1/*`
+- WHEN a client requests `/`
+- THEN this slice MUST NOT require the transport middleware baseline defined here to govern that route
+
+---
+
+### R35: Request ID Generation and Propagation Contract
+
+Every inbound request covered by this slice MUST have exactly one transport request identifier for
+the lifetime of that request.
+
+If the inbound request already contains a syntactically valid request ID in the configured inbound
+request ID header, Rook MUST adopt that value as the request's transport request ID.
+
+If the inbound request does not contain a valid request ID in the configured inbound request ID
+header, Rook MUST generate a new request ID before invoking downstream handlers.
+
+Rook MUST make the effective request ID available to downstream middleware, handlers, and transport
+observability hooks as request-scoped metadata.
+
+Rook MUST return the effective request ID to the client in the configured response request ID
+header on both success and error responses for covered routes.
+
+Request ID handling in this slice MUST be transport-scoped only. The request ID MUST NOT be used
+as an authentication credential, authorization decision input, or substitute for provider account
+identity.
+
+#### Scenario: server generates request ID when absent
+
+- GIVEN a covered inbound request without the configured request ID header
+- WHEN the request enters the transport middleware baseline
+- THEN Rook MUST generate a request ID before handler execution
+- AND the same request ID MUST be exposed to downstream request context
+- AND the response MUST include that request ID in the configured response header
+
+#### Scenario: server propagates valid inbound request ID
+
+- GIVEN a covered inbound request with a syntactically valid request ID in the configured inbound header
+- WHEN the request enters the transport middleware baseline
+- THEN Rook MUST reuse that inbound request ID as the effective request ID
+- AND the response MUST include the same request ID value
+
+#### Scenario: invalid inbound request ID is replaced deterministically
+
+- GIVEN a covered inbound request with a malformed or empty value in the configured inbound request ID header
+- WHEN the request enters the transport middleware baseline
+- THEN Rook MUST reject that value for transport correlation purposes
+- AND Rook MUST generate a new effective request ID
+- AND the response MUST include the generated request ID instead of the malformed inbound value
+
+---
+
+### R36: Transport Tracing and Logging Hooks
+
+Rook MUST emit transport-level tracing or structured logging hooks for every request covered by
+this slice.
+
+At minimum, transport observability hooks for a covered request MUST be able to record:
+
+- the effective request ID
+- the matched route or route template when available
+- the HTTP method
+- the response status code
+- request handling duration
+- whether forwarded metadata was ignored or trusted under the configured policy
+
+Transport observability hooks MUST use structured fields rather than relying only on interpolated
+message strings.
+
+Transport observability hooks MUST execute for both successful and error responses on covered
+routes.
+
+Transport observability hooks MUST NOT log or attach raw secret-bearing header values. At minimum,
+values for `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`, and provider or bearer
+token-like credentials MUST be redacted or omitted.
+
+If header metadata is logged for diagnostics, the implementation MUST log only sanitized header
+views consistent with this slice's header sanitation rules.
+
+#### Scenario: successful request emits correlated transport fields
+
+- GIVEN a covered request with an effective request ID
+- WHEN the request completes successfully
+- THEN transport tracing or logging MUST include the request ID, method, route metadata, status code, and duration
+
+#### Scenario: error response still emits transport correlation data
+
+- GIVEN a covered request that terminates with an error response
+- WHEN the response is produced
+- THEN transport tracing or logging MUST still include the effective request ID and response status code
+
+#### Scenario: secret-bearing headers are redacted from observability output
+
+- GIVEN a covered request containing `Authorization` and `Cookie` headers
+- WHEN transport tracing or logging hooks capture header-related diagnostics
+- THEN the raw values of those headers MUST NOT appear in logs or spans
+- AND only redacted or omitted representations MAY be emitted
+
+---
+
+### R37: Inbound Header Sanitation Rules
+
+Before downstream handlers rely on inbound transport metadata, Rook MUST sanitize inbound
+transport-layer and proxy-related headers for every request covered by this slice.
+
+For this slice, sanitation MUST apply at least to:
+
+- the configured request ID header when used for request correlation
+- `X-Forwarded-For`
+- `X-Forwarded-Host`
+- `X-Forwarded-Proto`
+- `X-Forwarded-Port`
+- `X-Real-IP`
+- `Via` (diagnostic-only; never trusted as canonical client/host/proto metadata)
+
+Sanitation for these headers MUST reject empty values and syntactically malformed values from
+security-sensitive interpretation.
+
+When a covered header is rejected for security-sensitive interpretation, Rook MUST prevent
+downstream transport consumers from treating the rejected value as trusted transport metadata.
+
+Header sanitation in this slice MUST NOT rewrite or remove unrelated application headers outside
+the transport/proxy concerns listed here unless another requirement explicitly defines that
+behavior.
+
+#### Scenario: empty forwarded header value is sanitized out of trusted view
+
+- GIVEN a covered request with `X-Forwarded-Proto: ` as an empty value
+- WHEN header sanitation runs
+- THEN the empty value MUST be rejected for trusted transport interpretation
+- AND downstream transport context MUST NOT expose it as trusted forwarded metadata
+
+#### Scenario: malformed request ID header does not survive as effective correlation ID
+
+- GIVEN a covered request with a malformed configured request ID header value
+- WHEN header sanitation runs
+- THEN that value MUST be rejected for request ID adoption
+- AND the effective request ID MUST come from generated server-side correlation data instead
+
+#### Scenario: unrelated application headers remain outside this sanitation contract
+
+- GIVEN a covered request with both `X-Forwarded-For` and a domain-specific application header
+- WHEN header sanitation runs
+- THEN this slice MUST govern the `X-Forwarded-For` handling
+- AND it MUST NOT require rewriting the unrelated application header
+
+---
+
+### R38: Strict-by-Default Forwarded Header Trust Policy
+
+Rook MUST treat inbound forwarded metadata as untrusted by default.
+
+Unless explicit trusted-proxy configuration is enabled for this slice, Rook MUST NOT trust
+`X-Forwarded-*`, `X-Real-IP`, or similar proxy-provided metadata for security-sensitive or
+canonical transport interpretation.
+
+When trusted-proxy configuration is not enabled, Rook MUST derive canonical transport context from
+the direct connection context and server-local request properties instead of forwarded headers.
+
+When forwarded metadata is ignored under the default strict posture, observability hooks SHOULD be
+able to indicate that forwarded metadata was present but not trusted.
+
+This strict default MUST apply equally to `/api/*` and `/v1/*` surfaces covered by this slice.
+
+#### Scenario: default policy ignores untrusted forwarded host and proto
+
+- GIVEN trusted-proxy configuration is not enabled
+- AND a client sends `X-Forwarded-Host: public.example.com` and `X-Forwarded-Proto: https`
+- WHEN a covered request is processed
+- THEN Rook MUST NOT treat those headers as canonical host or scheme metadata
+- AND downstream transport context MUST rely on direct connection or server-local request metadata
+
+#### Scenario: default policy ignores untrusted client IP metadata
+
+- GIVEN trusted-proxy configuration is not enabled
+- AND a client sends `X-Forwarded-For: 203.0.113.9` and `X-Real-IP: 203.0.113.9`
+- WHEN a covered request is processed
+- THEN Rook MUST NOT treat those values as trusted client address metadata for this slice
+
+---
+
+### R39: Explicit Trusted-Proxy Opt-In Behavior
+
+Rook MAY honor supported forwarded metadata only when an explicit trusted-proxy policy is
+configured for this slice.
+
+The trusted-proxy policy MUST be explicit enough to distinguish trusted proxy paths from untrusted
+clients; a bare assumption that the deployment is "behind a proxy" is insufficient.
+
+When trusted-proxy behavior is enabled, Rook MUST honor only the supported forwarded header
+families for this slice (`X-Forwarded-*` and `X-Real-IP`) and only for proxy sources covered by the
+configured policy.
+
+If a covered request arrives from a source that does not satisfy the trusted-proxy policy, Rook
+MUST fall back to the strict default behavior and ignore forwarded metadata for canonical transport
+interpretation.
+
+The standard `Forwarded` header is explicitly out of scope for this slice and MAY be specified in a
+later change.
+
+Trusted-proxy opt-in for this slice MUST affect only inbound transport interpretation. It MUST NOT,
+by itself, change auth policy, rate limiting, TLS policy, or outbound provider authentication.
+
+#### Scenario: trusted proxy policy allows configured forwarded metadata
+
+- GIVEN trusted-proxy configuration is enabled for a covered request path
+- AND the connection source satisfies the configured trusted-proxy policy
+- AND the request includes allowed forwarded metadata
+- WHEN the request is processed
+- THEN Rook MAY use that forwarded metadata for canonical transport interpretation within the configured scope
+
+#### Scenario: opt-in policy does not trust headers from non-trusted source
+
+- GIVEN trusted-proxy configuration is enabled
+- AND a covered request includes forwarded headers
+- AND the connection source does not satisfy the trusted-proxy policy
+- WHEN the request is processed
+- THEN Rook MUST ignore the forwarded headers for canonical transport interpretation
+- AND the request MUST fall back to the strict default behavior
+
+#### Scenario: trusted-proxy opt-in does not widen unrelated security behavior
+
+- GIVEN trusted-proxy configuration is enabled
+- WHEN a covered request is processed
+- THEN this slice MUST NOT treat that opt-in as enabling rate limiting, TLS termination policy, or outbound provider auth changes
+
+---
+
+### R40: Transport Middleware Configuration Contract
+
+This slice MUST define explicit configuration for transport middleware behavior on covered Rook
+HTTP entrypoints.
+
+At minimum, the configuration contract for this slice MUST provide:
+
+- whether the transport middleware baseline is enabled for covered `/api/*` and `/v1/*` surfaces if the implementation makes it configurable
+- the inbound request ID header name used for request ID adoption checks
+- the response request ID header name used to return the effective request ID
+- the strict forwarded-header trust posture as the default behavior when no trusted-proxy policy is configured
+- an explicit trusted-proxy policy shape or equivalent configuration entry required before forwarded metadata MAY be honored
+- any validation constraints necessary so invalid trusted-proxy configuration cannot silently weaken the strict default posture
+
+If trusted-proxy behavior is enabled but the trusted-proxy policy is missing, malformed, or not
+resolvable, configuration loading or startup MUST fail closed, or the server MUST deterministically
+fall back to the strict default behavior without partially trusting forwarded metadata.
+
+Configuration for this slice MUST remain separate from inbound bearer-auth secrets, provider
+account API keys, and outbound vendor authentication settings.
+
+#### Scenario: strict default requires no proxy trust configuration
+
+- GIVEN no trusted-proxy policy is configured
+- WHEN the server loads configuration for this slice
+- THEN the effective behavior MUST remain strict by default
+- AND forwarded metadata MUST remain untrusted
+
+#### Scenario: malformed trusted-proxy configuration cannot enable partial trust
+
+- GIVEN trusted-proxy behavior is configured with an invalid or incomplete policy
+- WHEN the server loads configuration for this slice
+- THEN the server MUST fail closed or deterministically revert to strict default behavior
+- AND it MUST NOT start in a partially trusted forwarded-header state
+
+#### Scenario: transport configuration is separate from auth and provider credentials
+
+- GIVEN inbound auth and provider account credentials are also configured
+- WHEN transport middleware configuration is loaded
+- THEN request ID and trusted-proxy settings MUST be validated independently from bearer-auth and provider API key settings
+
+---
+
+### R41: Non-Goals and Deferred Concerns for Transport Middleware Baseline
+
+This slice MUST remain narrow and MUST NOT require or imply implementation of:
+
+- rate limiting, quotas, or abuse controls
+- idempotency keys or replay protection
+- streaming request or streaming response transport behavior
+- TLS termination, certificate handling, or mTLS policy
+- RBAC, scopes, or multi-tenant authorization models
+- outbound provider authentication changes
+- changes to the archived `rook-591-inbound-auth-boundary` scope
+
+These concerns MAY be specified later, but compliance with this slice MUST NOT depend on them.
+
+#### Scenario: baseline acceptance does not require rate limiting or TLS work
+
+- GIVEN this transport middleware baseline slice is implemented
+- WHEN acceptance is evaluated
+- THEN the slice MUST be satisfiable without adding rate limiting, idempotency, streaming, or TLS policy changes
+
+---
+
+### R42: Global Surface Rate-Limit Coverage and Scope
+
+Rook MUST define this slice as a transport-boundary, global-by-surface admission-control policy for
+the following HTTP entrypoints only:
+
+- all routes whose effective path is under `/api/*`
+- `GET /v1/models`
+- `POST /v1/chat/completions`
+
+For this slice, each covered surface MUST consume from its own independent global budget. The
+`/api/*` surface MUST NOT share a budget with `/v1/models`, and `/v1/models` MUST NOT share a
+budget with `/v1/chat/completions`.
+
+Routes outside those surfaces, including dashboard routes and assets outside `/api/*` and `/v1/*`,
+MUST remain out of scope for this slice.
+
+This slice MUST remain limited to transport-level surface protection. It MUST NOT define or imply
+per-client, per-IP, per-identity, per-token, or per-session limit partitioning.
+
+#### Scenario: covered surfaces are limited independently
+
+- GIVEN Rook is configured with a global rate-limit policy for `/api/*`, `/v1/models`, and `/v1/chat/completions`
+- WHEN traffic reaches each covered surface
+- THEN Rook MUST evaluate each request against the budget for that exact covered surface
+- AND exhausting one covered surface MUST NOT, by itself, exhaust either of the other covered surfaces
+
+#### Scenario: out-of-scope routes remain unaffected by this slice
+
+- GIVEN Rook also serves routes outside `/api/*`, `/v1/models`, and `/v1/chat/completions`
+- WHEN a client sends a request to an out-of-scope route
+- THEN this slice MUST NOT require global surface rate-limit evaluation for that route
+
+---
+
+### R43: Global Rate-Limit Contract by Surface
+
+For each covered surface, Rook MUST support an explicit operator-controlled policy with a bounded
+request budget and a bounded time window.
+
+When a covered request arrives, Rook MUST evaluate that request against the configured global budget
+for the covered surface before auth middleware or business handler execution proceeds.
+
+If the covered surface still has capacity within the active window, the request MUST be admitted and
+allowed to proceed normally.
+
+If the covered surface has exhausted its budget for the active window, Rook MUST reject the request
+at the transport boundary without invoking the downstream admin or gateway business handler.
+
+This slice MAY use an in-memory, process-local implementation for the global-by-surface budget.
+
+#### Scenario: request within surface budget proceeds
+
+- GIVEN a covered surface still has remaining capacity in the active window
+- WHEN a request reaches that covered surface
+- THEN Rook MUST admit the request
+- AND downstream auth and business handler execution MAY continue
+
+#### Scenario: request over surface budget is rejected at the boundary
+
+- GIVEN a covered surface has exhausted its configured budget for the active window
+- WHEN another request reaches that covered surface
+- THEN Rook MUST reject the request before downstream auth or business handler execution
+
+---
+
+### R44: Surface Rate-Limit Rejection Semantics
+
+When a covered request is rejected because its surface budget is exhausted, Rook MUST return:
+
+- HTTP status `429 Too Many Requests`
+- a `Retry-After` response header
+
+The rejection body MUST preserve the existing error-envelope style for the affected surface:
+
+- `/api/*` rejections MUST use the admin/API error response contract
+- `/v1/*` rejections MUST use the gateway/OpenAI-style error response contract
+
+`Retry-After` MUST reflect the remaining wait time until the next admission opportunity for the
+covered surface according to the configured budget window.
+
+#### Scenario: admin surface rejection uses admin envelope plus Retry-After
+
+- GIVEN the `/api/*` surface has exhausted its budget
+- WHEN another request reaches `/api/health` or another `/api/*` route
+- THEN Rook MUST return `429`
+- AND the response MUST include `Retry-After`
+- AND the response body MUST follow the admin/API error envelope
+
+#### Scenario: gateway surface rejection uses gateway envelope plus Retry-After
+
+- GIVEN the `GET /v1/models` or `POST /v1/chat/completions` surface has exhausted its budget
+- WHEN another request reaches that covered route
+- THEN Rook MUST return `429`
+- AND the response MUST include `Retry-After`
+- AND the response body MUST follow the gateway/OpenAI-style error envelope
+
+---
+
+### R45: Surface Rate-Limit Startup and Configuration Contract
+
+Rook MUST expose startup/config-driven inputs for all three covered surface policies in this slice:
+
+- `/api/*`
+- `GET /v1/models`
+- `POST /v1/chat/completions`
+
+For each covered surface, the operator-facing configuration MUST provide, at minimum:
+
+- a request budget value
+- a time-window value
+
+The startup/config path for this slice MUST fail closed when any required covered-surface policy is
+missing, malformed, zero-valued where prohibited, or otherwise invalid for safe enforcement.
+
+This configuration contract MUST remain separate from:
+
+- inbound auth token configuration
+- transport request-ID / trusted-proxy configuration
+- outbound provider credential configuration
+
+#### Scenario: startup fails closed on incomplete surface configuration
+
+- GIVEN Rook is started with a missing or invalid rate-limit policy for any required covered surface
+- WHEN startup/config validation runs
+- THEN startup/config initialization MUST fail closed
+- AND Rook MUST NOT proceed with partially-applied surface rate limiting
+
+#### Scenario: explicit startup configuration controls each covered surface independently
+
+- GIVEN the operator provides explicit startup/config values for `/api/*`, `/v1/models`, and `/v1/chat/completions`
+- WHEN Rook initializes successfully
+- THEN each covered surface MUST use the policy configured for that exact surface
+- AND one covered surface's policy MUST NOT silently overwrite or inherit another's
+
+---
+
+### R46: Composition Boundaries with Existing Transport Slices
+
+This slice MUST remain separate from the archived inbound-auth-boundary and transport-middleware-baseline slices.
+
+For covered routes, the rate-limit boundary MUST compose at the transport/router layer without
+changing the contract of:
+
+- inbound auth enforcement
+- request ID propagation
+- tracing/logging hooks
+- trusted-proxy / header sanitation behavior
+
+This slice MUST NOT require implementing or altering:
+
+- per-client or per-IP throttling
+- idempotency
+- streaming support
+- TLS configuration
+- RBAC
+- outbound provider authentication behavior
+
+#### Scenario: rate-limit rejection occurs without replacing auth and middleware responsibilities
+
+- GIVEN a covered request reaches a surface whose budget is exhausted
+- WHEN Rook rejects the request with `429`
+- THEN the rejection MUST come from the rate-limit boundary for that surface
+- AND this slice MUST NOT require changing the already-defined auth or transport-middleware contracts
+
+#### Scenario: acceptance does not require streaming or idempotency work
+
+- GIVEN this slice is implemented as specified
+- WHEN rate-limit behavior is verified for the covered surfaces
+- THEN acceptance for this slice MUST NOT depend on adding streaming or idempotency functionality
+
+---
+
+### R47: Chat Completions Idempotency Surface
+
+The system MUST apply this idempotency slice only to `POST /v1/chat/completions`.
+
+The system MUST NOT apply this slice to `/api/*`, `GET /v1/models`, or any other route.
+
+The system MUST scope idempotency records by the authenticated inbound principal established by the
+existing inbound-auth boundary, so the same raw idempotency key used by different authenticated
+principals SHALL NOT collide.
+
+#### Scenario: Idempotency applies only to chat completions create
+
+- GIVEN a valid authenticated request to `POST /v1/chat/completions`
+- WHEN the request includes a valid idempotency header
+- THEN the gateway MUST evaluate the request under this idempotency slice
+
+#### Scenario: Admin API remains out of scope
+
+- GIVEN a valid authenticated request to `/api/accounts` with an `Idempotency-Key` header
+- WHEN the request is handled
+- THEN this slice MUST NOT create, read, or reject against a chat-completions idempotency record
+
+#### Scenario: Model listing remains out of scope
+
+- GIVEN a valid authenticated request to `GET /v1/models` with an `Idempotency-Key` header
+- WHEN the request is handled
+- THEN this slice MUST NOT create, read, or reject against a chat-completions idempotency record
+
+---
+
+### R48: Idempotency Request and Replay Contract
+
+The system MUST use `Idempotency-Key` as the request contract for this slice.
+
+When a valid idempotency key is present on `POST /v1/chat/completions`, the system MUST evaluate
+whether a prior keyed request for the same authenticated principal and equivalent canonical request
+body already exists within the replay window.
+
+If a keyed equivalent completed request exists, the system MUST return the stored terminal response
+deterministically and mark the replay response with `Idempotency-Replayed: true`.
+
+If the same keyed logical request is already in progress, the system MUST reject the duplicate with
+a conflict response and MUST NOT invoke the downstream handler a second time.
+
+If the same key is reused with materially different canonical request content, the system MUST
+reject the request as a key reuse mismatch.
+
+#### Scenario: completed equivalent request is replayed deterministically
+
+- GIVEN a valid keyed `POST /v1/chat/completions` request has already completed
+- WHEN an equivalent keyed request is retried within the replay window
+- THEN the system MUST return the stored terminal response
+- AND the response MUST include `Idempotency-Replayed: true`
+
+#### Scenario: in-progress duplicate is rejected without second execution
+
+- GIVEN a valid keyed `POST /v1/chat/completions` request is already in progress
+- WHEN an equivalent keyed request is retried before the first completes
+- THEN the system MUST reject the duplicate request
+- AND it MUST NOT invoke the downstream handler a second time
+
+#### Scenario: mismatched keyed request is rejected
+
+- GIVEN a previously seen idempotency key for `POST /v1/chat/completions`
+- WHEN the same key is reused with materially different canonical request content
+- THEN the system MUST reject the request as an idempotency mismatch
+
+---
+
+### R49: Idempotency Availability, Retention, and Boundaries
+
+This slice MUST define a bounded replay-retention window sufficient for meaningful client retries.
+
+Requests without `Idempotency-Key` MUST continue to behave as ordinary non-idempotent chat
+completion requests.
+
+If replay state is unavailable for a keyed request, the system MUST fail closed with an
+idempotency-unavailable server error rather than silently executing without replay protection.
+
+This slice MUST remain separate from rate limiting, streaming, TLS, RBAC, and outbound provider
+authentication behavior.
+
+#### Scenario: missing key does not enable replay protection
+
+- GIVEN a `POST /v1/chat/completions` request without `Idempotency-Key`
+- WHEN the request is handled
+- THEN the request MUST proceed without replay protection from this slice
+
+#### Scenario: acceptance does not require streaming or unrelated route idempotency
+
+- GIVEN this slice is implemented as specified
+- WHEN idempotency behavior is verified
+- THEN acceptance for this slice MUST NOT depend on adding streaming support or idempotency to `/api/*` or `GET /v1/models`
+
+#### Scenario: baseline acceptance remains separate from archived inbound auth work
+
+- GIVEN the archived `rook-591-inbound-auth-boundary` change already defines inbound bearer-auth behavior
+- WHEN this slice is accepted
+- THEN it MUST remain valid without changing that archived auth contract
+
+---
+
+### R50: Chat Completions Streaming Surface and Request Contract
+
+The system MUST apply this streaming slice only to `POST /v1/chat/completions` when the request body
+sets `stream: true`.
+
+The system MUST NOT apply this slice to `/api/*`, `GET /v1/models`, or non-streaming
+`POST /v1/chat/completions` requests.
+
+#### Scenario: streaming applies only to chat completions with stream true
+
+- GIVEN a request to `POST /v1/chat/completions`
+- WHEN the request body sets `stream: true`
+- THEN the gateway MUST use the streaming transport path for this slice
+
+#### Scenario: non-streaming chat completions remain on buffered path
+
+- GIVEN a request to `POST /v1/chat/completions`
+- WHEN the request body does not set `stream: true`
+- THEN this slice MUST NOT require streaming transport behavior
+
+---
+
+### R51: OpenAI-Compatible SSE Response Contract
+
+For covered streaming requests, the gateway MUST respond using OpenAI-compatible server-sent events
+(SSE).
+
+The response MUST use the SSE content type and emit ordered `data:` frames compatible with OpenAI
+chat-completions streaming clients.
+
+Successful stream completion MUST terminate with a single `[DONE]` sentinel frame.
+
+#### Scenario: streaming response emits SSE frames and done sentinel
+
+- GIVEN a valid covered streaming request
+- WHEN the upstream stream completes normally
+- THEN the gateway MUST emit ordered SSE `data:` frames
+- AND it MUST emit exactly one `[DONE]` sentinel on normal completion
+
+---
+
+### R52: Streaming Failure and Composition Boundaries
+
+If streaming setup fails before the response stream begins, the gateway MUST return the normal JSON
+gateway error response rather than an SSE stream.
+
+If a mid-stream transport failure occurs after streaming has started, the gateway MAY terminate the
+SSE stream without emitting `[DONE]`.
+
+This slice MUST remain separate from existing auth, transport middleware, rate limiting, and
+buffered idempotency behavior. Streaming requests MUST NOT be forced through buffered idempotency
+capture/replay semantics.
+
+#### Scenario: setup failure returns JSON error before stream starts
+
+- GIVEN a covered streaming request
+- WHEN the gateway cannot establish streaming before response emission starts
+- THEN the gateway MUST return a normal JSON gateway error response
+
+#### Scenario: mid-stream failure omits done sentinel
+
+- GIVEN a covered streaming request has already begun emitting SSE frames
+- WHEN a mid-stream transport failure occurs
+- THEN the gateway MAY terminate the stream abnormally
+- AND it MUST NOT emit `[DONE]` for that abnormal termination
+
+#### Scenario: streaming bypasses buffered idempotency replay path
+
+- GIVEN a covered streaming request with `stream: true`
+- WHEN the request is processed
+- THEN this slice MUST NOT require buffered idempotency capture/replay behavior for that response path
 
 ---
 


### PR DESCRIPTION
## Related Issues

- closes #591
- relates to #589
- relates to #590

---

## Summary

This PR hardens the Rook gateway transport and chat delivery path as a cohesive Rook-only change set.

- adds inbound auth enforcement for `/api/*` and `/v1/*`
- adds transport middleware for request IDs, structured observability, and strict-by-default forwarded-header handling
- adds global-by-surface rate limiting for `/api/*`, `/v1/models`, and `/v1/chat/completions`
- adds chat-completions idempotency for meaningful replay protection on keyed non-streaming requests
- adds OpenAI-compatible SSE streaming for `POST /v1/chat/completions` when `stream: true`
- syncs and archives the corresponding OpenSpec changes and gateway spec updates

---

## Tested Information

Targeted Rust tests were run across the implemented slices, including:

- auth boundary tests for protected `/api/*` and `/v1/*` routes
- transport middleware tests for request IDs, trusted-proxy policy, sanitized context, and redacted observability fields
- global surface rate-limit tests for independent budgets, `429`, `Retry-After`, and startup/config validation
- chat-completions idempotency tests for canonicalization, replay, mismatch, in-progress conflict, unavailable store handling, and route scoping
- chat-completions streaming tests for SSE framing, `[DONE]` termination, setup failure behavior, and mid-stream abort behavior

I also ran `cargo test --manifest-path "clients/rook/Cargo.toml"` during validation passes to confirm the Rook slice behavior in the broader crate context, while noting unrelated existing failures outside these slices where applicable.

---

## Documentation Impact

- Docs updated in:
  - `openspec/specs/gateway/spec.md`
  - `openspec/changes/archive/2026-04-21-rook-589-gateway-api/state.yaml`
  - `openspec/changes/archive/2026-04-22-rook-591-inbound-auth-boundary/`
  - `openspec/changes/archive/2026-04-22-rook-591-transport-middleware-baseline/`
  - `openspec/changes/archive/2026-04-22-rook-591-global-surface-rate-limits/`
  - `openspec/changes/archive/2026-04-22-rook-591-chat-completions-idempotency/`
  - `openspec/changes/archive/2026-04-22-rook-591-chat-completions-streaming-transport/`
- No docs update required because: n/a
- [x] I verified the documentation matches the current behavior.

---

## Breaking Changes

None intended. This PR expands Rook transport capabilities and constraints without intentionally changing unrelated public contracts outside the Rook gateway path.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/develop/CONTRIBUTING.md) and followed the project conventions.
- [x] I have included tests or explained why tests were not necessary.
- [x] I have updated documentation or confirmed it is not needed.
- [x] My commit messages follow the Conventional Commits format.
- [x] I verified the changes locally before opening this PR.
