### PR TITLE
feat(runtime): complete orchestration parity contract

### DIFF
--- a/clients/agent-runtime/src/agent/coordinator.rs
+++ b/clients/agent-runtime/src/agent/coordinator.rs
@@ -158,6 +158,7 @@ pub enum ApprovalBrokerMode {
     ParentOwnedOnly,
 }
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EnforcedExecutionGuarantees {
     pub transport: CoordinatorTransport,
@@ -306,18 +307,17 @@ pub enum ApprovalDecision {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ApprovalStatus {
+    #[default]
     None,
-    Pending { request: ApprovalRequest },
-    Resolved { decision: ApprovalDecision },
-}
-
-impl Default for ApprovalStatus {
-    fn default() -> Self {
-        Self::None
-    }
+    Pending {
+        request: ApprovalRequest,
+    },
+    Resolved {
+        decision: ApprovalDecision,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/clients/agent-runtime/src/agent/coordinator.rs
+++ b/clients/agent-runtime/src/agent/coordinator.rs
@@ -251,7 +251,10 @@ fn normalize_execution_metadata(
 
     if let Some(sandbox_mode) = &requested.sandbox_mode {
         let normalized = sandbox_mode.trim().to_ascii_lowercase();
-        if matches!(normalized.as_str(), "clone" | "cloned" | "isolated" | "workspace_clone") {
+        if matches!(
+            normalized.as_str(),
+            "clone" | "cloned" | "isolated" | "workspace_clone"
+        ) {
             return Err(LaunchContractRejection::UnsupportedIsolation {
                 field: "sandbox_mode".to_string(),
                 requested: sandbox_mode.clone(),
@@ -1170,12 +1173,10 @@ impl Coordinator {
         match payload {
             CoordinatorMessage::DispatchChild(_)
             | CoordinatorMessage::CancelChild { .. }
-            | CoordinatorMessage::ResolveApproval { .. } => {
-                child_id
-                    .cloned()
-                    .map(|value| LogicalEndpoint::child(self.coordinator_id.clone(), value))
-                    .unwrap_or_else(|| LogicalEndpoint::coordinator(self.coordinator_id.clone()))
-            }
+            | CoordinatorMessage::ResolveApproval { .. } => child_id
+                .cloned()
+                .map(|value| LogicalEndpoint::child(self.coordinator_id.clone(), value))
+                .unwrap_or_else(|| LogicalEndpoint::coordinator(self.coordinator_id.clone())),
             CoordinatorMessage::ChildStarted { .. }
             | CoordinatorMessage::ChildProgress { .. }
             | CoordinatorMessage::RequestApproval { .. }
@@ -3055,8 +3056,14 @@ mod tests {
             metadata.enforced.approval_broker_mode,
             ApprovalBrokerMode::ParentOwnedOnly
         );
-        assert_eq!(metadata.requested.sandbox_mode.as_deref(), Some("workspace_write"));
-        assert_eq!(metadata.requested.working_directory.as_deref(), Some("/tmp/project"));
+        assert_eq!(
+            metadata.requested.sandbox_mode.as_deref(),
+            Some("workspace_write")
+        );
+        assert_eq!(
+            metadata.requested.working_directory.as_deref(),
+            Some("/tmp/project")
+        );
         assert!(metadata.requested.read_only_project_access);
     }
 
@@ -3200,7 +3207,10 @@ mod tests {
         let latest_event = coordinator.event_log().unwrap().pop().unwrap();
         assert!(matches!(
             latest_event,
-            CoordinatorEvent::ChildStateChanged { state: ChildState::Cancelling, .. }
+            CoordinatorEvent::ChildStateChanged {
+                state: ChildState::Cancelling,
+                ..
+            }
         ));
     }
 

--- a/clients/agent-runtime/src/agent/coordinator.rs
+++ b/clients/agent-runtime/src/agent/coordinator.rs
@@ -177,6 +177,7 @@ pub struct ChildExecutionMetadataView {
     pub enforced: EnforcedExecutionGuarantees,
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum LaunchContractRejection {

--- a/clients/agent-runtime/src/agent/coordinator.rs
+++ b/clients/agent-runtime/src/agent/coordinator.rs
@@ -56,9 +56,11 @@ impl CoordinatorState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CoordinatorTransport {
     InProcess,
     Mailbox,
+    RemoteBridge,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -69,19 +71,271 @@ pub enum FanInPolicy {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ChildAgentId(pub String);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ChildState {
-    Registered,
+    Queued,
+    Starting,
     Running,
-    Succeeded,
+    WaitingOnParent,
+    Cancelling,
+    Completed,
     Failed,
     Cancelled,
 }
 
 impl ChildState {
     fn is_terminal(&self) -> bool {
-        matches!(self, Self::Succeeded | Self::Failed | Self::Cancelled)
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ChildExecutionSpec {
+    #[serde(default)]
+    pub working_directory: Option<String>,
+    #[serde(default)]
+    pub sandbox_mode: Option<String>,
+    #[serde(default)]
+    pub repository_id: Option<String>,
+    #[serde(default)]
+    pub worktree_id: Option<String>,
+    #[serde(default)]
+    pub tool_allowlist: Vec<String>,
+    #[serde(default)]
+    pub tool_denylist: Vec<String>,
+    #[serde(default)]
+    pub provider_override: Option<String>,
+    #[serde(default)]
+    pub model_override: Option<String>,
+    #[serde(default)]
+    pub transport: Option<CoordinatorTransport>,
+    #[serde(default)]
+    pub read_only_project_access: bool,
+    #[serde(default)]
+    pub permission_broker: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NormalizedExecutionRequest {
+    pub transport: CoordinatorTransport,
+    pub sandbox_mode: Option<String>,
+    pub repository_id: Option<String>,
+    pub worktree_id: Option<String>,
+    pub read_only_project_access: bool,
+    pub tool_allowlist: Vec<String>,
+    pub tool_denylist: Vec<String>,
+    pub provider_override: Option<String>,
+    pub model_override: Option<String>,
+    pub working_directory: Option<String>,
+    pub permission_broker: Option<String>,
+}
+
+impl From<&ChildExecutionSpec> for NormalizedExecutionRequest {
+    fn from(value: &ChildExecutionSpec) -> Self {
+        Self {
+            transport: value
+                .transport
+                .clone()
+                .unwrap_or(CoordinatorTransport::InProcess),
+            sandbox_mode: value.sandbox_mode.clone(),
+            repository_id: value.repository_id.clone(),
+            worktree_id: value.worktree_id.clone(),
+            read_only_project_access: value.read_only_project_access,
+            tool_allowlist: value.tool_allowlist.clone(),
+            tool_denylist: value.tool_denylist.clone(),
+            provider_override: value.provider_override.clone(),
+            model_override: value.model_override.clone(),
+            working_directory: value.working_directory.clone(),
+            permission_broker: value.permission_broker.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalBrokerMode {
+    None,
+    ParentOwnedOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnforcedExecutionGuarantees {
+    pub transport: CoordinatorTransport,
+    pub process_local_handle_authority: bool,
+    pub mailbox_backed_delivery: bool,
+    pub repository_isolation_enforced: bool,
+    pub worktree_isolation_enforced: bool,
+    pub sandbox_clone_enforced: bool,
+    pub remote_bridge_connected: bool,
+    pub approval_broker_mode: ApprovalBrokerMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChildExecutionMetadataView {
+    pub requested: NormalizedExecutionRequest,
+    pub enforced: EnforcedExecutionGuarantees,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum LaunchContractRejection {
+    UnsupportedTransport { requested: CoordinatorTransport },
+    UnsupportedIsolation { field: String, requested: String },
+    UnsupportedPermissionBroker { reason: String },
+}
+
+impl std::fmt::Display for LaunchContractRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedTransport { requested } => {
+                write!(f, "unsupported transport request: {requested:?}")
+            }
+            Self::UnsupportedIsolation { field, requested } => {
+                write!(f, "unsupported isolation request for {field}: {requested}")
+            }
+            Self::UnsupportedPermissionBroker { reason } => {
+                write!(f, "unsupported permission broker request: {reason}")
+            }
+        }
+    }
+}
+
+fn enforced_execution_guarantees(
+    requested: &NormalizedExecutionRequest,
+) -> EnforcedExecutionGuarantees {
+    EnforcedExecutionGuarantees {
+        transport: match requested.transport {
+            CoordinatorTransport::Mailbox => CoordinatorTransport::Mailbox,
+            CoordinatorTransport::InProcess | CoordinatorTransport::RemoteBridge => {
+                CoordinatorTransport::InProcess
+            }
+        },
+        process_local_handle_authority: true,
+        mailbox_backed_delivery: requested.transport == CoordinatorTransport::Mailbox,
+        repository_isolation_enforced: false,
+        worktree_isolation_enforced: false,
+        sandbox_clone_enforced: false,
+        remote_bridge_connected: false,
+        approval_broker_mode: ApprovalBrokerMode::ParentOwnedOnly,
+    }
+}
+
+fn normalize_execution_metadata(
+    spec: Option<&ChildExecutionSpec>,
+) -> Result<Option<ChildExecutionMetadataView>, LaunchContractRejection> {
+    let Some(spec) = spec else {
+        return Ok(None);
+    };
+
+    let requested = NormalizedExecutionRequest::from(spec);
+
+    if requested.transport == CoordinatorTransport::RemoteBridge {
+        return Err(LaunchContractRejection::UnsupportedTransport {
+            requested: CoordinatorTransport::RemoteBridge,
+        });
+    }
+
+    if let Some(repository_id) = &requested.repository_id {
+        return Err(LaunchContractRejection::UnsupportedIsolation {
+            field: "repository_id".to_string(),
+            requested: repository_id.clone(),
+        });
+    }
+
+    if let Some(worktree_id) = &requested.worktree_id {
+        return Err(LaunchContractRejection::UnsupportedIsolation {
+            field: "worktree_id".to_string(),
+            requested: worktree_id.clone(),
+        });
+    }
+
+    if let Some(sandbox_mode) = &requested.sandbox_mode {
+        let normalized = sandbox_mode.trim().to_ascii_lowercase();
+        if matches!(normalized.as_str(), "clone" | "cloned" | "isolated" | "workspace_clone") {
+            return Err(LaunchContractRejection::UnsupportedIsolation {
+                field: "sandbox_mode".to_string(),
+                requested: sandbox_mode.clone(),
+            });
+        }
+    }
+
+    if let Some(permission_broker) = &requested.permission_broker {
+        let normalized = permission_broker.trim().to_ascii_lowercase();
+        if normalized != "parent_owned_only" {
+            return Err(LaunchContractRejection::UnsupportedPermissionBroker {
+                reason: permission_broker.clone(),
+            });
+        }
+    }
+
+    Ok(Some(ChildExecutionMetadataView {
+        enforced: enforced_execution_guarantees(&requested),
+        requested,
+    }))
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApprovalRequest {
+    pub request_id: String,
+    pub tool_name: String,
+    pub reason: String,
+    #[serde(default)]
+    pub arguments: Option<serde_json::Value>,
+    pub requested_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ApprovalDecision {
+    Approved {
+        request_id: String,
+        decided_at: DateTime<Utc>,
+    },
+    Denied {
+        request_id: String,
+        decided_at: DateTime<Utc>,
+        reason: String,
+    },
+    Cancelled {
+        request_id: String,
+        decided_at: DateTime<Utc>,
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ApprovalStatus {
+    None,
+    Pending { request: ApprovalRequest },
+    Resolved { decision: ApprovalDecision },
+}
+
+impl Default for ApprovalStatus {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CoordinatorEvent {
+    ChildStateChanged {
+        child_id: String,
+        state: ChildState,
+        summary: Option<String>,
+        sequence: u64,
+    },
+    ApprovalRequested {
+        child_id: String,
+        request: ApprovalRequest,
+        sequence: u64,
+    },
+    ApprovalResolved {
+        child_id: String,
+        decision: ApprovalDecision,
+        sequence: u64,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -104,6 +358,8 @@ pub struct ChildRecord {
     pub launch_index: u32,
     pub session_id: Option<String>,
     pub state: ChildState,
+    pub execution: Option<ChildExecutionMetadataView>,
+    pub approval: ApprovalStatus,
     pub last_sequence: u64,
     pub terminal_reason: Option<ChildTerminationReason>,
     pub summary: Option<String>,
@@ -142,6 +398,7 @@ pub struct ChildLaunchRequest {
     pub prompt: String,
     pub context: Option<String>,
     pub launch_index: u32,
+    pub execution: Option<ChildExecutionSpec>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -171,6 +428,8 @@ pub enum CoordinatorMessage {
     CancelChild { reason: CancellationReason },
     ChildStarted { session_id: Option<String> },
     ChildProgress { summary: String },
+    RequestApproval { request: ApprovalRequest },
+    ResolveApproval { decision: ApprovalDecision },
     ChildCompleted { result: ChildExecutionResult },
     ChildFailed { error: ChildExecutionError },
     ChildCancelled { reason: CancellationReason },
@@ -227,6 +486,8 @@ pub enum CoordinatorError {
     InvalidEnvelope(String),
     #[error("coordinator failed closed: {0}")]
     FailedClosed(String),
+    #[error("launch contract rejected: {0}")]
+    LaunchContractRejected(LaunchContractRejection),
 }
 
 #[async_trait]
@@ -288,6 +549,17 @@ impl DelegatedAgentRunner {
             config.api_key = Some(key.clone());
         } else if let Some(key) = &self.fallback_credential {
             config.api_key = Some(key.clone());
+        }
+        if let Some(execution) = &request.execution {
+            if let Some(provider_override) = &execution.provider_override {
+                config.default_provider = Some(provider_override.clone());
+            }
+            if let Some(model_override) = &execution.model_override {
+                config.default_model = Some(model_override.clone());
+            }
+            if let Some(working_directory) = &execution.working_directory {
+                config.workspace_dir = std::path::PathBuf::from(working_directory);
+            }
         }
 
         let timeout_ms = agent_config
@@ -501,6 +773,7 @@ pub struct Coordinator {
     registry: Arc<Mutex<SupervisionRegistry>>,
     outcomes: Arc<Mutex<BTreeMap<ChildAgentId, CoordinatorChildOutcome>>>,
     applied_messages: Arc<Mutex<HashMap<(ChildAgentId, String), String>>>,
+    events: Arc<Mutex<Vec<CoordinatorEvent>>>,
     next_sequence: AtomicU64,
 }
 
@@ -526,6 +799,7 @@ impl Coordinator {
             registry: Arc::new(Mutex::new(BTreeMap::new())),
             outcomes: Arc::new(Mutex::new(BTreeMap::new())),
             applied_messages: Arc::new(Mutex::new(HashMap::new())),
+            events: Arc::new(Mutex::new(Vec::new())),
             next_sequence: AtomicU64::new(1),
         }
     }
@@ -566,6 +840,21 @@ impl Coordinator {
         Ok(state.clone())
     }
 
+    fn log_event(&self, event: CoordinatorEvent) -> Result<(), CoordinatorError> {
+        self.events
+            .lock()
+            .map_err(|_| CoordinatorError::FailedClosed("event log lock poisoned".to_string()))?
+            .push(event);
+        Ok(())
+    }
+
+    pub fn event_log(&self) -> Result<Vec<CoordinatorEvent>, CoordinatorError> {
+        self.events
+            .lock()
+            .map(|events| events.clone())
+            .map_err(|_| CoordinatorError::FailedClosed("event log lock poisoned".to_string()))
+    }
+
     pub fn admit_child(&self, request: &ChildLaunchRequest) -> Result<(), CoordinatorError> {
         let mut registry = self
             .registry
@@ -590,7 +879,10 @@ impl Coordinator {
                 agent_name: request.agent_name.clone(),
                 launch_index: request.launch_index,
                 session_id: None,
-                state: ChildState::Registered,
+                state: ChildState::Queued,
+                execution: normalize_execution_metadata(request.execution.as_ref())
+                    .map_err(CoordinatorError::LaunchContractRejected)?,
+                approval: ApprovalStatus::None,
                 last_sequence: 0,
                 terminal_reason: None,
                 summary: None,
@@ -617,6 +909,30 @@ impl Coordinator {
             .lock()
             .map(|registry| registry.get(child_id).cloned())
             .map_err(|_| CoordinatorError::FailedClosed("registry lock poisoned".to_string()))
+    }
+
+    fn apply_cancellation_visibility(
+        &self,
+        reason: &CancellationReason,
+    ) -> Result<(), CoordinatorError> {
+        for child_id in self.ordered_child_ids()? {
+            let Some(record) = self.child_record(&child_id)? else {
+                continue;
+            };
+            if record.state.is_terminal() || record.state == ChildState::Cancelling {
+                continue;
+            }
+
+            let cancel_envelope = self.next_envelope(
+                Some(child_id.clone()),
+                format!("cancel:{}", record.launch_index),
+                CoordinatorMessage::CancelChild {
+                    reason: reason.clone(),
+                },
+            );
+            self.apply_envelope(&cancel_envelope)?;
+        }
+        Ok(())
     }
 
     pub fn next_envelope(
@@ -702,11 +1018,12 @@ impl Coordinator {
 
         match &envelope.payload {
             CoordinatorMessage::DispatchChild(_) => {
-                record.state = ChildState::Registered;
+                record.state = ChildState::Starting;
+                record.summary = Some("dispatching child".to_string());
             }
             CoordinatorMessage::CancelChild { reason } => {
                 if !record.state.is_terminal() {
-                    record.state = ChildState::Running;
+                    record.state = ChildState::Cancelling;
                     record.summary = Some(format!("cancelling: {reason:?}"));
                 }
             }
@@ -715,6 +1032,7 @@ impl Coordinator {
                     return Err(CoordinatorError::AlreadyTerminalState);
                 }
                 record.state = ChildState::Running;
+                record.approval = ApprovalStatus::None;
                 record.session_id = session_id.clone();
             }
             CoordinatorMessage::ChildProgress { summary } => {
@@ -724,10 +1042,43 @@ impl Coordinator {
                 record.state = ChildState::Running;
                 record.summary = Some(summary.clone());
             }
+            CoordinatorMessage::RequestApproval { request } => {
+                if record.state.is_terminal() {
+                    return Err(CoordinatorError::AlreadyTerminalState);
+                }
+                record.state = ChildState::WaitingOnParent;
+                record.summary = Some(format!(
+                    "awaiting parent approval for {}",
+                    request.tool_name
+                ));
+                record.approval = ApprovalStatus::Pending {
+                    request: request.clone(),
+                };
+                self.log_event(CoordinatorEvent::ApprovalRequested {
+                    child_id: child_id.0.clone(),
+                    request: request.clone(),
+                    sequence: envelope.meta.sequence,
+                })?;
+            }
+            CoordinatorMessage::ResolveApproval { decision } => {
+                if record.state.is_terminal() {
+                    return Err(CoordinatorError::AlreadyTerminalState);
+                }
+                record.state = ChildState::Running;
+                record.summary = Some("approval decision recorded".to_string());
+                record.approval = ApprovalStatus::Resolved {
+                    decision: decision.clone(),
+                };
+                self.log_event(CoordinatorEvent::ApprovalResolved {
+                    child_id: child_id.0.clone(),
+                    decision: decision.clone(),
+                    sequence: envelope.meta.sequence,
+                })?;
+            }
             CoordinatorMessage::ChildCompleted { result } => {
                 self.record_terminal(
                     record,
-                    child_id,
+                    &child_id,
                     TerminalUpdate {
                         outcome: CoordinatorChildOutcome::Succeeded {
                             child_id: record.child_id.clone(),
@@ -735,7 +1086,7 @@ impl Coordinator {
                             result: result.clone(),
                         },
                         session_id: result.session_id.clone(),
-                        state: ChildState::Succeeded,
+                        state: ChildState::Completed,
                         terminal_reason: ChildTerminationReason::Completed,
                         summary: result.tool_result.output.clone(),
                     },
@@ -744,7 +1095,7 @@ impl Coordinator {
             CoordinatorMessage::ChildFailed { error } => {
                 self.record_terminal(
                     record,
-                    child_id,
+                    &child_id,
                     TerminalUpdate {
                         outcome: CoordinatorChildOutcome::Failed {
                             child_id: record.child_id.clone(),
@@ -761,7 +1112,7 @@ impl Coordinator {
             CoordinatorMessage::ChildCancelled { reason } => {
                 self.record_terminal(
                     record,
-                    child_id,
+                    &child_id,
                     TerminalUpdate {
                         outcome: CoordinatorChildOutcome::Cancelled {
                             child_id: record.child_id.clone(),
@@ -777,6 +1128,13 @@ impl Coordinator {
             }
         }
 
+        self.log_event(CoordinatorEvent::ChildStateChanged {
+            child_id: child_id.0.clone(),
+            state: record.state.clone(),
+            summary: record.summary.clone(),
+            sequence: envelope.meta.sequence,
+        })?;
+
         applied_messages.insert(duplicate_key, payload_digest);
         Ok(())
     }
@@ -787,11 +1145,14 @@ impl Coordinator {
         payload: &CoordinatorMessage,
     ) -> LogicalEndpoint {
         match payload {
-            CoordinatorMessage::DispatchChild(_) | CoordinatorMessage::CancelChild { .. } => {
+            CoordinatorMessage::DispatchChild(_)
+            | CoordinatorMessage::CancelChild { .. }
+            | CoordinatorMessage::ResolveApproval { .. } => {
                 LogicalEndpoint::coordinator(self.coordinator_id.clone())
             }
             CoordinatorMessage::ChildStarted { .. }
             | CoordinatorMessage::ChildProgress { .. }
+            | CoordinatorMessage::RequestApproval { .. }
             | CoordinatorMessage::ChildCompleted { .. }
             | CoordinatorMessage::ChildFailed { .. }
             | CoordinatorMessage::ChildCancelled { .. } => child_id
@@ -807,7 +1168,9 @@ impl Coordinator {
         payload: &CoordinatorMessage,
     ) -> LogicalEndpoint {
         match payload {
-            CoordinatorMessage::DispatchChild(_) | CoordinatorMessage::CancelChild { .. } => {
+            CoordinatorMessage::DispatchChild(_)
+            | CoordinatorMessage::CancelChild { .. }
+            | CoordinatorMessage::ResolveApproval { .. } => {
                 child_id
                     .cloned()
                     .map(|value| LogicalEndpoint::child(self.coordinator_id.clone(), value))
@@ -815,6 +1178,7 @@ impl Coordinator {
             }
             CoordinatorMessage::ChildStarted { .. }
             | CoordinatorMessage::ChildProgress { .. }
+            | CoordinatorMessage::RequestApproval { .. }
             | CoordinatorMessage::ChildCompleted { .. }
             | CoordinatorMessage::ChildFailed { .. }
             | CoordinatorMessage::ChildCancelled { .. } => child_id
@@ -827,7 +1191,7 @@ impl Coordinator {
     fn record_terminal(
         &self,
         record: &mut ChildRecord,
-        child_id: ChildAgentId,
+        child_id: &ChildAgentId,
         update: TerminalUpdate,
     ) -> Result<(), CoordinatorError> {
         if record.state.is_terminal() {
@@ -843,7 +1207,7 @@ impl Coordinator {
         self.outcomes
             .lock()
             .map_err(|_| CoordinatorError::FailedClosed("outcome lock poisoned".to_string()))?
-            .insert(child_id, update.outcome);
+            .insert(child_id.clone(), update.outcome);
         Ok(())
     }
 
@@ -863,7 +1227,9 @@ impl Coordinator {
         }
         if !matches!(
             envelope.meta.transport,
-            CoordinatorTransport::InProcess | CoordinatorTransport::Mailbox
+            CoordinatorTransport::InProcess
+                | CoordinatorTransport::Mailbox
+                | CoordinatorTransport::RemoteBridge
         ) {
             return Err(CoordinatorError::InvalidEnvelope(
                 "unsupported transport".to_string(),
@@ -881,7 +1247,9 @@ impl Coordinator {
         };
 
         match &envelope.payload {
-            CoordinatorMessage::DispatchChild(_) | CoordinatorMessage::CancelChild { .. } => {
+            CoordinatorMessage::DispatchChild(_)
+            | CoordinatorMessage::CancelChild { .. }
+            | CoordinatorMessage::ResolveApproval { .. } => {
                 match (&envelope.meta.sender, &envelope.meta.recipient) {
                     (
                         LogicalEndpoint::Coordinator { coordinator_id, .. },
@@ -901,6 +1269,7 @@ impl Coordinator {
             }
             CoordinatorMessage::ChildStarted { .. }
             | CoordinatorMessage::ChildProgress { .. }
+            | CoordinatorMessage::RequestApproval { .. }
             | CoordinatorMessage::ChildCompleted { .. }
             | CoordinatorMessage::ChildFailed { .. }
             | CoordinatorMessage::ChildCancelled { .. } => {
@@ -1038,6 +1407,9 @@ impl Coordinator {
                                 }
                                 if !coordinator_cancellation.is_cancelled() {
                                     let _ = self.transition(CoordinatorState::Cancelling);
+                                    if let Some(reason) = &cancel_reason {
+                                        self.apply_cancellation_visibility(reason)?;
+                                    }
                                     coordinator_cancellation.cancel();
                                 }
                             }
@@ -1066,6 +1438,7 @@ impl Coordinator {
             if parent_cancellation.is_cancelled() && !coordinator_cancellation.is_cancelled() {
                 cancel_reason = Some(CancellationReason::ParentRequested);
                 let _ = self.transition(CoordinatorState::Cancelling);
+                self.apply_cancellation_visibility(&CancellationReason::ParentRequested)?;
                 coordinator_cancellation.cancel();
             }
         }
@@ -1142,9 +1515,12 @@ impl From<CoordinatorState> for CoordinatorStateView {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ChildStateView {
-    Registered,
+    Queued,
+    Starting,
     Running,
-    Succeeded,
+    WaitingOnParent,
+    Cancelling,
+    Completed,
     Failed,
     Cancelled,
 }
@@ -1152,9 +1528,12 @@ pub enum ChildStateView {
 impl From<ChildState> for ChildStateView {
     fn from(s: ChildState) -> Self {
         match s {
-            ChildState::Registered => Self::Registered,
+            ChildState::Queued => Self::Queued,
+            ChildState::Starting => Self::Starting,
             ChildState::Running => Self::Running,
-            ChildState::Succeeded => Self::Succeeded,
+            ChildState::WaitingOnParent => Self::WaitingOnParent,
+            ChildState::Cancelling => Self::Cancelling,
+            ChildState::Completed => Self::Completed,
             ChildState::Failed => Self::Failed,
             ChildState::Cancelled => Self::Cancelled,
         }
@@ -1200,6 +1579,7 @@ pub struct OrchestrationSnapshot {
     pub parent_session_id: Option<String>,
     pub state: CoordinatorStateView,
     pub children: Vec<ChildLifecycleView>,
+    pub events: Vec<LifecycleEventView>,
     pub outcome: Option<OrchestrationOutcomeView>,
 }
 
@@ -1211,6 +1591,8 @@ pub struct ChildLifecycleView {
     pub launch_index: u32,
     pub session_id: Option<String>,
     pub state: ChildStateView,
+    pub execution: Option<ChildExecutionMetadataView>,
+    pub approval: ApprovalStatus,
     pub summary: Option<String>,
     pub terminal_reason: Option<ChildTerminationView>,
 }
@@ -1223,8 +1605,56 @@ impl From<&ChildRecord> for ChildLifecycleView {
             launch_index: r.launch_index,
             session_id: r.session_id.clone(),
             state: r.state.clone().into(),
+            execution: r.execution.clone(),
+            approval: r.approval.clone(),
             summary: r.summary.clone(),
             terminal_reason: r.terminal_reason.as_ref().map(ChildTerminationView::from),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LifecycleEventView {
+    pub sequence: u64,
+    pub child_id: String,
+    pub kind: String,
+    pub summary: Option<String>,
+}
+
+impl From<&CoordinatorEvent> for LifecycleEventView {
+    fn from(event: &CoordinatorEvent) -> Self {
+        match event {
+            CoordinatorEvent::ChildStateChanged {
+                child_id,
+                state,
+                summary,
+                sequence,
+            } => Self {
+                sequence: *sequence,
+                child_id: child_id.clone(),
+                kind: format!("child_state_changed:{state:?}").to_ascii_lowercase(),
+                summary: summary.clone(),
+            },
+            CoordinatorEvent::ApprovalRequested {
+                child_id,
+                request,
+                sequence,
+            } => Self {
+                sequence: *sequence,
+                child_id: child_id.clone(),
+                kind: "approval_requested".to_string(),
+                summary: Some(request.reason.clone()),
+            },
+            CoordinatorEvent::ApprovalResolved {
+                child_id,
+                decision,
+                sequence,
+            } => Self {
+                sequence: *sequence,
+                child_id: child_id.clone(),
+                kind: "approval_resolved".to_string(),
+                summary: Some(format!("{decision:?}")),
+            },
         }
     }
 }
@@ -1290,7 +1720,7 @@ impl From<&CoordinatorChildOutcome> for ChildOutcomeView {
             } => Self {
                 child_id: child_id.0.clone(),
                 launch_index: *launch_index,
-                state: ChildStateView::Succeeded,
+                state: ChildStateView::Completed,
             },
             CoordinatorChildOutcome::Failed {
                 child_id,
@@ -1403,6 +1833,18 @@ impl SupervisedOrchestrationService {
         }
     }
 
+    fn validate_launch_request(
+        request: &CoordinatorLaunchRequest,
+    ) -> Result<(), OrchestrationServiceError> {
+        let validator = Coordinator::new();
+        for child in &request.children {
+            validator
+                .admit_child(child)
+                .map_err(OrchestrationServiceError::CoordinatorError)?;
+        }
+        Ok(())
+    }
+
     // ── Task 1.4: snapshot helper ─────────────────────────────────────────
 
     fn snapshot_from_coordinator(
@@ -1429,12 +1871,19 @@ impl SupervisedOrchestrationService {
                 children.push(ChildLifecycleView::from(&record));
             }
         }
+        let events = coordinator
+            .event_log()
+            .map_err(OrchestrationServiceError::CoordinatorError)?
+            .iter()
+            .map(LifecycleEventView::from)
+            .collect();
 
         Ok(OrchestrationSnapshot {
             handle: handle.clone(),
             parent_session_id: request.parent_session_id.clone(),
             state,
             children,
+            events,
             outcome,
         })
     }
@@ -1454,7 +1903,14 @@ impl SupervisedOrchestrationService {
         request: CoordinatorLaunchRequest,
         runner: Arc<dyn CoordinatorChildRunner>,
     ) -> Result<OrchestrationLaunchReceipt, OrchestrationServiceError> {
+        Self::validate_launch_request(&request)?;
         let handle = OrchestrationHandle::new();
+        let snapshot_seed = Arc::new(Coordinator::new());
+        for child in &request.children {
+            snapshot_seed
+                .admit_child(child)
+                .map_err(OrchestrationServiceError::CoordinatorError)?;
+        }
         let coordinator = Arc::new(Coordinator::new());
         let cancel_token = CancellationToken::new();
 
@@ -1465,7 +1921,7 @@ impl SupervisedOrchestrationService {
             tokio::spawn(async move { coordinator.run_with_cancellation(req, runner, token).await })
         };
 
-        let snapshot = Self::snapshot_from_coordinator(&handle, &coordinator, &request, None)?;
+        let snapshot = Self::snapshot_from_coordinator(&handle, &snapshot_seed, &request, None)?;
 
         let active = ActiveRun {
             coordinator,
@@ -1717,6 +2173,18 @@ impl SupervisedOrchestrationService {
                 children: children.iter().map(ChildOutcomeView::from).collect(),
             },
         }
+    }
+}
+
+#[cfg(test)]
+impl SupervisedOrchestrationService {
+    pub(crate) fn registered_handles(&self) -> Vec<OrchestrationHandle> {
+        self.registry
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .keys()
+            .cloned()
+            .collect()
     }
 }
 
@@ -1982,7 +2450,18 @@ mod tests {
             prompt: format!("prompt-{child_id}"),
             context: None,
             launch_index,
+            execution: None,
         }
+    }
+
+    fn child_with_execution(
+        child_id: &str,
+        launch_index: u32,
+        execution: ChildExecutionSpec,
+    ) -> ChildLaunchRequest {
+        let mut request = child(child_id, launch_index);
+        request.execution = Some(execution);
+        request
     }
 
     fn child_outcome_ids(children: &[CoordinatorChildOutcome]) -> Vec<String> {
@@ -2184,7 +2663,7 @@ mod tests {
         coordinator.apply_envelope(&envelope).unwrap();
         assert_eq!(
             coordinator.child_record(&child_id).unwrap().unwrap().state,
-            ChildState::Succeeded
+            ChildState::Completed
         );
     }
 
@@ -2475,14 +2954,16 @@ mod tests {
         assert_eq!(second.meta.correlation_id, first.meta.correlation_id);
     }
 
-    /// Compile-time assertion: Slice 3 transport remains limited to in-process and mailbox.
-    /// Remote bridge, worktree isolation, and other deferred transports must stay out of scope.
+    /// Compile-time assertion: coordinator transport remains constrained to the
+    /// explicit local/bridge variants we model today.
     #[test]
-    fn coordinator_slice_limits_transport_to_in_process_and_mailbox() {
+    fn coordinator_transport_limits_surface_to_supported_variants() {
         fn assert_allowed_transport(t: CoordinatorTransport) -> bool {
             matches!(
                 t,
-                CoordinatorTransport::InProcess | CoordinatorTransport::Mailbox
+                CoordinatorTransport::InProcess
+                    | CoordinatorTransport::Mailbox
+                    | CoordinatorTransport::RemoteBridge
             )
         }
         assert!(
@@ -2492,6 +2973,10 @@ mod tests {
         assert!(
             assert_allowed_transport(CoordinatorTransport::Mailbox),
             "CoordinatorTransport must allow mailbox transport"
+        );
+        assert!(
+            assert_allowed_transport(CoordinatorTransport::RemoteBridge),
+            "CoordinatorTransport must allow remote bridge transport"
         );
     }
 
@@ -2530,6 +3015,253 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, CoordinatorError::InvalidEnvelope(_)));
+    }
+
+    #[test]
+    fn admit_child_normalizes_requested_vs_enforced_execution_metadata() {
+        let coordinator = Coordinator::new();
+        coordinator
+            .admit_child(&child_with_execution(
+                "child-a",
+                0,
+                ChildExecutionSpec {
+                    transport: Some(CoordinatorTransport::Mailbox),
+                    sandbox_mode: Some("workspace_write".to_string()),
+                    tool_allowlist: vec!["read".to_string()],
+                    provider_override: Some("anthropic".to_string()),
+                    model_override: Some("claude".to_string()),
+                    working_directory: Some("/tmp/project".to_string()),
+                    read_only_project_access: true,
+                    ..ChildExecutionSpec::default()
+                },
+            ))
+            .unwrap();
+
+        let record = coordinator
+            .child_record(&ChildAgentId("child-a".to_string()))
+            .unwrap()
+            .unwrap();
+        let metadata = record.execution.expect("normalized execution metadata");
+
+        assert_eq!(metadata.requested.transport, CoordinatorTransport::Mailbox);
+        assert_eq!(metadata.enforced.transport, CoordinatorTransport::Mailbox);
+        assert!(metadata.enforced.process_local_handle_authority);
+        assert!(metadata.enforced.mailbox_backed_delivery);
+        assert!(!metadata.enforced.repository_isolation_enforced);
+        assert!(!metadata.enforced.worktree_isolation_enforced);
+        assert!(!metadata.enforced.sandbox_clone_enforced);
+        assert!(!metadata.enforced.remote_bridge_connected);
+        assert_eq!(
+            metadata.enforced.approval_broker_mode,
+            ApprovalBrokerMode::ParentOwnedOnly
+        );
+        assert_eq!(metadata.requested.sandbox_mode.as_deref(), Some("workspace_write"));
+        assert_eq!(metadata.requested.working_directory.as_deref(), Some("/tmp/project"));
+        assert!(metadata.requested.read_only_project_access);
+    }
+
+    #[test]
+    fn admit_child_rejects_remote_bridge_requests_fail_closed() {
+        let coordinator = Coordinator::new();
+
+        let error = coordinator
+            .admit_child(&child_with_execution(
+                "child-a",
+                0,
+                ChildExecutionSpec {
+                    transport: Some(CoordinatorTransport::RemoteBridge),
+                    ..ChildExecutionSpec::default()
+                },
+            ))
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            CoordinatorError::LaunchContractRejected(
+                LaunchContractRejection::UnsupportedTransport {
+                    requested: CoordinatorTransport::RemoteBridge
+                }
+            )
+        ));
+    }
+
+    #[test]
+    fn admit_child_rejects_unsupported_isolation_requests_fail_closed() {
+        let coordinator = Coordinator::new();
+
+        let repository_error = coordinator
+            .admit_child(&child_with_execution(
+                "child-a",
+                0,
+                ChildExecutionSpec {
+                    repository_id: Some("repo-1".to_string()),
+                    ..ChildExecutionSpec::default()
+                },
+            ))
+            .unwrap_err();
+        assert!(matches!(
+            repository_error,
+            CoordinatorError::LaunchContractRejected(
+                LaunchContractRejection::UnsupportedIsolation { field, requested }
+            ) if field == "repository_id" && requested == "repo-1"
+        ));
+
+        let sandbox_error = coordinator
+            .admit_child(&child_with_execution(
+                "child-b",
+                1,
+                ChildExecutionSpec {
+                    sandbox_mode: Some("clone".to_string()),
+                    ..ChildExecutionSpec::default()
+                },
+            ))
+            .unwrap_err();
+        assert!(matches!(
+            sandbox_error,
+            CoordinatorError::LaunchContractRejected(
+                LaunchContractRejection::UnsupportedIsolation { field, requested }
+            ) if field == "sandbox_mode" && requested == "clone"
+        ));
+    }
+
+    #[test]
+    fn admit_child_rejects_unsupported_permission_broker_requests_fail_closed() {
+        let coordinator = Coordinator::new();
+
+        let error = coordinator
+            .admit_child(&child_with_execution(
+                "child-a",
+                0,
+                ChildExecutionSpec {
+                    permission_broker: Some("child_owned".to_string()),
+                    ..ChildExecutionSpec::default()
+                },
+            ))
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            CoordinatorError::LaunchContractRejected(
+                LaunchContractRejection::UnsupportedPermissionBroker { reason }
+            ) if reason == "child_owned"
+        ));
+    }
+
+    #[test]
+    fn cancel_envelope_moves_child_into_cancelling_until_terminal_resolution() {
+        let coordinator = Coordinator::new();
+        let child_id = ChildAgentId("child-a".to_string());
+        coordinator.admit_child(&child("child-a", 0)).unwrap();
+        coordinator
+            .apply_envelope(&MessageEnvelope {
+                meta: EnvelopeMeta {
+                    coordinator_id: coordinator.coordinator_id().to_string(),
+                    child_id: Some(child_id.clone()),
+                    sequence: 1,
+                    message_id: "dispatch-msg".to_string(),
+                    correlation_id: "corr-a".to_string(),
+                    sender: LogicalEndpoint::coordinator(coordinator.coordinator_id().to_string()),
+                    recipient: LogicalEndpoint::child(
+                        coordinator.coordinator_id().to_string(),
+                        child_id.clone(),
+                    ),
+                    sent_at: Utc::now(),
+                    transport: CoordinatorTransport::InProcess,
+                },
+                payload: CoordinatorMessage::DispatchChild(child("child-a", 0)),
+            })
+            .unwrap();
+
+        coordinator
+            .apply_envelope(&MessageEnvelope {
+                meta: EnvelopeMeta {
+                    coordinator_id: coordinator.coordinator_id().to_string(),
+                    child_id: Some(child_id.clone()),
+                    sequence: 2,
+                    message_id: "cancel-msg".to_string(),
+                    correlation_id: "corr-a".to_string(),
+                    sender: LogicalEndpoint::coordinator(coordinator.coordinator_id().to_string()),
+                    recipient: LogicalEndpoint::child(
+                        coordinator.coordinator_id().to_string(),
+                        child_id.clone(),
+                    ),
+                    sent_at: Utc::now(),
+                    transport: CoordinatorTransport::InProcess,
+                },
+                payload: CoordinatorMessage::CancelChild {
+                    reason: CancellationReason::ParentRequested,
+                },
+            })
+            .unwrap();
+
+        let record = coordinator.child_record(&child_id).unwrap().unwrap();
+        assert_eq!(record.state, ChildState::Cancelling);
+
+        let latest_event = coordinator.event_log().unwrap().pop().unwrap();
+        assert!(matches!(
+            latest_event,
+            CoordinatorEvent::ChildStateChanged { state: ChildState::Cancelling, .. }
+        ));
+    }
+
+    #[test]
+    fn duplicate_redelivery_does_not_duplicate_visible_events() {
+        let coordinator = Coordinator::new();
+        let child_id = ChildAgentId("child-a".to_string());
+        coordinator.admit_child(&child("child-a", 0)).unwrap();
+
+        let completed = MessageEnvelope {
+            meta: EnvelopeMeta {
+                coordinator_id: coordinator.coordinator_id().to_string(),
+                child_id: Some(child_id.clone()),
+                sequence: 5,
+                message_id: "terminal-msg".to_string(),
+                correlation_id: "corr-a".to_string(),
+                sender: LogicalEndpoint::child(
+                    coordinator.coordinator_id().to_string(),
+                    child_id.clone(),
+                ),
+                recipient: LogicalEndpoint::coordinator_child(
+                    coordinator.coordinator_id().to_string(),
+                    child_id.clone(),
+                ),
+                sent_at: Utc::now(),
+                transport: CoordinatorTransport::Mailbox,
+            },
+            payload: CoordinatorMessage::ChildCompleted {
+                result: ChildExecutionResult {
+                    session_id: "session-a".to_string(),
+                    tool_result: ToolResult {
+                        success: true,
+                        output: "done".to_string(),
+                        error: None,
+                        structured: None,
+                    },
+                    status: ChildTerminalStatus::Succeeded,
+                },
+            },
+        };
+
+        coordinator.apply_envelope(&completed).unwrap();
+        let event_count_after_first = coordinator.event_log().unwrap().len();
+        coordinator.apply_envelope(&completed).unwrap();
+        let events = coordinator.event_log().unwrap();
+
+        assert_eq!(events.len(), event_count_after_first);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    CoordinatorEvent::ChildStateChanged {
+                        state: ChildState::Completed,
+                        child_id,
+                        ..
+                    } if child_id == "child-a"
+                ))
+                .count(),
+            1
+        );
     }
 
     #[tokio::test]
@@ -2674,7 +3406,7 @@ mod tests {
             .child_record(&ChildAgentId("child-a".to_string()))
             .expect("registry should be readable")
             .expect("child should remain inspectable");
-        assert_eq!(final_record.state, ChildState::Succeeded);
+        assert_eq!(final_record.state, ChildState::Completed);
         assert_eq!(final_record.session_id.as_deref(), Some("session-child-a"));
     }
 
@@ -2829,6 +3561,7 @@ mod tests {
                     prompt: format!("task for {name}"),
                     context: None,
                     launch_index: u32::try_from(i).unwrap_or(u32::MAX),
+                    execution: None,
                 })
                 .collect(),
             fan_in: FanInPolicy::AllMustSucceed,

--- a/clients/agent-runtime/src/agent/mailbox.rs
+++ b/clients/agent-runtime/src/agent/mailbox.rs
@@ -236,6 +236,8 @@ impl SqliteMailboxStore {
             CoordinatorMessage::CancelChild { .. } => "cancel_child",
             CoordinatorMessage::ChildStarted { .. } => "child_started",
             CoordinatorMessage::ChildProgress { .. } => "child_progress",
+            CoordinatorMessage::RequestApproval { .. } => "request_approval",
+            CoordinatorMessage::ResolveApproval { .. } => "resolve_approval",
             CoordinatorMessage::ChildCompleted { .. } => "child_completed",
             CoordinatorMessage::ChildFailed { .. } => "child_failed",
             CoordinatorMessage::ChildCancelled { .. } => "child_cancelled",
@@ -777,6 +779,7 @@ mod tests {
             prompt: format!("prompt-{child_id}"),
             context: None,
             launch_index,
+            execution: None,
         }
     }
 

--- a/clients/agent-runtime/src/bridge/mod.rs
+++ b/clients/agent-runtime/src/bridge/mod.rs
@@ -1,0 +1,91 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BridgeProtocolVersion {
+    V1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BridgeTransportKind {
+    Sse,
+    Websocket,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteBridgeRequest {
+    pub protocol_version: BridgeProtocolVersion,
+    pub transport: BridgeTransportKind,
+    pub session_scope: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RemoteBridgeAvailability {
+    Deferred,
+    Rejected { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BridgeEnvelope {
+    pub version: BridgeProtocolVersion,
+    pub session_scope: String,
+    pub sequence: u64,
+    pub transport: BridgeTransportKind,
+    pub kind: String,
+    pub payload: serde_json::Value,
+}
+
+impl BridgeEnvelope {
+    pub fn to_sse_frame(&self) -> anyhow::Result<String> {
+        Ok(format!(
+            "event: {}\nid: {}\ndata: {}\n\n",
+            self.kind,
+            self.sequence,
+            serde_json::to_string(self)?
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bridge_envelope_serializes_metadata_only_seam() {
+        let envelope = BridgeEnvelope {
+            version: BridgeProtocolVersion::V1,
+            session_scope: "sess-1".to_string(),
+            sequence: 7,
+            transport: BridgeTransportKind::Sse,
+            kind: "validation_failed".to_string(),
+            payload: serde_json::json!({"reason": "deferred"}),
+        };
+        let frame = envelope.to_sse_frame().unwrap();
+        assert!(frame.contains("event: validation_failed"));
+        assert!(frame.contains("\"session_scope\":\"sess-1\""));
+    }
+
+    #[test]
+    fn remote_bridge_request_and_availability_remain_metadata_only() {
+        let request = RemoteBridgeRequest {
+            protocol_version: BridgeProtocolVersion::V1,
+            transport: BridgeTransportKind::Websocket,
+            session_scope: "scope-1".to_string(),
+        };
+        let availability = RemoteBridgeAvailability::Rejected {
+            reason: "remote bridge transport is deferred in this slice".to_string(),
+        };
+
+        let request_json = serde_json::to_value(&request).unwrap();
+        let availability_json = serde_json::to_value(&availability).unwrap();
+
+        assert_eq!(request_json["transport"], "websocket");
+        assert_eq!(availability_json["kind"], "rejected");
+        assert!(availability_json["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("deferred"));
+    }
+}

--- a/clients/agent-runtime/src/gateway/mod.rs
+++ b/clients/agent-runtime/src/gateway/mod.rs
@@ -1682,6 +1682,33 @@ async fn update_session_activity_if_persisted(
     }
 }
 
+async fn finalize_generated_session_if_needed(
+    state: &AppState,
+    session_id: &str,
+    session_source: webhook_dispatch::WebhookSessionSource,
+) {
+    if !matches!(
+        session_source,
+        webhook_dispatch::WebhookSessionSource::Generated
+    ) {
+        return;
+    }
+
+    if let Err(error) = state.mem.end_session(session_id).await {
+        tracing::debug!("generated session end best-effort failed: {error}");
+        return;
+    }
+
+    let workspace_dir = state.config.lock().workspace_dir.clone();
+    if let Err(error) = crate::memory::record_session_completion(&workspace_dir) {
+        tracing::debug!("dream session counter update failed: {error}");
+        return;
+    }
+    if let Err(error) = crate::memory::run_dream_if_triggered(&workspace_dir) {
+        tracing::debug!("dream consolidation after generated session skipped: {error}");
+    }
+}
+
 fn webhook_duplicate_response(idempotency_key: &str) -> WebhookResponse {
     tracing::info!(
         idempotency_key_fingerprint = %fingerprint_idempotency_key(idempotency_key),

--- a/clients/agent-runtime/src/lib.rs
+++ b/clients/agent-runtime/src/lib.rs
@@ -43,6 +43,7 @@ pub mod agent;
 pub mod approval;
 pub mod auth;
 pub mod bootstrap;
+pub mod bridge;
 pub mod capabilities;
 pub mod channels;
 pub mod config;

--- a/clients/agent-runtime/src/memory/dream.rs
+++ b/clients/agent-runtime/src/memory/dream.rs
@@ -1,0 +1,435 @@
+use anyhow::Result;
+use chrono::{Duration, Local, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DREAM_STATE_FILE: &str = "dream_state.json";
+const DREAM_LOCK_FILE: &str = "dream.lock";
+const DREAM_MEMORY_LINE_BUDGET: usize = 200;
+const DREAM_MEMORY_BYTE_BUDGET: usize = 25 * 1024;
+const DREAM_SESSION_TRIGGER_COUNT: u64 = 5;
+const DREAM_TIME_TRIGGER_HOURS: i64 = 24;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DreamTriggerReason {
+    TimeElapsed,
+    SessionCount,
+    Manual,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DreamRunStatus {
+    Skipped,
+    Running,
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DreamLockState {
+    Acquired,
+    Busy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DreamPhase {
+    Orientation,
+    RecentSignalCollection,
+    Consolidation,
+    PruneIndex,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DreamPhaseResult {
+    pub phase: DreamPhase,
+    pub summary: String,
+    pub touched_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DreamLaunchContract {
+    pub read_only_project_access: bool,
+    pub writable_roots: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryConsolidationReport {
+    pub trigger_reason: DreamTriggerReason,
+    pub status: DreamRunStatus,
+    pub lock_state: DreamLockState,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    pub phases: Vec<DreamPhaseResult>,
+    pub normalized_dates: u64,
+    pub duplicates_removed: u64,
+    pub retained_lines: usize,
+    pub launch_contract: DreamLaunchContract,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct DreamState {
+    last_successful_run_at: Option<String>,
+    sessions_since_last_run: u64,
+    last_report: Option<MemoryConsolidationReport>,
+}
+
+pub fn run_if_triggered(workspace_dir: &Path) -> Result<Option<MemoryConsolidationReport>> {
+    let state = load_state(workspace_dir)?;
+    let Some(trigger_reason) = due_trigger_reason(&state)? else {
+        return Ok(None);
+    };
+    run_now(workspace_dir, trigger_reason)
+}
+
+pub fn run_now(
+    workspace_dir: &Path,
+    trigger_reason: DreamTriggerReason,
+) -> Result<Option<MemoryConsolidationReport>> {
+    let Some(lock_guard) = DreamLockGuard::acquire(workspace_dir)? else {
+        return Ok(Some(MemoryConsolidationReport {
+            trigger_reason,
+            status: DreamRunStatus::Skipped,
+            lock_state: DreamLockState::Busy,
+            started_at: Utc::now().to_rfc3339(),
+            finished_at: Some(Utc::now().to_rfc3339()),
+            phases: vec![],
+            normalized_dates: 0,
+            duplicates_removed: 0,
+            retained_lines: 0,
+            launch_contract: launch_contract(workspace_dir),
+        }));
+    };
+
+    let started_at = Utc::now().to_rfc3339();
+    let memory_dir = workspace_dir.join("memory");
+    fs::create_dir_all(&memory_dir)?;
+    let core_path = workspace_dir.join("MEMORY.md");
+
+    let mut phases = Vec::new();
+    let touched = vec![display_path(&core_path), display_path(&memory_dir)];
+    phases.push(DreamPhaseResult {
+        phase: DreamPhase::Orientation,
+        summary: "Scanned memory root, core memory file, and recent signal sources.".to_string(),
+        touched_files: touched.clone(),
+    });
+
+    let recent_signal_files = recent_memory_files(&memory_dir)?;
+    phases.push(DreamPhaseResult {
+        phase: DreamPhase::RecentSignalCollection,
+        summary: format!(
+            "Collected {} recent memory log files.",
+            recent_signal_files.len()
+        ),
+        touched_files: recent_signal_files
+            .iter()
+            .map(|path| display_path(path))
+            .collect(),
+    });
+
+    let existing = if core_path.exists() {
+        fs::read_to_string(&core_path)?
+    } else {
+        "# Long-Term Memory\n\n".to_string()
+    };
+    let mut normalized_dates = 0_u64;
+    let mut merged_lines = extract_memory_lines(&existing);
+    for file in &recent_signal_files {
+        let content = fs::read_to_string(file)?;
+        for line in extract_memory_lines(&content) {
+            let normalized = normalize_relative_dates(&line, &mut normalized_dates);
+            merged_lines.push(normalized);
+        }
+    }
+    phases.push(DreamPhaseResult {
+        phase: DreamPhase::Consolidation,
+        summary: format!(
+            "Merged {} candidate memory lines into the consolidation set.",
+            merged_lines.len()
+        ),
+        touched_files: vec![display_path(&core_path)],
+    });
+
+    let deduped = dedupe_preserving_order(merged_lines);
+    let duplicates_removed = deduped.removed;
+    let pruned = prune_to_budget(&deduped.lines);
+    let retained_lines = pruned.len();
+
+    let mut rendered = String::from("# Long-Term Memory\n\n");
+    for line in &pruned {
+        rendered.push_str("- ");
+        rendered.push_str(line);
+        rendered.push('\n');
+    }
+    fs::write(&core_path, rendered)?;
+
+    phases.push(DreamPhaseResult {
+        phase: DreamPhase::PruneIndex,
+        summary: format!(
+            "Pruned duplicates and enforced {DREAM_MEMORY_LINE_BUDGET} line / {DREAM_MEMORY_BYTE_BUDGET} byte budget."
+        ),
+        touched_files: vec![display_path(&core_path)],
+    });
+
+    let report = MemoryConsolidationReport {
+        trigger_reason,
+        status: DreamRunStatus::Completed,
+        lock_state: DreamLockState::Acquired,
+        started_at,
+        finished_at: Some(Utc::now().to_rfc3339()),
+        phases,
+        normalized_dates,
+        duplicates_removed,
+        retained_lines,
+        launch_contract: launch_contract(workspace_dir),
+    };
+
+    let mut state = load_state(workspace_dir)?;
+    state.last_successful_run_at = report.finished_at.clone();
+    state.sessions_since_last_run = 0;
+    state.last_report = Some(report.clone());
+    store_state(workspace_dir, &state)?;
+    drop(lock_guard);
+
+    Ok(Some(report))
+}
+
+pub fn record_session_completion(workspace_dir: &Path) -> Result<u64> {
+    let mut state = load_state(workspace_dir)?;
+    state.sessions_since_last_run = state.sessions_since_last_run.saturating_add(1);
+    let count = state.sessions_since_last_run;
+    store_state(workspace_dir, &state)?;
+    Ok(count)
+}
+
+fn due_trigger_reason(state: &DreamState) -> Result<Option<DreamTriggerReason>> {
+    if state.sessions_since_last_run >= DREAM_SESSION_TRIGGER_COUNT {
+        return Ok(Some(DreamTriggerReason::SessionCount));
+    }
+
+    let Some(last_run_at) = state.last_successful_run_at.as_deref() else {
+        return Ok(Some(DreamTriggerReason::TimeElapsed));
+    };
+
+    let parsed = chrono::DateTime::parse_from_rfc3339(last_run_at)?.with_timezone(&Utc);
+    if Utc::now().signed_duration_since(parsed) >= Duration::hours(DREAM_TIME_TRIGGER_HOURS) {
+        return Ok(Some(DreamTriggerReason::TimeElapsed));
+    }
+
+    Ok(None)
+}
+
+fn extract_memory_lines(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| line.trim_start_matches("- ").trim().to_string())
+        .collect()
+}
+
+fn normalize_relative_dates(line: &str, counter: &mut u64) -> String {
+    let today = Local::now().format("%Y-%m-%d").to_string();
+    let yesterday = (Local::now() - Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+    let tomorrow = (Local::now() + Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+
+    let mut normalized = line.to_string();
+    for (needle, replacement) in [
+        (" today", format!(" on {today}")),
+        (" yesterday", format!(" on {yesterday}")),
+        (" tomorrow", format!(" on {tomorrow}")),
+    ] {
+        if normalized.contains(needle) {
+            normalized = normalized.replace(needle, &replacement);
+            *counter = counter.saturating_add(1);
+        }
+    }
+    normalized
+}
+
+struct DedupedLines {
+    lines: Vec<String>,
+    removed: u64,
+}
+
+fn dedupe_preserving_order(lines: Vec<String>) -> DedupedLines {
+    let mut seen = BTreeSet::new();
+    let mut kept = Vec::new();
+    let mut removed = 0_u64;
+    for line in lines {
+        let key = line.to_ascii_lowercase();
+        if seen.insert(key) {
+            kept.push(line);
+        } else {
+            removed = removed.saturating_add(1);
+        }
+    }
+    DedupedLines {
+        lines: kept,
+        removed,
+    }
+}
+
+fn prune_to_budget(lines: &[String]) -> Vec<String> {
+    let mut kept = Vec::new();
+    let mut bytes = "# Long-Term Memory\n\n".len();
+    for line in lines.iter().rev() {
+        let projected = bytes + line.len() + 3;
+        if kept.len() >= DREAM_MEMORY_LINE_BUDGET || projected > DREAM_MEMORY_BYTE_BUDGET {
+            continue;
+        }
+        kept.push(line.clone());
+        bytes = projected;
+    }
+    kept.reverse();
+    kept
+}
+
+fn recent_memory_files(memory_dir: &Path) -> Result<Vec<PathBuf>> {
+    if !memory_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut files: Vec<PathBuf> = fs::read_dir(memory_dir)?
+        .filter_map(|entry| entry.ok().map(|value| value.path()))
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("md"))
+        .collect();
+    files.sort();
+    if files.len() > 5 {
+        files = files.split_off(files.len() - 5);
+    }
+    Ok(files)
+}
+
+fn launch_contract(workspace_dir: &Path) -> DreamLaunchContract {
+    DreamLaunchContract {
+        read_only_project_access: true,
+        writable_roots: vec![
+            display_path(&workspace_dir.join("MEMORY.md")),
+            display_path(&workspace_dir.join("memory")),
+            display_path(&workspace_dir.join("state")),
+        ],
+    }
+}
+
+fn dream_state_path(workspace_dir: &Path) -> PathBuf {
+    workspace_dir.join("state").join(DREAM_STATE_FILE)
+}
+
+fn dream_lock_path(workspace_dir: &Path) -> PathBuf {
+    workspace_dir.join("state").join(DREAM_LOCK_FILE)
+}
+
+fn load_state(workspace_dir: &Path) -> Result<DreamState> {
+    let path = dream_state_path(workspace_dir);
+    if !path.exists() {
+        return Ok(DreamState::default());
+    }
+    let raw = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&raw).unwrap_or_default())
+}
+
+fn store_state(workspace_dir: &Path, state: &DreamState) -> Result<()> {
+    let path = dream_state_path(workspace_dir);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_vec_pretty(state)?)?;
+    Ok(())
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy().to_string()
+}
+
+struct DreamLockGuard {
+    path: PathBuf,
+}
+
+impl DreamLockGuard {
+    fn acquire(workspace_dir: &Path) -> Result<Option<Self>> {
+        let path = dream_lock_path(workspace_dir);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(_) => Ok(Some(Self { path })),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+impl Drop for DreamLockGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn session_trigger_fires_after_five_sessions() {
+        let tmp = TempDir::new().unwrap();
+        for _ in 0..5 {
+            record_session_completion(tmp.path()).unwrap();
+        }
+
+        let report = run_if_triggered(tmp.path()).unwrap().unwrap();
+        assert_eq!(report.trigger_reason, DreamTriggerReason::SessionCount);
+        assert_eq!(report.status, DreamRunStatus::Completed);
+    }
+
+    #[test]
+    fn time_trigger_fires_without_prior_state() {
+        let tmp = TempDir::new().unwrap();
+        let report = run_if_triggered(tmp.path()).unwrap().unwrap();
+        assert_eq!(report.trigger_reason, DreamTriggerReason::TimeElapsed);
+    }
+
+    #[test]
+    fn lock_prevents_concurrent_runs() {
+        let tmp = TempDir::new().unwrap();
+        let _guard = DreamLockGuard::acquire(tmp.path()).unwrap().unwrap();
+        let report = run_now(tmp.path(), DreamTriggerReason::Manual)
+            .unwrap()
+            .unwrap();
+        assert_eq!(report.lock_state, DreamLockState::Busy);
+        assert_eq!(report.status, DreamRunStatus::Skipped);
+    }
+
+    #[test]
+    fn dream_normalizes_relative_dates_and_prunes_duplicates() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("memory")).unwrap();
+        fs::write(
+            tmp.path().join("memory").join("2026-04-22.md"),
+            "# Daily Log\n\n- Met user today\n- Met user today\n- Reviewed roadmap yesterday\n",
+        )
+        .unwrap();
+
+        let report = run_now(tmp.path(), DreamTriggerReason::Manual)
+            .unwrap()
+            .unwrap();
+        let memory = fs::read_to_string(tmp.path().join("MEMORY.md")).unwrap();
+
+        assert!(report.normalized_dates >= 2);
+        assert!(report.duplicates_removed >= 1);
+        assert!(memory.contains("on "));
+    }
+}

--- a/clients/agent-runtime/src/memory/mod.rs
+++ b/clients/agent-runtime/src/memory/mod.rs
@@ -17,6 +17,7 @@ pub use backend::{
     classify_memory_backend, default_memory_backend_key, memory_backend_profile,
     selectable_memory_backends, MemoryBackendKind, MemoryBackendProfile,
 };
+#[allow(unused_imports)]
 pub use dream::{
     record_session_completion, run_if_triggered as run_dream_if_triggered,
     run_now as run_dream_now, DreamLaunchContract, DreamLockState, DreamPhase, DreamPhaseResult,

--- a/clients/agent-runtime/src/memory/mod.rs
+++ b/clients/agent-runtime/src/memory/mod.rs
@@ -1,5 +1,6 @@
 pub mod backend;
 pub mod chunker;
+pub mod dream;
 pub mod embeddings;
 pub mod hygiene;
 pub mod lucid;
@@ -15,6 +16,11 @@ pub mod vector;
 pub use backend::{
     classify_memory_backend, default_memory_backend_key, memory_backend_profile,
     selectable_memory_backends, MemoryBackendKind, MemoryBackendProfile,
+};
+pub use dream::{
+    record_session_completion, run_if_triggered as run_dream_if_triggered,
+    run_now as run_dream_now, DreamLaunchContract, DreamLockState, DreamPhase, DreamPhaseResult,
+    DreamRunStatus, DreamTriggerReason, MemoryConsolidationReport,
 };
 pub use lucid::LucidMemory;
 pub use markdown::MarkdownMemory;
@@ -87,6 +93,9 @@ pub fn create_memory(
     // Best-effort memory hygiene/retention pass (throttled by state file).
     if let Err(e) = hygiene::run_if_due(&effective_config, workspace_dir) {
         tracing::warn!("memory hygiene skipped: {e}");
+    }
+    if let Err(e) = dream::run_if_triggered(workspace_dir) {
+        tracing::warn!("dream consolidation skipped: {e}");
     }
 
     // If snapshot_on_hygiene is enabled, export core memories during hygiene.

--- a/clients/agent-runtime/src/tools/delegate.rs
+++ b/clients/agent-runtime/src/tools/delegate.rs
@@ -279,6 +279,7 @@ impl DelegateTool {
                 prompt: prompt.to_string(),
                 context: context.map(ToOwned::to_owned),
                 launch_index: 0,
+                execution: None,
             }],
             fan_in: FanInPolicy::AllMustSucceed,
         };
@@ -1228,6 +1229,56 @@ mod tests {
         assert!(result.success);
         assert_eq!(result.output, "mailbox-session-ok");
         assert_eq!(result.structured, Some(json!({"mode": "mailbox"})));
+    }
+
+    #[tokio::test]
+    async fn supervised_single_child_delegate_remains_compatible_with_shared_orchestration_contract() {
+        let tmp = TempDir::new().unwrap();
+        let mut agents = HashMap::new();
+        agents.insert(
+            "code_agent".to_string(),
+            DelegateAgentConfig {
+                provider: "openrouter".to_string(),
+                model: "anthropic/claude-sonnet-4-20250514".to_string(),
+                system_prompt: None,
+                api_key: Some("test-key".to_string()),
+                temperature: None,
+                max_depth: 3,
+                execution_mode: DelegateExecutionMode::Session,
+                max_iterations: None,
+                timeout_ms: None,
+            },
+        );
+
+        let service = Arc::new(SupervisedOrchestrationService::new());
+        let mailbox = Arc::new(
+            SqliteMailboxStore::from_db_path(tmp.path().join("state/orchestration/mailbox.db"))
+                .unwrap(),
+        );
+        let runner: Arc<dyn CoordinatorChildRunner> = Arc::new(MailboxBackedChildRunner::new(
+            mailbox,
+            Arc::new(SuccessfulRunner),
+            Arc::new(MailboxWakeupHub::default()),
+        ));
+        let tool = DelegateTool::with_supervised_executor(
+            agents,
+            None,
+            test_security(),
+            test_base_config(&tmp),
+            Arc::clone(&service),
+            runner,
+        );
+
+        let result = tool
+            .execute(json!({"agent": "code_agent", "prompt": "write tests"}))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        let handles = service.registered_handles();
+        assert_eq!(handles.len(), 1, "single-child delegate should use one orchestration handle");
+        let snapshot = service.inspect(&handles[0]).unwrap().expect("snapshot for shared handle");
+        assert_eq!(snapshot.children.len(), 1);
     }
 
     #[tokio::test]

--- a/clients/agent-runtime/src/tools/delegate.rs
+++ b/clients/agent-runtime/src/tools/delegate.rs
@@ -1232,7 +1232,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn supervised_single_child_delegate_remains_compatible_with_shared_orchestration_contract() {
+    async fn supervised_single_child_delegate_remains_compatible_with_shared_orchestration_contract(
+    ) {
         let tmp = TempDir::new().unwrap();
         let mut agents = HashMap::new();
         agents.insert(
@@ -1276,8 +1277,15 @@ mod tests {
 
         assert!(result.success);
         let handles = service.registered_handles();
-        assert_eq!(handles.len(), 1, "single-child delegate should use one orchestration handle");
-        let snapshot = service.inspect(&handles[0]).unwrap().expect("snapshot for shared handle");
+        assert_eq!(
+            handles.len(),
+            1,
+            "single-child delegate should use one orchestration handle"
+        );
+        let snapshot = service
+            .inspect(&handles[0])
+            .unwrap()
+            .expect("snapshot for shared handle");
         assert_eq!(snapshot.children.len(), 1);
     }
 

--- a/clients/agent-runtime/src/tools/delegate_cancel.rs
+++ b/clients/agent-runtime/src/tools/delegate_cancel.rs
@@ -224,6 +224,7 @@ mod tests {
                 prompt: "do it".into(),
                 context: None,
                 launch_index: 0,
+                execution: None,
             }],
             fan_in: FanInPolicy::AllMustSucceed,
         }
@@ -388,5 +389,31 @@ mod tests {
             "already_terminal",
             "expected already_terminal disposition"
         );
+    }
+
+    #[tokio::test]
+    async fn cancel_result_preserves_cancelling_and_terminal_visibility() {
+        let svc = service();
+        let runner = Arc::new(WaitForCancellationRunner);
+        let receipt = svc.launch(one_child_request(), runner).await.unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let result = tool(Arc::clone(&svc))
+            .execute(serde_json::json!({ "handle": receipt.handle.0 }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "expected success, got: {:?}", result.error);
+        let structured = result.structured.unwrap();
+        assert_eq!(
+            structured["cancel_result"]["snapshot"]["children"][0]["state"],
+            "cancelled"
+        );
+        assert!(structured["cancel_result"]["snapshot"]["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|event| event["kind"].as_str().unwrap_or("").contains("cancelling")));
     }
 }

--- a/clients/agent-runtime/src/tools/delegate_inspect.rs
+++ b/clients/agent-runtime/src/tools/delegate_inspect.rs
@@ -273,6 +273,7 @@ mod tests {
                 prompt: "do it".into(),
                 context: None,
                 launch_index: 0,
+                execution: None,
             }],
             fan_in: FanInPolicy::AllMustSucceed,
         };
@@ -313,6 +314,7 @@ mod tests {
                 prompt: "do it".into(),
                 context: None,
                 launch_index: 0,
+                execution: None,
             }],
             fan_in: FanInPolicy::AllMustSucceed,
         };
@@ -358,6 +360,7 @@ mod tests {
                 prompt: "do it".into(),
                 context: None,
                 launch_index: 0,
+                execution: None,
             }],
             fan_in: FanInPolicy::AllMustSucceed,
         };
@@ -373,6 +376,56 @@ mod tests {
         assert!(result.success, "expected success, got: {:?}", result.error);
         let structured = result.structured.unwrap();
         assert_eq!(structured["snapshot"]["handle"], receipt.handle.0);
+
+        release.notify_waiters();
+    }
+
+    #[tokio::test]
+    async fn inspect_surfaces_requested_vs_enforced_metadata_and_lifecycle_events() {
+        let svc = Arc::new(SupervisedOrchestrationService::new());
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let runner = Arc::new(GatedRunner {
+            started: started.clone(),
+            release: release.clone(),
+        });
+
+        let request = CoordinatorLaunchRequest {
+            parent_session_id: None,
+            children: vec![ChildLaunchRequest {
+                child_id: ChildAgentId("c1".into()),
+                agent_name: "AgentA".into(),
+                prompt: "do it".into(),
+                context: None,
+                launch_index: 0,
+                execution: Some(crate::agent::coordinator::ChildExecutionSpec {
+                    transport: Some(CoordinatorTransport::Mailbox),
+                    sandbox_mode: Some("workspace_write".into()),
+                    read_only_project_access: true,
+                    ..crate::agent::coordinator::ChildExecutionSpec::default()
+                }),
+            }],
+            fan_in: FanInPolicy::AllMustSucceed,
+        };
+
+        let receipt = svc.launch(request, runner).await.unwrap();
+        started.notified().await;
+
+        let result = tool(Arc::clone(&svc))
+            .execute(serde_json::json!({ "handle": receipt.handle.0.clone() }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "expected success, got: {:?}", result.error);
+        let structured = result.structured.unwrap();
+        let execution = &structured["snapshot"]["children"][0]["execution"];
+        assert_eq!(execution["requested"]["transport"], "mailbox");
+        assert_eq!(execution["enforced"]["transport"], "mailbox");
+        assert_eq!(
+            execution["enforced"]["process_local_handle_authority"],
+            serde_json::json!(true)
+        );
+        assert!(structured["snapshot"]["events"].as_array().unwrap().len() >= 2);
 
         release.notify_waiters();
     }

--- a/clients/agent-runtime/src/tools/delegate_launch.rs
+++ b/clients/agent-runtime/src/tools/delegate_launch.rs
@@ -99,6 +99,33 @@ impl Tool for DelegateLaunchTool {
                             "context": {
                                 "type": "string",
                                 "description": "Optional context to prepend to the child's prompt."
+                            },
+                            "execution": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "description": "Optional execution metadata for isolation, transport, and model overrides.",
+                                "properties": {
+                                    "working_directory": { "type": "string" },
+                                    "sandbox_mode": { "type": "string" },
+                                    "repository_id": { "type": "string" },
+                                    "worktree_id": { "type": "string" },
+                                    "tool_allowlist": {
+                                        "type": "array",
+                                        "items": { "type": "string" }
+                                    },
+                                    "tool_denylist": {
+                                        "type": "array",
+                                        "items": { "type": "string" }
+                                    },
+                                    "provider_override": { "type": "string" },
+                                    "model_override": { "type": "string" },
+                                    "permission_broker": { "type": "string" },
+                                    "transport": {
+                                        "type": "string",
+                                        "enum": ["in_process", "mailbox", "remote_bridge"]
+                                    },
+                                    "read_only_project_access": { "type": "boolean" }
+                                }
                             }
                         }
                     }
@@ -176,6 +203,12 @@ impl Tool for DelegateLaunchTool {
                 .get("context")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
+            let execution = item
+                .get("execution")
+                .cloned()
+                .map(serde_json::from_value::<crate::agent::coordinator::ChildExecutionSpec>)
+                .transpose()
+                .map_err(|error| anyhow::anyhow!("invalid execution metadata: {error}"))?;
 
             child_requests.push(ChildLaunchRequest {
                 child_id: ChildAgentId(child_id),
@@ -183,6 +216,7 @@ impl Tool for DelegateLaunchTool {
                 prompt,
                 context,
                 launch_index: u32::try_from(launch_index).unwrap_or(u32::MAX),
+                execution,
             });
         }
 
@@ -417,5 +451,99 @@ mod tests {
             .unwrap();
         assert!(!result.success);
         assert!(result.error.is_some());
+    }
+
+    #[tokio::test]
+    async fn returns_requested_and_enforced_execution_metadata_in_initial_snapshot() {
+        let result = tool()
+            .execute(serde_json::json!({
+                "children": [
+                    {
+                        "child_id": "a",
+                        "agent_name": "AgentA",
+                        "prompt": "p",
+                        "execution": {
+                            "transport": "mailbox",
+                            "sandbox_mode": "workspace_write",
+                            "tool_allowlist": ["read"],
+                            "read_only_project_access": true,
+                            "working_directory": "/tmp/project"
+                        }
+                    }
+                ]
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "expected success, got: {:?}", result.error);
+        let structured = result.structured.expect("structured payload");
+        let execution = &structured["snapshot"]["children"][0]["execution"];
+        assert_eq!(execution["requested"]["transport"], "mailbox");
+        assert_eq!(execution["requested"]["sandbox_mode"], "workspace_write");
+        assert_eq!(
+            execution["requested"]["read_only_project_access"],
+            serde_json::json!(true)
+        );
+        assert_eq!(execution["enforced"]["transport"], "mailbox");
+        assert_eq!(
+            execution["enforced"]["process_local_handle_authority"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            execution["enforced"]["approval_broker_mode"],
+            "parent_owned_only"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_remote_bridge_requests_without_local_fallback() {
+        let result = tool()
+            .execute(serde_json::json!({
+                "children": [
+                    {
+                        "child_id": "a",
+                        "agent_name": "AgentA",
+                        "prompt": "p",
+                        "execution": {
+                            "transport": "remote_bridge"
+                        }
+                    }
+                ]
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("unsupported transport request"));
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_permission_broker_requests_fail_closed() {
+        let result = tool()
+            .execute(serde_json::json!({
+                "children": [
+                    {
+                        "child_id": "a",
+                        "agent_name": "AgentA",
+                        "prompt": "p",
+                        "execution": {
+                            "permission_broker": "child_owned"
+                        }
+                    }
+                ]
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("unsupported permission broker request"));
     }
 }

--- a/openspec/changes/archive/2026-04-22-2026-04-22-track-4-orchestration-parity-seam/design.md
+++ b/openspec/changes/archive/2026-04-22-2026-04-22-track-4-orchestration-parity-seam/design.md
@@ -1,0 +1,429 @@
+# Design: Track 4 Orchestration Parity and Bridge Seam
+
+## Technical Approach
+
+This slice keeps `clients/agent-runtime/src/agent/coordinator.rs` as the runtime-owned orchestration
+authority and finishes the contract around it instead of introducing a second orchestration layer.
+`SupervisedOrchestrationService` remains the parent-owned lifecycle registry for launch, inspect, and
+cancel; `MailboxBackedChildRunner` remains an internal delivery mechanism only; and the tool surface
+(`delegate_launch`, `delegate_inspect`, `delegate_cancel`, plus the compatibility path in
+`delegate`) is narrowed to one durable local contract.
+
+The main design move is to split **requested execution metadata** from **enforced guarantees** in the
+ read model, then thread that same normalized contract through the coordinator, mailbox envelopes,
+ and tool responses. That gives Track 4 a complete local lifecycle model while adding only the
+ fail-closed `remote_bridge` seam needed for Track 6.
+
+## Architecture Decisions
+
+### Decision: Keep orchestration authority in `SupervisedOrchestrationService` + `Coordinator`
+
+**Choice**: The orchestration contract lives in `agent/coordinator.rs`, with `SupervisedOrchestrationService`
+owning durable handles and live-parent authority, and `Coordinator` owning per-run child state,
+event ordering, approval state, and terminal outcome calculation.
+
+**Alternatives considered**:
+- Move handle/state ownership into `mailbox.rs`
+- Create a new orchestration store module for this slice
+- Let each tool assemble its own lifecycle state from mailbox rows
+
+**Rationale**: The current code already centralizes lifecycle transitions, dedupe, and read models in
+`Coordinator` and `SupervisedOrchestrationService`. Reusing that authority preserves the current
+reviewable shape, keeps mailbox persistence as transport support rather than authority, and matches
+the spec requirement that inspect/cancel fail closed after parent loss.
+
+### Decision: Treat mailbox as delivery + evidence, not lifecycle authority
+
+**Choice**: `MailboxBackedChildRunner` and `SqliteMailboxStore` stay responsible for internal
+control/lifecycle envelope delivery, at-least-once redelivery, leasing, ack/release, and terminal
+error recording, but the parent-visible lifecycle view comes only from coordinator-applied events and
+child records.
+
+**Alternatives considered**:
+- Read mailbox rows directly during `delegate_inspect`
+- Persist inspection state in mailbox tables and rebuild state from SQLite
+- Make mailbox rows the long-term source of truth for cancellation authority
+
+**Rationale**: The current mailbox code already supports at-least-once delivery while the
+coordinator already tracks dedupe via `(child_id, message_id)` and monotonic `sequence`. Keeping
+mailbox as transport-only satisfies deterministic visibility and prevents authority reconstruction
+after parent loss.
+
+### Decision: Normalize execution metadata into requested vs enforced substructures
+
+**Choice**: Replace the current single `ChildExecutionSpec` read-model exposure with a normalized
+contract that keeps the original requested fields and adds an explicit enforced/delivered summary.
+The requested side remains transport-agnostic; the enforced side reports what this slice actually
+guarantees for local execution.
+
+**Alternatives considered**:
+- Keep only `ChildExecutionSpec` and rely on docs to explain what is not enforced
+- Encode enforcement as free-form strings in `summary`
+- Add booleans per field directly onto `ChildLifecycleView`
+
+**Rationale**: The spec explicitly requires that inspection preserve requested metadata without
+overstating local enforcement. A two-part structure makes unsupported guarantees fail closed at
+launch time and makes delivered guarantees inspectable without ambiguity.
+
+### Decision: Represent approval propagation as parent-owned broker status only
+
+**Choice**: Approval remains modeled as coordinator-owned status (`None`, `Pending`, `Resolved`) and
+is surfaced as parent-visible broker state, but unsupported child escalation paths are rejected
+during launch/admission rather than delegated to children.
+
+**Alternatives considered**:
+- Add child-driven approval continuation flows in this slice
+- Introduce a new approval service for delegated sessions
+- Silently accept approval-related metadata and let children block later
+
+**Rationale**: The repo already has `approval/mod.rs` for local interactive approval and the
+coordinator already models `WaitingOnParent`. Extending that model into a fail-closed permission
+broker seam is enough for Track 4 parity and avoids pretending Track 6 delegation flows exist.
+
+### Decision: Model `remote_bridge` as an admitted transport enum with a rejected executor path
+
+**Choice**: Keep `CoordinatorTransport::RemoteBridge` and define a narrow runtime seam around it,
+but reject any launch that requests `remote_bridge` before runner dispatch. `bridge/mod.rs` remains
+type-only for protocol/session primitives and is not wired into active execution.
+
+**Alternatives considered**:
+- Remove `remote_bridge` until Track 6
+- Transparently downgrade `remote_bridge` to `mailbox`
+- Partially execute remote children through mailbox while calling them bridge-backed
+
+**Rationale**: The proposal/spec require one transport-agnostic contract and explicit fail-closed
+behavior. Keeping the enum and shared metadata shape avoids a second lifecycle model later, while
+early validation prevents accidental local fallback.
+
+## Data Flow
+
+### Launch / inspect / cancel composition
+
+```text
+delegate_launch
+  -> SupervisedOrchestrationService::launch(request, runner)
+       -> validate requested transport / approval / isolation contract
+       -> create OrchestrationHandle + ActiveRun entry
+       -> Coordinator::admit_child(...) for each child
+       -> spawn Coordinator::run_with_cancellation(...)
+       -> return initial OrchestrationSnapshot
+
+delegate_inspect
+  -> SupervisedOrchestrationService::inspect(handle)
+       -> read ActiveRun or Terminal entry
+       -> build snapshot from coordinator-owned child records + event visibility
+
+delegate_cancel
+  -> SupervisedOrchestrationService::cancel(handle)
+       -> verify handle belongs to live registry
+       -> cancel parent token
+       -> await join handle
+       -> store terminal snapshot
+```
+
+### Mailbox-backed local child flow
+
+Sequence diagram:
+
+```text
+Parent tool        OrchestrationService      Coordinator        MailboxRunner        SqliteMailbox      Child Runner
+    |                       |                    |                   |                    |                 |
+    | launch(children)      |                    |                   |                    |                 |
+    |---------------------->|                    |                   |                    |                 |
+    |                       | create handle      |                   |                    |                 |
+    |                       | spawn run -------->| admit + dispatch  |                    |                 |
+    |                       |                    | dispatch envelope->| enqueue ---------->|                 |
+    |                       |                    |                   | wake child          |                 |
+    |<----------------------| initial snapshot   |                   |                    |                 |
+    |                       |                    |                   | lease dispatch <----|                 |
+    |                       |                    |                   | delegated run ----------------------->|
+    |                       |                    |                   |<--------------------------------------|
+    |                       |                    |                   | enqueue response -->|                 |
+    |                       |                    | apply envelope <--| lease/ack response  |                 |
+    | inspect(handle)       |                    |                   |                    |                 |
+    |---------------------->| snapshot from coordinator state/events |                    |                 |
+    |<----------------------|                                                |             |                 |
+```
+
+### Fail-closed validation path
+
+```text
+requested child execution
+  -> normalize request
+  -> evaluate transport/isolation/approval broker requirements
+       -> supported local request? continue
+       -> unsupported stronger guarantee / remote_bridge / delegated approval? reject
+  -> no silent downgrade to mailbox or in_process
+```
+
+## Durable State / Storage Model
+
+### 1. Live orchestration handle registry
+
+**Location**: `SupervisedOrchestrationService.registry` in `agent/coordinator.rs`
+
+**Authority**:
+- `HashMap<OrchestrationHandle, RunEntry>` remains the only live authority for inspect/cancel
+- `RunEntry::Active` holds:
+  - `coordinator: Arc<Coordinator>`
+  - `cancel_token: CancellationToken`
+  - `join_handle: AsyncMutex<Option<JoinHandle<...>>>`
+  - original `CoordinatorLaunchRequest`
+- `RunEntry::Terminal` holds immutable terminal snapshot + terminal outcome for the lifetime of the
+  live parent runtime context
+
+**Durability boundary**:
+- Durable for the lifetime of the owning parent runtime process only
+- Not restart-recoverable
+- Unknown/stale handles fail closed after parent loss or service rebuild
+
+### 2. Child state and lifecycle visibility
+
+**Location**: `Coordinator.registry`, `Coordinator.outcomes`, `Coordinator.events`, and
+`Coordinator.applied_messages`
+
+**State model adjustments**:
+- Add an explicit public cancelling state to the read model, mapped from parent-requested
+  cancellation before terminal resolution
+- Keep terminal child states immutable once `Completed`, `Failed`, or `Cancelled`
+- Preserve stable `child_id`, `launch_index`, `session_id`, approval status, normalized execution
+  metadata, and terminal reason
+
+**Event visibility**:
+- Extend `OrchestrationSnapshot` with a bounded `events: Vec<LifecycleEventView>` or equivalent
+  parent-visible history derived from `Coordinator.events`
+- Event rows are correlated by handle and child id, ordered by coordinator `sequence`
+- Duplicate mailbox redelivery remains suppressed by `applied_messages`
+
+### 3. Mailbox/event persistence
+
+**Location**: `state/orchestration/mailbox.db` via `SqliteMailboxStore`
+
+**Tables already present**:
+- `mailbox_messages`
+- `mailbox_metadata`
+
+**Role in this slice**:
+- Persist in-flight internal orchestration envelopes
+- Support lease, ack, release, and terminal transport error recording
+- Never act as the source of truth for `delegate_inspect` or `delegate_cancel`
+
+**No new recovery model**:
+- No replay-based state rebuild
+- No reattachment after restart
+- No cross-parent authority reconstruction
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `clients/agent-runtime/src/agent/coordinator.rs` | Modify | Finalize orchestration contract types, add normalized execution metadata/read model, expose lifecycle event visibility, represent cancelling state, centralize fail-closed validation for transport/isolation/approval broker requests, and keep handle authority in `SupervisedOrchestrationService`. |
+| `clients/agent-runtime/src/agent/mailbox.rs` | Modify | Keep mailbox transport internal, document/store only lifecycle/control envelopes, and ensure transport metadata and dedupe semantics stay aligned with coordinator-owned sequencing. |
+| `clients/agent-runtime/src/tools/delegate_launch.rs` | Modify | Validate launch requests against normalized execution contract, reject unsupported `remote_bridge` and stronger-isolation/escalation requests, and return initial snapshot with requested/enforced metadata. |
+| `clients/agent-runtime/src/tools/delegate_inspect.rs` | Modify | Return coordinator-owned lifecycle snapshot including normalized execution metadata, approval broker status, and bounded lifecycle event visibility. |
+| `clients/agent-runtime/src/tools/delegate_cancel.rs` | Modify | Keep idempotent parent-owned cancel semantics and expose whether a new cancellation transition occurred. |
+| `clients/agent-runtime/src/tools/delegate.rs` | Modify | Preserve single-child compatibility while routing session-mode execution through the same normalized orchestration contract and rejecting unsupported deferred transport fields. |
+| `clients/agent-runtime/src/tools/mod.rs` | Modify | Keep shared service/runner wiring unchanged in shape, but ensure the same contract types are used by all delegate lifecycle tools. |
+| `clients/agent-runtime/src/bridge/mod.rs` | Modify | Narrow bridge primitives to the future transport seam: bridge transport descriptor, remote child request metadata, and validation reasons only; no live execution wiring. |
+| `clients/agent-runtime/src/lib.rs` | Modify | Re-export any newly public orchestration/bridge seam types if they must be visible outside the runtime crate. |
+| `openspec/changes/2026-04-22-track-4-orchestration-parity-seam/design.md` | Create | Technical design for this slice. |
+| `openspec/changes/2026-04-22-track-4-orchestration-parity-seam/state.yaml` | Modify | Mark design phase complete and advance to tasks. |
+
+## Interfaces / Contracts
+
+### Runtime orchestration contract placement
+
+The primary contract remains in `agent/coordinator.rs` and should be made explicit around three
+layers:
+
+1. **Launch input contract**: `CoordinatorLaunchRequest`, `ChildLaunchRequest`, normalized child
+   execution request metadata.
+2. **Runtime authority contract**: `OrchestrationHandle`, `SupervisedOrchestrationService`,
+   coordinator child/event state.
+3. **Inspection/cancel read model**: `OrchestrationSnapshot`, `CancelResult`, child/event views.
+
+### Proposed normalized execution metadata shape
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NormalizedExecutionRequest {
+    pub transport: CoordinatorTransport,
+    pub sandbox_mode: Option<String>,
+    pub repository_id: Option<String>,
+    pub worktree_id: Option<String>,
+    pub read_only_project_access: bool,
+    pub tool_allowlist: Vec<String>,
+    pub tool_denylist: Vec<String>,
+    pub provider_override: Option<String>,
+    pub model_override: Option<String>,
+    pub working_directory: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct EnforcedExecutionGuarantees {
+    pub transport: CoordinatorTransport,
+    pub process_local_handle_authority: bool,
+    pub mailbox_backed_delivery: bool,
+    pub repository_isolation_enforced: bool,
+    pub worktree_isolation_enforced: bool,
+    pub sandbox_clone_enforced: bool,
+    pub remote_bridge_connected: bool,
+    pub approval_broker_mode: ApprovalBrokerMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalBrokerMode {
+    None,
+    ParentOwnedOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChildExecutionMetadataView {
+    pub requested: NormalizedExecutionRequest,
+    pub enforced: EnforcedExecutionGuarantees,
+}
+```
+
+Design notes:
+- `requested.transport` defaults to `in_process` when omitted before normalization
+- `enforced.transport` is what actually ran; for this slice it can only be `in_process` or
+  `mailbox`
+- `remote_bridge_connected` is always `false` in this slice
+- stronger isolation flags remain `false` unless there is already concrete enforcement in the local
+  runtime path
+
+### Proposed lifecycle visibility additions
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChildStateView {
+    Queued,
+    Starting,
+    Running,
+    WaitingOnParent,
+    Cancelling,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LifecycleEventView {
+    pub sequence: u64,
+    pub child_id: String,
+    pub kind: String,
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct OrchestrationSnapshot {
+    pub handle: OrchestrationHandle,
+    pub parent_session_id: Option<String>,
+    pub state: CoordinatorStateView,
+    pub children: Vec<ChildLifecycleView>,
+    pub events: Vec<LifecycleEventView>,
+    pub outcome: Option<OrchestrationOutcomeView>,
+}
+```
+
+### Proposed launch validation contract
+
+Validation should occur before the service admits children into the run registry.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum LaunchContractRejection {
+    UnsupportedTransport { requested: CoordinatorTransport },
+    UnsupportedIsolation { field: String, requested: String },
+    UnsupportedPermissionBroker { reason: String },
+}
+```
+
+Behavior:
+- `remote_bridge` -> reject with `UnsupportedTransport`
+- unsupported repository/worktree/sandbox guarantees -> reject with `UnsupportedIsolation`
+- any child request that implies child-owned approval/escalation -> reject with
+  `UnsupportedPermissionBroker`
+- no fallback from rejected requests to weaker local execution
+
+### Bridge seam contract
+
+`bridge/mod.rs` should keep shared protocol/session primitives but add only the minimum request-side
+descriptor needed by orchestration types, for example:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteBridgeRequest {
+    pub protocol_version: BridgeProtocolVersion,
+    pub requested_transport: Option<BridgeTransportKind>,
+    pub session_scope: Option<String>,
+}
+```
+
+This type is metadata-only in this slice. It is referenced by normalized execution request metadata
+or validation output, but not consumed by an active child runner.
+
+## Approval Propagation and Fail-Closed Permission Broker Behavior
+
+1. Parent authority remains the only authority for approval-sensitive delegated activity.
+2. Child lifecycle can enter `WaitingOnParent` only for existing local approval events that the
+   parent runtime can observe and decide.
+3. Any requested launch mode that implies child-controlled escalation, remote approval relay, or a
+   brokered capability unavailable in-process is rejected before dispatch.
+4. Inspection may show `approval.status = pending/resolved` and `approval_broker_mode =
+   parent_owned_only`, but never a child-capable approval channel.
+5. Cancellation of a child waiting on approval remains parent-owned and transitions through
+   cancelling/terminal states using the same handle contract.
+
+## Test Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Launch normalization and fail-closed validation for `remote_bridge`, stronger isolation requests, and unsupported permission broker requests | Add focused tests in `delegate_launch.rs` and/or `coordinator.rs` that assert explicit rejection and no local fallback. |
+| Unit | Child lifecycle read model distinguishes `running`, `waiting_on_parent`, and `cancelling` | Extend coordinator tests to drive `RequestApproval`, `ResolveApproval`, `CancelChild`, and terminal envelopes and assert snapshot state transitions. |
+| Unit | Snapshot preserves requested metadata and reports enforced guarantees separately | Add snapshot tests around `SupervisedOrchestrationService::inspect` for both `in_process` and mailbox-backed children. |
+| Unit | Mailbox redelivery does not duplicate visible lifecycle events or terminal outcomes | Extend `mailbox.rs` / `coordinator.rs` redelivery tests to inspect the event view exposed by the service. |
+| Integration | `delegate_launch` -> `delegate_inspect` -> `delegate_cancel` share one handle contract for mailbox-backed runs | Reuse current tool-level async tests with shared `SupervisedOrchestrationService` and `MailboxBackedChildRunner`. |
+| Integration | Unknown/stale handles fail closed after service loss semantics | Add service-level tests asserting inspect/cancel return unknown/unavailable when a fresh service instance sees old mailbox state. |
+| Integration | Single-child `delegate` remains compatible | Extend `delegate.rs` session-mode tests to verify one-child success/failure semantics remain unchanged while using the supervised executor. |
+| E2E | None for this slice | Out of scope. No gateway/SSE/WebSocket execution is being delivered. |
+
+## Tradeoffs and Rejected Alternatives
+
+- **Mailbox as source of truth** was rejected because it would blur transport persistence with parent
+  authority, complicate deterministic inspection, and weaken fail-closed behavior after parent loss.
+- **Implementing a partial remote bridge now** was rejected because it would pull Track 6 transport,
+  auth, and recovery concerns into a Track 4 parity slice.
+- **Document-only metadata clarification** was rejected because the current surface already exposes
+  transport/isolation fields; without explicit requested/enforced separation, the runtime would still
+  overstate guarantees.
+- **Separate local vs remote orchestration contracts** was rejected because it would force a second
+  lifecycle model when Track 6 lands.
+
+## Migration / Rollout
+
+No migration required.
+
+This slice only adjusts runtime types, service validation, read models, and tool responses. Existing
+mailbox SQLite data remains transport state, not upgraded durable authority.
+
+## Rollback
+
+Rollback is straightforward because the seam is type-level and fail-closed:
+
+1. Remove requested/enforced metadata normalization and fall back to the current single execution
+   metadata structure.
+2. Remove explicit `remote_bridge` validation/reporting from tool and service launch paths.
+3. Keep local handle/inspect/cancel improvements that stand on their own, provided they do not depend
+   on bridge seam types.
+4. Leave mailbox schema unchanged, since no new durable authority tables are introduced.
+
+## Open Questions
+
+- [ ] Should lifecycle event visibility include the full bounded event list on every inspect result,
+      or only the latest event per child for this slice?
+- [ ] Should unsupported isolation guarantees be modeled as one generic rejection shape or distinct
+      typed reasons per field to simplify future Track 6/Track 7 evolution?

--- a/openspec/changes/archive/2026-04-22-2026-04-22-track-4-orchestration-parity-seam/proposal.md
+++ b/openspec/changes/archive/2026-04-22-2026-04-22-track-4-orchestration-parity-seam/proposal.md
@@ -1,0 +1,130 @@
+# Proposal: Track 4 Orchestration Parity and Bridge Seam
+
+## Intent
+
+Finish the reviewable runtime slice that turns the current Track 4 coordinator/mailbox/delegate
+work into a complete durable local orchestration contract, while carving only the minimum
+transport-agnostic seam needed so a future Track 6 remote bridge child can speak the same runtime
+contract.
+
+The current worktree already advances Track 4 materially: `clients/agent-runtime/src/agent/coordinator.rs`,
+`clients/agent-runtime/src/agent/mailbox.rs`, and the `delegate_launch` / `delegate_inspect` /
+`delegate_cancel` tools now expose multi-child orchestration handles, mailbox-backed internal
+delivery, inspection, and cancellation. The changed tool schema in
+`clients/agent-runtime/src/tools/delegate_launch.rs` already includes execution metadata such as
+`transport`, `sandbox_mode`, `repository_id`, `worktree_id`, and `read_only_project_access`, and it
+explicitly enumerates `remote_bridge` alongside `in_process` and `mailbox`. At the same time,
+`clients/agent-runtime/src/bridge/mod.rs` adds foundational remote-session and bridge-envelope
+types, but not a production bridge transport. This proposal packages those facts into one coherent
+story: complete Track 4 where the runtime contract is already real, and define only the smallest
+shared seam for Track 6 instead of jumping ahead into full remote sessions.
+
+## Scope
+
+### In Scope
+- Finish Track 4 durable orchestration behavior around the existing coordinator, mailbox transport,
+  and lifecycle tools so launch, inspect, and cancel form one explicit, parent-owned runtime
+  contract.
+- Normalize the execution/transport metadata already surfacing through `delegate_launch` into a
+  stable runtime-owned contract for local children, including the minimum isolation-related metadata
+  required to describe how a child was requested to run.
+- Define and/or tighten permission-broker expectations only where required for this slice to fail
+  closed when a child request would need approval, elevation, or transport/isolation guarantees that
+  this slice does not yet implement.
+- Clarify inspection and cancellation semantics for mailbox-backed orchestration so they remain live,
+  process-local, handle-based, and parent-authoritative.
+- Introduce the smallest transport-agnostic child execution seam so in-process children,
+  mailbox-backed children, and a future remote-bridge child can share one orchestration contract
+  without widening current delivery scope.
+- Document explicit boundaries between delivered Track 4 behavior and deferred Track 6 bridge work.
+
+### Out of Scope
+- Full Track 6 bridge delivery, including production SSE or WebSocket runtime transport,
+  bidirectional remote session streaming, reconnect/resume semantics, remote session recovery, or
+  cross-process/host reattachment.
+- Any user-facing remote-bridge product flow, operator UX, or external API for bridge-backed child
+  orchestration beyond the narrow seam required by this slice.
+- Worktree cloning, repository-per-agent execution, sandbox cloning, or full isolation enforcement.
+- General delegated permission workflows between parent and child agents beyond a fail-closed broker
+  seam and metadata contract.
+- Using mailbox persistence as the source of truth for restart recovery, historical inspection, or
+  cancellation authority after parent-process loss.
+
+## Approach
+
+Treat the current worktree as a convergence slice instead of a new feature branch. The runtime
+already contains most of the Track 4 mechanics, so this change should finish the contract and name
+the seam cleanly rather than adding another bespoke path.
+
+Concretely, the proposal should drive the next phases to:
+- keep `SupervisedOrchestrationService` and coordinator state as the authority for lifecycle,
+  ordering, inspection, and cancellation;
+- keep mailbox delivery limited to internal lifecycle/control envelopes and preserve at-least-once,
+  idempotent processing semantics;
+- elevate child execution metadata into a documented orchestration contract that can be carried
+  across transports without promising that all metadata is enforced today;
+- define a transport abstraction where `in_process` and `mailbox` are delivered implementations and
+  `remote_bridge` is an explicit deferred variant that validates/fails closed unless the future Track
+  6 bridge implementation is present;
+- define a narrow permission/isolation seam so future remote children do not require a second
+  orchestration contract when Track 6 lands.
+
+This keeps the PR reviewable as one story: “local multi-agent orchestration reaches contract
+completeness, and the contract stops hardcoding locality.”
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `clients/agent-runtime/src/agent/coordinator.rs` | Modified | Finalize orchestration handle, lifecycle read model, parent-owned cancellation, inspection semantics, and transport-agnostic child execution contract. |
+| `clients/agent-runtime/src/agent/mailbox.rs` | Modified | Keep mailbox delivery constrained to internal orchestration envelopes and aligned with durable local Track 4 behavior. |
+| `clients/agent-runtime/src/tools/delegate_launch.rs` | Modified | Promote current child execution metadata into the documented runtime launch contract and fail closed for deferred transport/isolation/approval modes. |
+| `clients/agent-runtime/src/tools/delegate_inspect.rs` | Modified | Align inspection payloads with the completed orchestration contract while preserving process-local authority. |
+| `clients/agent-runtime/src/tools/delegate_cancel.rs` | Modified | Align handle-based cancellation with parent-owned semantics and deferred remote transport boundaries. |
+| `clients/agent-runtime/src/tools/delegate.rs` | Modified | Preserve single-child compatibility while routing through the completed orchestration contract where appropriate. |
+| `clients/agent-runtime/src/bridge/mod.rs` | Modified | Keep only the minimum shared bridge/session envelope primitives required to express the future Track 6 seam without implementing full transport. |
+| `clients/agent-runtime/src/gateway/mod.rs` | Modified | Adjust runtime wiring only if needed so orchestration contracts and future bridge seams share consistent types. |
+| `clients/agent-runtime/src/lib.rs` | Modified | Export the finalized orchestration and bridge seam surfaces if they become public runtime modules. |
+| `openspec/specs/multi-agent-orchestration/spec.md` | Referenced | Baseline Track 4 requirements and explicit deferred-scope boundaries that this change will extend or complete. |
+| `tmp/CLAUDIO_ROADMAP.md` | Referenced | Roadmap should reflect that Track 4 is substantially completed by this slice while full Track 6 bridge delivery remains pending. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| The seam leaks too much Track 6 design into a Track 4 slice and makes the PR feel half-finished | Medium | Keep remote bridge behavior contract-only: shared metadata, transport enum, and fail-closed validation, but no production SSE/WebSocket transport. |
+| Execution metadata is mistaken for enforced isolation guarantees | High | Make inspection/output distinguish requested metadata from delivered guarantees, and document that worktree/repository isolation remains deferred. |
+| Permission broker language implies approval delegation already exists | Medium | Scope broker work to validation and contract seams only; reject unsupported escalation paths explicitly. |
+| Multiple transport paths diverge into separate contracts | Medium | Centralize child execution metadata and transport semantics in coordinator-owned types used by launch/inspect/cancel tooling. |
+| Rollback becomes messy if bridge primitives spread too far into runtime modules | Medium | Keep bridge additions narrow and type-focused so reverting the seam does not require undoing the completed local orchestration contract. |
+
+## Rollback Plan
+
+Revert the transport-agnostic seam and any bridge-specific metadata/wiring that exceeds local Track 4
+needs, while preserving the local coordinator/mailbox/inspection/cancellation improvements that stand
+on their own. If necessary, fall back to the already-understood local `in_process`/`mailbox`
+orchestration contract and remove `remote_bridge` validation paths until Track 6 is ready. Because
+this slice should not deliver full remote sessions or persistent recovery behavior, rollback should
+be limited to runtime types, tool schemas, and service wiring, with no data migration required.
+
+## Dependencies
+
+- Existing Track 4 coordinator/mailbox/lifecycle work already present in this worktree.
+- `openspec/specs/multi-agent-orchestration/spec.md` as the normative Track 4 baseline.
+- The current bridge scaffolding in `clients/agent-runtime/src/bridge/mod.rs`, which is suitable as a
+  seam but not yet as a delivered remote transport.
+- Roadmap alignment so Track 4 completion and Track 6 deferral are both visible after the slice is
+  specified.
+
+## Success Criteria
+
+- [ ] The change defines one coherent runtime contract for launching, inspecting, and cancelling
+      multi-child orchestration runs with durable local mailbox-backed behavior.
+- [ ] Child execution metadata for transport, isolation, and access constraints is documented and
+      exposed through the orchestration contract without overstating current enforcement.
+- [ ] Unsupported remote-bridge, escalation, or stronger-isolation requests fail closed rather than
+      silently falling back to local behavior.
+- [ ] The resulting contract can be reused by a future Track 6 remote child implementation without
+      requiring a second orchestration lifecycle model.
+- [ ] The proposal/spec/design for this slice explicitly state that full SSE/WebSocket bridge
+      transport, remote session recovery, and broader Track 6 behaviors remain out of scope.

--- a/openspec/changes/archive/2026-04-22-2026-04-22-track-4-orchestration-parity-seam/specs/multi-agent-orchestration/spec.md
+++ b/openspec/changes/archive/2026-04-22-2026-04-22-track-4-orchestration-parity-seam/specs/multi-agent-orchestration/spec.md
@@ -1,0 +1,250 @@
+# Delta for Multi-Agent Orchestration
+
+## ADDED Requirements
+
+### Requirement: Durable Local Orchestration Contract Surface
+
+The system MUST define one runtime-owned orchestration contract that covers launch, handle issuance,
+inspection, and cancellation for local multi-child orchestration in this slice. That contract MUST
+be the authority for `delegate_launch`, `delegate_inspect`, and `delegate_cancel`, and it MUST
+remain compatible with the existing single-child `delegate` surface.
+
+The delivered contract surface in this slice MUST include:
+- stable orchestration handle issuance at launch time,
+- parent-readable orchestration and child lifecycle inspection by handle,
+- parent-owned cancellation by handle,
+- transport selection limited to delivered local behavior plus explicit deferred validation for
+  `remote_bridge`, and
+- normalized execution metadata describing the requested child execution mode.
+
+The system MUST NOT require callers to use a separate lifecycle model for mailbox-backed local
+children versus in-process local children.
+
+#### Scenario: Launch, inspect, and cancel share one local orchestration contract
+
+- GIVEN a parent caller launches one or more child agents through the runtime orchestration entry
+  point
+- WHEN the runtime accepts the launch
+- THEN the runtime MUST return a stable orchestration handle governed by the same contract used by
+  inspection and cancellation
+- AND subsequent inspect and cancel operations for that run MUST resolve against that same runtime-
+  owned orchestration contract.
+
+#### Scenario: Existing single-child delegate caller remains compatible
+
+- GIVEN an existing caller uses the single-child `delegate` path after this slice is delivered
+- WHEN the delegate call is routed through the runtime orchestration contract
+- THEN the system MUST preserve the caller's existing single-child success and failure semantics
+- AND the caller MUST NOT be forced to adopt a different lifecycle contract to keep current
+  behavior.
+
+### Requirement: Child Lifecycle State Contract
+
+The system MUST expose a stable child lifecycle state contract for every child supervised within an
+orchestration run. Each child record MUST include a stable child identity and a lifecycle state that
+distinguishes, at minimum, admission, active execution, terminal success, terminal failure,
+terminal cancellation, and parent-requested cancellation in progress when cancellation has started
+but terminal resolution has not yet completed.
+
+Lifecycle inspection MUST report child states from the parent-owned orchestration authority rather
+than inferring them from mailbox rows alone. Once a child reaches a terminal lifecycle state, that
+terminal state MUST remain immutable except for additional read-only metadata attached to the same
+record.
+
+#### Scenario: Inspection distinguishes running from cancelling children
+
+- GIVEN a parent owns an orchestration run with multiple supervised children
+- AND one child is still executing while another has received parent-owned cancellation but has not
+  yet reached its terminal outcome
+- WHEN the parent inspects the run by handle
+- THEN the inspection result MUST distinguish the actively running child from the cancelling child
+- AND each child record MUST remain correlated to its stable child identity.
+
+#### Scenario: Child terminal state remains immutable after inspection updates
+
+- GIVEN a supervised child has already reached a terminal failed, cancelled, or successful state
+- WHEN a later inspection request observes the same child
+- THEN the system MUST preserve the same terminal lifecycle state
+- AND the system MUST NOT transition that child back to a non-terminal state.
+
+### Requirement: Durable Local Handle, Inspect, and Cancel Semantics
+
+The runtime MUST treat the orchestration handle as durable for the lifetime of the owning live
+parent runtime context. Within that live parent context, the handle MUST remain sufficient to
+inspect or cancel the same orchestration run without requiring the original launch request payload.
+
+Inspection and cancellation in this slice MUST remain parent-owned and process-local even when child
+delivery uses the mailbox transport. If a handle references a run that is unknown to the current
+runtime context, belongs to another parent runtime context, or has become unavailable because the
+owning parent process is no longer live, inspect and cancel requests MUST fail closed rather than
+reconstructing authority from mailbox persistence alone.
+
+Cancellation by handle MUST be idempotent. A cancellation request against an already terminal run
+MUST leave the recorded terminal outcome unchanged and MUST report that no new cancellation
+transition occurred.
+
+#### Scenario: Live parent reuses handle for later inspection
+
+- GIVEN a live parent runtime process launched an orchestration run and retained its stable handle
+- WHEN the parent later requests inspection using only that handle
+- THEN the runtime MUST return the current run and child lifecycle view for that owned run
+- AND the parent MUST NOT need to resubmit the original launch payload to inspect it.
+
+#### Scenario: Cancellation of terminal run is idempotent
+
+- GIVEN an orchestration run identified by a stable handle has already reached a terminal outcome
+- WHEN the parent requests cancellation for that handle
+- THEN the runtime MUST leave the terminal outcome unchanged
+- AND the runtime MUST report that no new cancellation transition occurred.
+
+#### Scenario: Handle authority is unavailable after parent loss
+
+- GIVEN a mailbox-backed orchestration run was started by a parent runtime process that is no longer
+  the current live owner
+- WHEN a caller attempts inspection or cancellation using the prior stable handle
+- THEN the runtime MUST reject the request as unavailable or unknown in the current runtime context
+- AND the system MUST NOT reconstruct orchestration authority solely from mailbox contents.
+
+### Requirement: Mailbox Event Visibility and Ordering
+
+The system MUST expose mailbox-backed orchestration visibility as a runtime lifecycle view rather
+than as raw mailbox rows. Mailbox delivery in this slice MUST remain limited to internal
+orchestration lifecycle/control envelopes, and inspection MUST surface only the resulting lifecycle
+state and correlated events relevant to the owning orchestration run.
+
+For a single orchestration run, event application MUST preserve a deterministic parent-owned order of
+meaning even when mailbox delivery is at-least-once and physical arrival timing differs. Duplicate or
+re-delivered mailbox envelopes MUST NOT create duplicate visible lifecycle events, duplicate child
+terminal outcomes, or nondeterministic aggregate ordering.
+
+The system MUST NOT expose mailbox rows from another run, another endpoint, or another parent as part
+of the current run's visible lifecycle history.
+
+#### Scenario: Inspection shows deterministic lifecycle visibility despite redelivery
+
+- GIVEN a mailbox-backed orchestration run receives a valid child terminal envelope
+- AND that same logical envelope is later re-delivered through at-least-once mailbox semantics
+- WHEN the parent inspects the run
+- THEN the visible lifecycle state and ordering MUST match the first successful application of that
+  logical envelope
+- AND the inspection result MUST NOT show a duplicate terminal event for the same child.
+
+#### Scenario: Inspection does not leak mailbox visibility across runs
+
+- GIVEN two different orchestration runs have mailbox-backed lifecycle traffic in the same runtime
+- WHEN the parent inspects one run by its stable handle
+- THEN the inspection result MUST contain only lifecycle visibility for that owned run
+- AND mailbox activity from the other run MUST remain invisible to that inspection result.
+
+### Requirement: Parent-Owned Approval Propagation and Permission Broker
+
+The system MUST keep approval authority with the parent runtime for this slice. When a child launch,
+tool action, or transport/isolation request would require approval, permission escalation, or a
+brokered capability that this slice does not implement end-to-end, the runtime MUST fail closed.
+
+The runtime MAY expose normalized approval or permission-needed status through the orchestration
+contract, but it MUST NOT imply that children can independently complete unsupported elevation flows.
+Any permission broker behavior delivered in this slice MUST be limited to parent-owned decision
+points and explicit rejection of unsupported escalation paths.
+
+#### Scenario: Unsupported child approval path fails closed
+
+- GIVEN a child execution request would require an approval or escalation flow not delivered by this
+  slice
+- WHEN the runtime evaluates that request
+- THEN the runtime MUST reject the request or block the affected child path without silently
+  continuing
+- AND the orchestration contract MUST preserve parent-owned authority over that decision.
+
+#### Scenario: Parent-visible permission-needed status does not grant child authority
+
+- GIVEN a child path reports that additional approval or brokered capability is needed
+- WHEN the parent inspects the orchestration run
+- THEN the inspection result MAY indicate that approval is required
+- AND the child MUST NOT be treated as having independent authority to satisfy that approval without
+  the parent-owned contract.
+
+### Requirement: Execution Metadata and Isolation Contract Boundaries
+
+The runtime MUST normalize child execution metadata into one transport-agnostic contract carried by
+launch and inspection surfaces. At minimum, the normalized metadata MUST preserve the requested
+transport, sandbox mode, repository identity, worktree identity, and read-only project access flag
+when those fields were part of the launch request.
+
+Inspection MUST distinguish requested execution metadata from delivered or currently enforced runtime
+guarantees. The system MUST NOT overstate local execution metadata as proof that repository cloning,
+worktree isolation, sandbox cloning, stronger remote isolation, or repository-per-agent execution is
+already enforced when those behaviors remain deferred.
+
+If a launch request asks for transport, isolation, or access guarantees that this slice does not
+support, the runtime MUST fail closed rather than silently downgrading or omitting the unsupported
+contract terms.
+
+#### Scenario: Inspection preserves normalized requested execution metadata
+
+- GIVEN a parent launches a child with requested transport and isolation-related metadata
+- WHEN the parent later inspects that orchestration run
+- THEN the inspection result MUST report the normalized requested execution metadata for that child
+- AND the same metadata contract MUST be usable across delivered local transports.
+
+#### Scenario: Unsupported stronger isolation request fails closed
+
+- GIVEN a launch request asks for execution guarantees that exceed the delivered local slice, such as
+  repository-per-agent or cloned sandbox isolation
+- WHEN the runtime evaluates the launch request
+- THEN the runtime MUST reject the unsupported request
+- AND the system MUST NOT silently downgrade the request to a weaker local execution mode.
+
+### Requirement: Fail-Closed Remote Bridge Seam
+
+The orchestration contract MUST include an explicit transport seam for `remote_bridge` so that a
+future Track 6 child implementation can reuse the same lifecycle and metadata model. In this slice,
+`remote_bridge` MUST be recognized as a distinct requested transport and MUST fail closed unless a
+future implementation explicitly provides the required remote bridge behavior.
+
+The system MUST NOT silently substitute `in_process` or `mailbox` execution when `remote_bridge` was
+requested. The seam MAY share normalized types, metadata, and envelope contracts with local
+transports, but it MUST NOT claim delivered SSE transport, WebSocket transport, reconnect/resume,
+remote session recovery, JWT bridge authentication, or full remote child execution in this slice.
+
+#### Scenario: Remote bridge request is rejected without local fallback
+
+- GIVEN a parent requests child execution with transport set to `remote_bridge`
+- WHEN the runtime evaluates that request in this slice
+- THEN the runtime MUST reject the request as unsupported or unavailable
+- AND the runtime MUST NOT silently launch that child through `in_process` or `mailbox` transport.
+
+#### Scenario: Remote bridge seam reuses orchestration contract shape
+
+- GIVEN the runtime reports validation details for a rejected `remote_bridge` child request
+- WHEN the parent inspects or receives the failed launch outcome
+- THEN the result MUST use the same orchestration handle, lifecycle, and metadata contract shape used
+  by local children where applicable
+- AND the result MUST clearly indicate that the remote bridge transport itself remains deferred.
+
+### Requirement: Explicit Non-Goals and Deferred Concerns
+
+This slice MUST explicitly exclude full Track 6 transport and remote session behaviors. The system
+MUST NOT treat the following as delivered by this change: production SSE or WebSocket transport,
+reconnect/resume, remote session recovery, reattachment after parent loss, JWT bridge
+authentication, full remote bridge child sessions, mailbox-backed historical replay as an authority,
+or broader delegated permission workflows beyond fail-closed parent-owned seams.
+
+The system MUST also NOT treat repository cloning, worktree cloning, sandbox cloning, or full
+repository-per-agent execution isolation as delivered guarantees for this slice.
+
+#### Scenario: Deferred remote session capabilities remain unavailable
+
+- GIVEN an orchestration request or inspection expectation depends on reconnect, resume, or remote
+  session recovery
+- WHEN the runtime evaluates that expectation under this slice
+- THEN the system MUST treat that capability as deferred
+- AND the runtime MUST NOT claim that the current orchestration contract delivers it.
+
+#### Scenario: Historical mailbox data is not treated as durable orchestration authority
+
+- GIVEN historical mailbox rows exist for a prior orchestration run
+- WHEN a caller attempts to use those rows as the basis for present inspection, cancellation, or
+  authority reconstruction after parent loss
+- THEN the runtime MUST reject that authority reconstruction path
+- AND the system MUST keep live parent-owned orchestration state as the authoritative source.

--- a/openspec/changes/archive/2026-04-22-2026-04-22-track-4-orchestration-parity-seam/state.yaml
+++ b/openspec/changes/archive/2026-04-22-2026-04-22-track-4-orchestration-parity-seam/state.yaml
@@ -1,0 +1,12 @@
+change: 2026-04-22-track-4-orchestration-parity-seam
+current_phase: archive
+completed:
+  - propose
+  - spec
+  - design
+  - tasks
+  - apply
+  - verify
+  - archive
+next: none
+updated: 2026-04-22T23:59:59Z

--- a/openspec/changes/archive/2026-04-22-2026-04-22-track-4-orchestration-parity-seam/tasks.md
+++ b/openspec/changes/archive/2026-04-22-2026-04-22-track-4-orchestration-parity-seam/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Track 4 Orchestration Parity and Bridge Seam
+
+## Phase 1: Contract and Validation Foundation
+
+- [x] 1.1 RED: Add coordinator/service tests in `clients/agent-runtime/src/agent/coordinator.rs` for normalized execution metadata, `remote_bridge` rejection, unsupported isolation rejection, and unsupported permission-broker rejection.
+- [x] 1.2 GREEN: In `clients/agent-runtime/src/agent/coordinator.rs`, add normalized request/enforced-guarantee types, launch rejection types, and centralized fail-closed admission validation used by supervised orchestration.
+- [x] 1.3 REFACTOR: Tighten `clients/agent-runtime/src/bridge/mod.rs` to metadata-only seam types consumed by the orchestration contract, without active runner wiring.
+
+## Phase 2: Lifecycle Read Model and Mailbox Semantics
+
+- [x] 2.1 RED: Extend coordinator/mailbox tests in `clients/agent-runtime/src/agent/coordinator.rs` and `clients/agent-runtime/src/agent/mailbox.rs` for `cancelling` state, immutable terminal states, deterministic event ordering, and redelivery dedupe.
+- [x] 2.2 GREEN: Update `clients/agent-runtime/src/agent/coordinator.rs` to expose child execution metadata views, bounded lifecycle events, explicit `Cancelling` state, and terminal snapshot handling from coordinator-owned authority.
+- [x] 2.3 GREEN: Update `clients/agent-runtime/src/agent/mailbox.rs` so mailbox-backed delivery remains internal lifecycle/control transport aligned with coordinator sequencing, dedupe, and no cross-run visibility.
+
+## Phase 3: Tool Surface Parity Wiring
+
+- [x] 3.1 RED: Add tool/service tests in `clients/agent-runtime/src/tools/delegate_launch.rs`, `delegate_inspect.rs`, and `delegate_cancel.rs` covering shared handle usage, requested vs enforced metadata visibility, idempotent cancel, and stale-handle fail-closed behavior.
+- [x] 3.2 GREEN: Update `clients/agent-runtime/src/tools/delegate_launch.rs` to normalize launch metadata, reject unsupported transport/isolation/approval requests before admission, and return the initial orchestration snapshot.
+- [x] 3.3 GREEN: Update `clients/agent-runtime/src/tools/delegate_inspect.rs` and `clients/agent-runtime/src/tools/delegate_cancel.rs` to read only supervised orchestration authority, expose lifecycle/event views, and preserve parent-owned cancel semantics.
+- [x] 3.4 GREEN: Update `clients/agent-runtime/src/tools/delegate.rs` and `clients/agent-runtime/src/tools/mod.rs` to keep single-child compatibility while routing through the same supervised orchestration contract.
+
+## Phase 4: Focused Compatibility and Boundary Coverage
+
+- [x] 4.1 RED: Add integration tests around shared `SupervisedOrchestrationService` in `clients/agent-runtime/src/tools/` for mailbox-backed launch→inspect→cancel flow and single-child `delegate` compatibility.
+- [x] 4.2 GREEN: Adjust `clients/agent-runtime/src/lib.rs` exports only as needed so the finalized orchestration and bridge seam types are consistently available to the runtime crate surface.
+- [x] 4.3 VERIFY: Update/mark `openspec/changes/2026-04-22-track-4-orchestration-parity-seam/tasks.md` during apply as tasks land, keeping Track 6 transport, reconnect/resume, JWT auth, and full remote sessions explicitly out of scope.

--- a/openspec/changes/archive/2026-04-22-2026-04-22-track-4-orchestration-parity-seam/verify-report.md
+++ b/openspec/changes/archive/2026-04-22-2026-04-22-track-4-orchestration-parity-seam/verify-report.md
@@ -1,0 +1,158 @@
+## Verification Report
+
+**Change**: `2026-04-22-track-4-orchestration-parity-seam`
+**Verdict**: PASS WITH WARNINGS
+
+---
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 11 |
+| Tasks complete | 11 |
+| Tasks incomplete | 0 |
+
+All checklist items in `tasks.md` are marked complete.
+
+---
+
+### Verification Scope
+
+Verified against:
+
+- `openspec/changes/2026-04-22-track-4-orchestration-parity-seam/proposal.md`
+- `openspec/changes/2026-04-22-track-4-orchestration-parity-seam/specs/multi-agent-orchestration/spec.md`
+- `openspec/changes/2026-04-22-track-4-orchestration-parity-seam/design.md`
+- `openspec/changes/2026-04-22-track-4-orchestration-parity-seam/tasks.md`
+
+Static evidence reviewed in:
+
+- `clients/agent-runtime/src/agent/coordinator.rs`
+- `clients/agent-runtime/src/agent/mailbox.rs`
+- `clients/agent-runtime/src/tools/delegate_launch.rs`
+- `clients/agent-runtime/src/tools/delegate_inspect.rs`
+- `clients/agent-runtime/src/tools/delegate_cancel.rs`
+- `clients/agent-runtime/src/tools/delegate.rs`
+- `clients/agent-runtime/src/tools/mod.rs`
+- `clients/agent-runtime/src/bridge/mod.rs`
+
+---
+
+### Real Execution Evidence
+
+Per instruction to run the smallest relevant evidence, verification used focused Rust tests only.
+No build command was run because the user explicitly said **do not build**.
+
+Command executed from the worktree root:
+
+```text
+cargo test --manifest-path clients/agent-runtime/Cargo.toml <17 targeted test names>
+```
+
+Observed result:
+
+- Exit code: `0`
+- Focused targeted tests: `17/17` passed
+- Failed targeted tests: `0`
+- Skipped targeted tests: `0`
+
+Passing targeted evidence included:
+
+- `tools::delegate_launch::tests::returns_requested_and_enforced_execution_metadata_in_initial_snapshot`
+- `tools::delegate_inspect::tests::inspect_surfaces_requested_vs_enforced_metadata_and_lifecycle_events`
+- `tools::delegate_launch::tests::mailbox_backed_launch_keeps_handle_and_snapshot_contract`
+- `tools::delegate_inspect::tests::mailbox_backed_inspect_remains_process_local`
+- `tools::delegate_cancel::tests::mailbox_backed_cancel_does_not_recover_across_services`
+- `tools::delegate::tests::supervised_single_child_delegate_remains_compatible_with_shared_orchestration_contract`
+- `tools::delegate_launch::tests::rejects_remote_bridge_requests_without_local_fallback`
+- `tools::delegate_launch::tests::rejects_unsupported_permission_broker_requests_fail_closed`
+- `agent::coordinator::tests::admit_child_normalizes_requested_vs_enforced_execution_metadata`
+- `agent::coordinator::tests::admit_child_rejects_remote_bridge_requests_fail_closed`
+- `agent::coordinator::tests::admit_child_rejects_unsupported_isolation_requests_fail_closed`
+- `agent::coordinator::tests::cancel_envelope_moves_child_into_cancelling_until_terminal_resolution`
+- `agent::coordinator::tests::duplicate_redelivery_does_not_duplicate_visible_events`
+- `agent::coordinator::tests::terminal_coordinator_state_is_immutable`
+- `agent::coordinator::tests::launch_returns_receipt_with_handle`
+- `agent::coordinator::tests::inspect_active_run_returns_snapshot`
+- `agent::coordinator::tests::cancel_already_terminal_returns_already_terminal_disposition`
+
+Non-blocking execution note:
+
+- Cargo emitted unrelated existing warnings for unused imports in `clients/agent-runtime/src/memory/mod.rs` during the test runs.
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Evidence | Result |
+|-------------|----------|----------|--------|
+| Durable Local Orchestration Contract Surface | Launch, inspect, and cancel share one local orchestration contract | `launch_returns_receipt_with_handle`, `inspect_active_run_returns_snapshot`, shared service-backed tool tests, coordinator-owned handle registry | ✅ COMPLIANT |
+| Durable Local Orchestration Contract Surface | Existing single-child delegate caller remains compatible | `supervised_single_child_delegate_remains_compatible_with_shared_orchestration_contract` | ✅ COMPLIANT |
+| Child Lifecycle State Contract | Inspection distinguishes running from cancelling children | `cancel_envelope_moves_child_into_cancelling_until_terminal_resolution`, explicit `ChildStateView::Cancelling`, cancel visibility tests | ✅ COMPLIANT |
+| Child Lifecycle State Contract | Child terminal state remains immutable after inspection updates | `terminal_coordinator_state_is_immutable` | ✅ COMPLIANT |
+| Durable Local Handle, Inspect, and Cancel Semantics | Live parent reuses handle for later inspection | `inspect_active_run_returns_snapshot` | ✅ COMPLIANT |
+| Durable Local Handle, Inspect, and Cancel Semantics | Cancellation of terminal run is idempotent | `cancel_already_terminal_returns_already_terminal_disposition` | ✅ COMPLIANT |
+| Durable Local Handle, Inspect, and Cancel Semantics | Handle authority is unavailable after parent loss | `mailbox_backed_inspect_remains_process_local`, `mailbox_backed_cancel_does_not_recover_across_services` | ✅ COMPLIANT |
+| Mailbox Event Visibility and Ordering | Inspection shows deterministic lifecycle visibility despite redelivery | `duplicate_redelivery_does_not_duplicate_visible_events` | ✅ COMPLIANT |
+| Mailbox Event Visibility and Ordering | Inspection does not leak mailbox visibility across runs | mailbox endpoint/run isolation in `mailbox.rs`, process-local inspect behavior tests | ✅ COMPLIANT |
+| Parent-Owned Approval Propagation and Permission Broker | Unsupported child approval path fails closed | `admit_child_rejects_unsupported_permission_broker_requests_fail_closed`, `rejects_unsupported_permission_broker_requests_fail_closed` | ✅ COMPLIANT |
+| Parent-Owned Approval Propagation and Permission Broker | Parent-visible permission-needed status does not grant child authority | approval state model and `WaitingOnParent` are present structurally, but no focused runtime lifecycle-tool test proves pending approval visibility | ⚠️ PARTIAL |
+| Execution Metadata and Isolation Contract Boundaries | Inspection preserves normalized requested execution metadata | `returns_requested_and_enforced_execution_metadata_in_initial_snapshot`, `inspect_surfaces_requested_vs_enforced_metadata_and_lifecycle_events` | ✅ COMPLIANT |
+| Execution Metadata and Isolation Contract Boundaries | Unsupported stronger isolation request fails closed | `admit_child_rejects_unsupported_isolation_requests_fail_closed` | ✅ COMPLIANT |
+| Fail-Closed Remote Bridge Seam | Remote bridge request is rejected without local fallback | `admit_child_rejects_remote_bridge_requests_fail_closed`, `rejects_remote_bridge_requests_without_local_fallback` | ✅ COMPLIANT |
+| Fail-Closed Remote Bridge Seam | Remote bridge seam reuses orchestration contract shape | fail-closed rejection is covered, but there is still no focused runtime test proving the exact rejected contract shape “where applicable” | ⚠️ PARTIAL |
+| Explicit Non-Goals and Deferred Concerns | Deferred remote session capabilities remain unavailable | metadata-only `bridge/mod.rs`, `session_mode_schema_rejects_deferred_transport_fields`, remote bridge rejection coverage | ✅ COMPLIANT |
+| Explicit Non-Goals and Deferred Concerns | Historical mailbox data is not treated as durable orchestration authority | `mailbox_backed_inspect_remains_process_local`, `mailbox_backed_cancel_does_not_recover_across_services` | ✅ COMPLIANT |
+
+**Compliance summary**: 15 compliant / 17 scenarios total, 2 partial, 0 failing, 0 untested-critical.
+
+---
+
+### Correctness (Static — Structural Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Unified orchestration contract | ✅ Implemented | `SupervisedOrchestrationService` owns handle registry and snapshots; delegate lifecycle tools route through the shared supervised contract. |
+| Lifecycle visibility and cancelling state | ✅ Implemented | `ChildStateView::Cancelling`, event projection, immutable terminal handling, and parent-owned state transitions are present in `coordinator.rs`. |
+| Mailbox-backed local delivery only | ✅ Implemented | `mailbox.rs` remains transport-only storage/delivery for internal envelopes with coordinator-owned visibility. |
+| Requested vs enforced metadata split | ✅ Implemented | `NormalizedExecutionRequest`, `EnforcedExecutionGuarantees`, and `ChildExecutionMetadataView` are present and now behaviorally validated on launch and inspect surfaces. |
+| Fail-closed approval / isolation / transport validation | ✅ Implemented | `normalize_execution_metadata()` rejects `remote_bridge`, unsupported isolation requests, and unsupported permission broker requests without local fallback. |
+| Remote bridge seam only, no Track 6 transport | ✅ Implemented | `bridge/mod.rs` stays metadata-only; no active bridge child runner, reconnect/resume, JWT auth, or remote session implementation was found. |
+
+---
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Keep orchestration authority in `SupervisedOrchestrationService` + `Coordinator` | ✅ Yes | Matches implementation and test evidence. |
+| Treat mailbox as delivery + evidence, not lifecycle authority | ✅ Yes | Inspect/cancel stay tied to live service registry; stale service instances fail closed. |
+| Normalize execution metadata into requested vs enforced structures | ✅ Yes | Both structures are implemented and exposed through launch/inspect snapshots. |
+| Represent approval as parent-owned broker status only | ✅ Yes | Unsupported broker requests reject before dispatch; approval remains modeled in coordinator state. |
+| Model `remote_bridge` as admitted enum with rejected executor path | ✅ Yes | Enum and seam types exist, but execution remains rejected and deferred. |
+
+---
+
+### Issues Found
+
+**CRITICAL**
+
+None.
+
+**WARNING**
+
+1. Parent-visible permission-needed inspection behavior is modeled structurally, but verification did not find a focused runtime test proving a lifecycle-tool snapshot with `WaitingOnParent` / pending approval state.
+2. Remote-bridge rejection is fail-closed and covered, but verification did not find a focused runtime test proving the exact rejected orchestration-contract shape for the deferred seam scenario.
+3. Test runs still emit unrelated warnings from `clients/agent-runtime/src/memory/mod.rs` unused imports, so the verification run is not warning-clean.
+
+**SUGGESTION**
+
+1. Add a focused lifecycle-tool test that drives `RequestApproval` and verifies parent-visible pending approval state in inspect output.
+2. Add a focused rejected-launch test that asserts the exact error/metadata contract shape for `remote_bridge` rejections.
+
+---
+
+### State Update Decision
+
+`state.yaml` **can advance to verify complete** because the prior critical metadata-launch failure is resolved and targeted runtime verification now passes. Remaining issues are warnings, not blockers.

--- a/openspec/specs/multi-agent-orchestration/spec.md
+++ b/openspec/specs/multi-agent-orchestration/spec.md
@@ -389,3 +389,250 @@ remains deferred to later Track 4 slices.
 - THEN `tmp/CLAUDIO_ROADMAP.md` MUST describe the delivered in-process coordinator foundations
 - AND the document MUST continue to list mailbox-on-disk, remote bridge, worktree isolation, and
   full permission escalation as pending future work.
+
+### Requirement: Durable Local Orchestration Contract Surface
+
+The system MUST define one runtime-owned orchestration contract that covers launch, handle issuance,
+inspection, and cancellation for local multi-child orchestration in this slice. That contract MUST
+be the authority for `delegate_launch`, `delegate_inspect`, and `delegate_cancel`, and it MUST
+remain compatible with the existing single-child `delegate` surface.
+
+The delivered contract surface in this slice MUST include:
+- stable orchestration handle issuance at launch time,
+- parent-readable orchestration and child lifecycle inspection by handle,
+- parent-owned cancellation by handle,
+- transport selection limited to delivered local behavior plus explicit deferred validation for
+  `remote_bridge`, and
+- normalized execution metadata describing the requested child execution mode.
+
+The system MUST NOT require callers to use a separate lifecycle model for mailbox-backed local
+children versus in-process local children.
+
+#### Scenario: Launch, inspect, and cancel share one local orchestration contract
+
+- GIVEN a parent caller launches one or more child agents through the runtime orchestration entry
+  point
+- WHEN the runtime accepts the launch
+- THEN the runtime MUST return a stable orchestration handle governed by the same contract used by
+  inspection and cancellation
+- AND subsequent inspect and cancel operations for that run MUST resolve against that same runtime-
+  owned orchestration contract.
+
+#### Scenario: Existing single-child delegate caller remains compatible
+
+- GIVEN an existing caller uses the single-child `delegate` path after this slice is delivered
+- WHEN the delegate call is routed through the runtime orchestration contract
+- THEN the system MUST preserve the caller's existing single-child success and failure semantics
+- AND the caller MUST NOT be forced to adopt a different lifecycle contract to keep current
+  behavior.
+
+### Requirement: Child Lifecycle State Contract
+
+The system MUST expose a stable child lifecycle state contract for every child supervised within an
+orchestration run. Each child record MUST include a stable child identity and a lifecycle state that
+distinguishes, at minimum, admission, active execution, terminal success, terminal failure,
+terminal cancellation, and parent-requested cancellation in progress when cancellation has started
+but terminal resolution has not yet completed.
+
+Lifecycle inspection MUST report child states from the parent-owned orchestration authority rather
+than inferring them from mailbox rows alone. Once a child reaches a terminal lifecycle state, that
+terminal state MUST remain immutable except for additional read-only metadata attached to the same
+record.
+
+#### Scenario: Inspection distinguishes running from cancelling children
+
+- GIVEN a parent owns an orchestration run with multiple supervised children
+- AND one child is still executing while another has received parent-owned cancellation but has not
+  yet reached its terminal outcome
+- WHEN the parent inspects the run by handle
+- THEN the inspection result MUST distinguish the actively running child from the cancelling child
+- AND each child record MUST remain correlated to its stable child identity.
+
+#### Scenario: Child terminal state remains immutable after inspection updates
+
+- GIVEN a supervised child has already reached a terminal failed, cancelled, or successful state
+- WHEN a later inspection request observes the same child
+- THEN the system MUST preserve the same terminal lifecycle state
+- AND the system MUST NOT transition that child back to a non-terminal state.
+
+### Requirement: Durable Local Handle, Inspect, and Cancel Semantics
+
+The runtime MUST treat the orchestration handle as durable for the lifetime of the owning live
+parent runtime context. Within that live parent context, the handle MUST remain sufficient to
+inspect or cancel the same orchestration run without requiring the original launch request payload.
+
+Inspection and cancellation in this slice MUST remain parent-owned and process-local even when child
+delivery uses the mailbox transport. If a handle references a run that is unknown to the current
+runtime context, belongs to another parent runtime context, or has become unavailable because the
+owning parent process is no longer live, inspect and cancel requests MUST fail closed rather than
+reconstructing authority from mailbox persistence alone.
+
+Cancellation by handle MUST be idempotent. A cancellation request against an already terminal run
+MUST leave the recorded terminal outcome unchanged and MUST report that no new cancellation
+transition occurred.
+
+#### Scenario: Live parent reuses handle for later inspection
+
+- GIVEN a live parent runtime process launched an orchestration run and retained its stable handle
+- WHEN the parent later requests inspection using only that handle
+- THEN the runtime MUST return the current run and child lifecycle view for that owned run
+- AND the parent MUST NOT need to resubmit the original launch payload to inspect it.
+
+#### Scenario: Cancellation of terminal run is idempotent
+
+- GIVEN an orchestration run identified by a stable handle has already reached a terminal outcome
+- WHEN the parent requests cancellation for that handle
+- THEN the runtime MUST leave the terminal outcome unchanged
+- AND the runtime MUST report that no new cancellation transition occurred.
+
+#### Scenario: Handle authority is unavailable after parent loss
+
+- GIVEN a mailbox-backed orchestration run was started by a parent runtime process that is no longer
+  the current live owner
+- WHEN a caller attempts inspection or cancellation using the prior stable handle
+- THEN the runtime MUST reject the request as unavailable or unknown in the current runtime context
+- AND the system MUST NOT reconstruct orchestration authority solely from mailbox contents.
+
+### Requirement: Mailbox Event Visibility and Ordering
+
+The system MUST expose mailbox-backed orchestration visibility as a runtime lifecycle view rather
+than as raw mailbox rows. Mailbox delivery in this slice MUST remain limited to internal
+orchestration lifecycle/control envelopes, and inspection MUST surface only the resulting lifecycle
+state and correlated events relevant to the owning orchestration run.
+
+For a single orchestration run, event application MUST preserve a deterministic parent-owned order of
+meaning even when mailbox delivery is at-least-once and physical arrival timing differs. Duplicate or
+re-delivered mailbox envelopes MUST NOT create duplicate visible lifecycle events, duplicate child
+terminal outcomes, or nondeterministic aggregate ordering.
+
+The system MUST NOT expose mailbox rows from another run, another endpoint, or another parent as part
+of the current run's visible lifecycle history.
+
+#### Scenario: Inspection shows deterministic lifecycle visibility despite redelivery
+
+- GIVEN a mailbox-backed orchestration run receives a valid child terminal envelope
+- AND that same logical envelope is later re-delivered through at-least-once mailbox semantics
+- WHEN the parent inspects the run
+- THEN the visible lifecycle state and ordering MUST match the first successful application of that
+  logical envelope
+- AND the inspection result MUST NOT show a duplicate terminal event for the same child.
+
+#### Scenario: Inspection does not leak mailbox visibility across runs
+
+- GIVEN two different orchestration runs have mailbox-backed lifecycle traffic in the same runtime
+- WHEN the parent inspects one run by its stable handle
+- THEN the inspection result MUST contain only lifecycle visibility for that owned run
+- AND mailbox activity from the other run MUST remain invisible to that inspection result.
+
+### Requirement: Parent-Owned Approval Propagation and Permission Broker
+
+The system MUST keep approval authority with the parent runtime for this slice. When a child launch,
+tool action, or transport/isolation request would require approval, permission escalation, or a
+brokered capability that this slice does not implement end-to-end, the runtime MUST fail closed.
+
+The runtime MAY expose normalized approval or permission-needed status through the orchestration
+contract, but it MUST NOT imply that children can independently complete unsupported elevation flows.
+Any permission broker behavior delivered in this slice MUST be limited to parent-owned decision
+points and explicit rejection of unsupported escalation paths.
+
+#### Scenario: Unsupported child approval path fails closed
+
+- GIVEN a child execution request would require an approval or escalation flow not delivered by this
+  slice
+- WHEN the runtime evaluates that request
+- THEN the runtime MUST reject the request or block the affected child path without silently
+  continuing
+- AND the orchestration contract MUST preserve parent-owned authority over that decision.
+
+#### Scenario: Parent-visible permission-needed status does not grant child authority
+
+- GIVEN a child path reports that additional approval or brokered capability is needed
+- WHEN the parent inspects the orchestration run
+- THEN the inspection result MAY indicate that approval is required
+- AND the child MUST NOT be treated as having independent authority to satisfy that approval without
+  the parent-owned contract.
+
+### Requirement: Execution Metadata and Isolation Contract Boundaries
+
+The runtime MUST normalize child execution metadata into one transport-agnostic contract carried by
+launch and inspection surfaces. At minimum, the normalized metadata MUST preserve the requested
+transport, sandbox mode, repository identity, worktree identity, and read-only project access flag
+when those fields were part of the launch request.
+
+Inspection MUST distinguish requested execution metadata from delivered or currently enforced runtime
+guarantees. The system MUST NOT overstate local execution metadata as proof that repository cloning,
+worktree isolation, sandbox cloning, stronger remote isolation, or repository-per-agent execution is
+already enforced when those behaviors remain deferred.
+
+If a launch request asks for transport, isolation, or access guarantees that this slice does not
+support, the runtime MUST fail closed rather than silently downgrading or omitting the unsupported
+contract terms.
+
+#### Scenario: Inspection preserves normalized requested execution metadata
+
+- GIVEN a parent launches a child with requested transport and isolation-related metadata
+- WHEN the parent later inspects that orchestration run
+- THEN the inspection result MUST report the normalized requested execution metadata for that child
+- AND the same metadata contract MUST be usable across delivered local transports.
+
+#### Scenario: Unsupported stronger isolation request fails closed
+
+- GIVEN a launch request asks for execution guarantees that exceed the delivered local slice, such as
+  repository-per-agent or cloned sandbox isolation
+- WHEN the runtime evaluates the launch request
+- THEN the runtime MUST reject the unsupported request
+- AND the system MUST NOT silently downgrade the request to a weaker local execution mode.
+
+### Requirement: Fail-Closed Remote Bridge Seam
+
+The orchestration contract MUST include an explicit transport seam for `remote_bridge` so that a
+future Track 6 child implementation can reuse the same lifecycle and metadata model. In this slice,
+`remote_bridge` MUST be recognized as a distinct requested transport and MUST fail closed unless a
+future implementation explicitly provides the required remote bridge behavior.
+
+The system MUST NOT silently substitute `in_process` or `mailbox` execution when `remote_bridge` was
+requested. The seam MAY share normalized types, metadata, and envelope contracts with local
+transports, but it MUST NOT claim delivered SSE transport, WebSocket transport, reconnect/resume,
+remote session recovery, JWT bridge authentication, or full remote child execution in this slice.
+
+#### Scenario: Remote bridge request is rejected without local fallback
+
+- GIVEN a parent requests child execution with transport set to `remote_bridge`
+- WHEN the runtime evaluates that request in this slice
+- THEN the runtime MUST reject the request as unsupported or unavailable
+- AND the runtime MUST NOT silently launch that child through `in_process` or `mailbox` transport.
+
+#### Scenario: Remote bridge seam reuses orchestration contract shape
+
+- GIVEN the runtime reports validation details for a rejected `remote_bridge` child request
+- WHEN the parent inspects or receives the failed launch outcome
+- THEN the result MUST use the same orchestration handle, lifecycle, and metadata contract shape used
+  by local children where applicable
+- AND the result MUST clearly indicate that the remote bridge transport itself remains deferred.
+
+### Requirement: Explicit Non-Goals and Deferred Concerns
+
+This slice MUST explicitly exclude full Track 6 transport and remote session behaviors. The system
+MUST NOT treat the following as delivered by this change: production SSE or WebSocket transport,
+reconnect/resume, remote session recovery, reattachment after parent loss, JWT bridge
+authentication, full remote bridge child sessions, mailbox-backed historical replay as an authority,
+or broader delegated permission workflows beyond fail-closed parent-owned seams.
+
+The system MUST also NOT treat repository cloning, worktree cloning, sandbox cloning, or full
+repository-per-agent execution isolation as delivered guarantees for this slice.
+
+#### Scenario: Deferred remote session capabilities remain unavailable
+
+- GIVEN an orchestration request or inspection expectation depends on reconnect, resume, or remote
+  session recovery
+- WHEN the runtime evaluates that expectation under this slice
+- THEN the system MUST treat that capability as deferred
+- AND the runtime MUST NOT claim that the current orchestration contract delivers it.
+
+#### Scenario: Historical mailbox data is not treated as durable orchestration authority
+
+- GIVEN historical mailbox rows exist for a prior orchestration run
+- WHEN a caller attempts to use those rows as the basis for present inspection, cancellation, or
+  authority reconstruction after parent loss
+- THEN the runtime MUST reject that authority reconstruction path
+- AND the system MUST keep live parent-owned orchestration state as the authoritative source.


### PR DESCRIPTION
## Related Issues

- closes #525
- relates to #528

---

## Summary

This PR completes the current runtime slice for Track 4 orchestration parity and adds the minimum fail-closed seam required for future bridge-backed children.

- finalizes durable local orchestration handle / inspect / cancel behavior
- strengthens mailbox-backed lifecycle visibility and parent-owned control flow
- normalizes requested vs enforced execution metadata in launch and inspect surfaces
- keeps `remote_bridge` present only as a fail-closed contract seam, without implementing full remote transport behavior
- includes the minimal Dream/session-completion hook currently required by the runtime integration path
- syncs and archives the corresponding OpenSpec change for this slice

---

## Tested Information

Focused runtime validation covered the slice behavior, including:

- coordinator state and transition tests
- launch-time requested/enforced metadata snapshot tests
- inspect surface lifecycle and metadata visibility tests
- cancel flow tests
- single-child delegate compatibility tests
- fail-closed `remote_bridge` rejection tests

The branch also passed the repository pre-push Rust checks before push completed.

---

## Documentation Impact

- Docs updated in:
  - `openspec/specs/multi-agent-orchestration/spec.md`
  - `openspec/changes/archive/2026-04-22-2026-04-22-track-4-orchestration-parity-seam/`
- No docs update required because: n/a
- [x] I verified the documentation matches the current behavior.

---

## Breaking Changes

None intended. This PR tightens orchestration/runtime contracts but does not intentionally introduce a public breaking change outside the runtime parity slice.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
