### PR TITLE
feat(agent-runtime): add dream system consolidation

### DIFF
--- a/clients/agent-runtime/src/config/mod.rs
+++ b/clients/agent-runtime/src/config/mod.rs
@@ -5,15 +5,15 @@ pub use schema::{
     default_mcp_capabilities, AccountPoolStrategy, AgentConfig, AudioConfig, AuditConfig,
     AutonomyConfig, BrowserComputerUseConfig, BrowserConfig, ChannelsConfig, ClassificationRule,
     CodeSessionConfig, ComposioConfig, Config, CostConfig, CronConfig, DelegateAgentConfig,
-    DelegateExecutionMode, DiscordConfig, DockerRuntimeConfig, ExecutionMode, GatewayConfig,
-    HardwareConfig, HardwareTransport, HeartbeatConfig, HttpRequestConfig, IMessageConfig,
-    IdentityConfig, LarkConfig, MatrixConfig, McpConfig, McpServerConfig, MemoryCerebroConfig,
-    MemoryConfig, MissionConfig, ModelRouteConfig, MultimodalConfig, ObservabilityConfig,
-    PeripheralBoardConfig, PeripheralsConfig, ProviderAccountConfig, ProviderAccountPoolConfig,
-    QueryClassificationConfig, ReliabilityConfig, ResourceLimitsConfig, RuntimeConfig,
-    SandboxBackend, SandboxConfig, SchedulerConfig, SecretsConfig, SecurityConfig, SkillsConfig,
-    SlackConfig, StreamMode, TelegramConfig, TunnelConfig, UpdateConfig, WebSearchConfig,
-    WebhookConfig,
+    DelegateExecutionMode, DiscordConfig, DockerRuntimeConfig, DreamTriggerConfig, ExecutionMode,
+    GatewayConfig, HardwareConfig, HardwareTransport, HeartbeatConfig, HttpRequestConfig,
+    IMessageConfig, IdentityConfig, LarkConfig, MatrixConfig, McpConfig, McpServerConfig,
+    MemoryCerebroConfig, MemoryConfig, MissionConfig, ModelRouteConfig, MultimodalConfig,
+    ObservabilityConfig, PeripheralBoardConfig, PeripheralsConfig, ProviderAccountConfig,
+    ProviderAccountPoolConfig, QueryClassificationConfig, ReliabilityConfig, ResourceLimitsConfig,
+    RuntimeConfig, SandboxBackend, SandboxConfig, SchedulerConfig, SecretsConfig, SecurityConfig,
+    SkillsConfig, SlackConfig, StreamMode, TelegramConfig, TunnelConfig, UpdateConfig,
+    WebSearchConfig, WebhookConfig,
 };
 
 #[cfg(test)]
@@ -128,6 +128,7 @@ always_ask = []
     fn reexported_runtime_config_docker_settings() {
         let runtime = RuntimeConfig {
             kind: "docker".to_string(),
+            dream: DreamTriggerConfig::default(),
             docker: DockerRuntimeConfig {
                 image: "custom:latest".to_string(),
                 network: "bridge".to_string(),
@@ -148,6 +149,13 @@ always_ask = []
         let gateway = GatewayConfig::default();
         assert_eq!(gateway.port, 3000);
         assert_eq!(gateway.host, "127.0.0.1");
+    }
+
+    #[test]
+    fn reexported_dream_trigger_config_defaults() {
+        let dream = DreamTriggerConfig::default();
+        assert_eq!(dream.session_count, 5);
+        assert_eq!(dream.time_hours, 24);
     }
 
     #[test]

--- a/clients/agent-runtime/src/config/schema.rs
+++ b/clients/agent-runtime/src/config/schema.rs
@@ -1617,9 +1617,21 @@ pub struct RuntimeConfig {
     #[serde(default = "default_runtime_kind")]
     pub kind: String,
 
+    /// Dream trigger thresholds for long-term memory consolidation.
+    #[serde(default)]
+    pub dream: DreamTriggerConfig,
+
     /// Docker runtime settings (used when `kind = "docker"`).
     #[serde(default)]
     pub docker: DockerRuntimeConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DreamTriggerConfig {
+    #[serde(default = "default_dream_session_count")]
+    pub session_count: usize,
+    #[serde(default = "default_dream_time_hours")]
+    pub time_hours: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1657,6 +1669,14 @@ fn default_runtime_kind() -> String {
     "native".into()
 }
 
+fn default_dream_session_count() -> usize {
+    5
+}
+
+fn default_dream_time_hours() -> i64 {
+    24
+}
+
 fn default_docker_image() -> String {
     "alpine:3.20".into()
 }
@@ -1687,10 +1707,20 @@ impl Default for DockerRuntimeConfig {
     }
 }
 
+impl Default for DreamTriggerConfig {
+    fn default() -> Self {
+        Self {
+            session_count: default_dream_session_count(),
+            time_hours: default_dream_time_hours(),
+        }
+    }
+}
+
 impl Default for RuntimeConfig {
     fn default() -> Self {
         Self {
             kind: default_runtime_kind(),
+            dream: DreamTriggerConfig::default(),
             docker: DockerRuntimeConfig::default(),
         }
     }

--- a/clients/agent-runtime/src/config/schema.rs
+++ b/clients/agent-runtime/src/config/schema.rs
@@ -1634,6 +1634,18 @@ pub struct DreamTriggerConfig {
     pub time_hours: i64,
 }
 
+impl DreamTriggerConfig {
+    pub fn validate(&self) -> Result<()> {
+        if self.session_count == 0 {
+            anyhow::bail!("runtime.dream.session_count must be greater than zero");
+        }
+        if self.time_hours <= 0 {
+            anyhow::bail!("runtime.dream.time_hours must be greater than zero");
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DockerRuntimeConfig {
     /// Runtime image used to execute shell commands.
@@ -3221,7 +3233,8 @@ impl Config {
         self.validate_account_pools()?;
         self.validate_skills_config()?;
         self.validate_multimodal_config()?;
-        self.validate_audio_config()
+        self.validate_audio_config()?;
+        self.runtime.dream.validate()
     }
 
     fn validate_cost_config(&self) -> Result<()> {
@@ -4416,6 +4429,28 @@ tool_dispatcher = "xml"
         assert!(err
             .to_string()
             .contains("agents.child.timeout_ms must be greater than zero"));
+    }
+
+    #[test]
+    fn validate_for_runtime_rejects_dream_session_count_zero() {
+        let mut config = Config::default();
+        config.runtime.dream.session_count = 0;
+
+        let err = config.validate_for_runtime().unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("runtime.dream.session_count must be greater than zero"));
+    }
+
+    #[test]
+    fn validate_for_runtime_rejects_dream_time_hours_non_positive() {
+        let mut config = Config::default();
+        config.runtime.dream.time_hours = 0;
+
+        let err = config.validate_for_runtime().unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("runtime.dream.time_hours must be greater than zero"));
     }
 
     #[test]

--- a/clients/agent-runtime/src/gateway/mod.rs
+++ b/clients/agent-runtime/src/gateway/mod.rs
@@ -1700,8 +1700,8 @@ async fn finalize_generated_session_if_needed(
     }
 
     let workspace_dir = state.config.lock().workspace_dir.clone();
-    if let Err(error) = crate::memory::record_session_completion(&workspace_dir) {
-        tracing::debug!("dream session counter update failed: {error}");
+    if let Err(error) = crate::memory::record_session_completion(&workspace_dir, session_id) {
+        tracing::debug!("dream session completion recording failed: {error}");
         return;
     }
     if let Err(error) = crate::memory::run_dream_if_triggered(&workspace_dir) {
@@ -3621,6 +3621,11 @@ mod tests {
         (output, layer.snapshot())
     }
 
+    async fn end_session_for_test(mem: &Arc<dyn crate::memory::Memory>, session_id: &str) {
+        mem.upsert_session(session_id, None).await.unwrap();
+        mem.end_session(session_id).await.unwrap();
+    }
+
     #[test]
     fn security_body_limit_is_64kb() {
         assert_eq!(MAX_BODY_SIZE, 65_536);
@@ -3699,6 +3704,122 @@ mod tests {
     fn app_state_is_clone() {
         fn assert_clone<T: Clone>() {}
         assert_clone::<AppState>();
+    }
+
+    #[tokio::test]
+    async fn generated_session_completion_records_before_dream_evaluation() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let workspace = tmp.path().to_path_buf();
+        let mem = Arc::new(crate::memory::SqliteMemory::new(&workspace).unwrap());
+        end_session_for_test(
+            &(mem.clone() as Arc<dyn crate::memory::Memory>),
+            "sess-generated",
+        )
+        .await;
+
+        let mut config = Config::default();
+        config.workspace_dir = workspace.clone();
+        let state = AppState {
+            config: Arc::new(Mutex::new(config)),
+            cost_tracker: None,
+            provider: Arc::new(MockProvider::default()),
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: mem.clone() as Arc<dyn crate::memory::Memory>,
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_mins(5), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            channel_runtime_handle: None,
+            observer: Arc::new(crate::observability::NoopObserver),
+            transcriber: None,
+            audio_config: crate::config::AudioConfig::default(),
+        };
+
+        finalize_generated_session_if_needed(
+            &state,
+            "sess-generated",
+            webhook_dispatch::WebhookSessionSource::Generated,
+        )
+        .await;
+
+        let eligibility = crate::memory::dream_eligibility(&workspace, "sess-generated").unwrap();
+        assert_eq!(
+            eligibility,
+            crate::memory::DreamEligibility::AlreadyConsolidated
+        );
+    }
+
+    #[tokio::test]
+    async fn generated_session_completion_blocks_dream_without_recorded_completion() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let workspace = tmp.path().to_path_buf();
+
+        let eligibility = crate::memory::dream_eligibility(&workspace, "sess-missing").unwrap();
+        assert_eq!(eligibility, crate::memory::DreamEligibility::NotCompleted);
+        assert!(crate::memory::run_dream_if_triggered(&workspace)
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn generated_session_completion_remains_runtime_idempotent_on_repeat() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let workspace = tmp.path().to_path_buf();
+        let mem = Arc::new(crate::memory::SqliteMemory::new(&workspace).unwrap());
+        end_session_for_test(
+            &(mem.clone() as Arc<dyn crate::memory::Memory>),
+            "sess-repeat",
+        )
+        .await;
+
+        let mut config = Config::default();
+        config.workspace_dir = workspace.clone();
+        let state = AppState {
+            config: Arc::new(Mutex::new(config)),
+            cost_tracker: None,
+            provider: Arc::new(MockProvider::default()),
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: mem.clone() as Arc<dyn crate::memory::Memory>,
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_mins(5), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            channel_runtime_handle: None,
+            observer: Arc::new(crate::observability::NoopObserver),
+            transcriber: None,
+            audio_config: crate::config::AudioConfig::default(),
+        };
+
+        finalize_generated_session_if_needed(
+            &state,
+            "sess-repeat",
+            webhook_dispatch::WebhookSessionSource::Generated,
+        )
+        .await;
+        finalize_generated_session_if_needed(
+            &state,
+            "sess-repeat",
+            webhook_dispatch::WebhookSessionSource::Generated,
+        )
+        .await;
+
+        assert_eq!(
+            crate::memory::dream_eligibility(&workspace, "sess-repeat").unwrap(),
+            crate::memory::DreamEligibility::AlreadyConsolidated
+        );
+        assert!(crate::memory::run_dream_if_triggered(&workspace)
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]

--- a/clients/agent-runtime/src/gateway/mod.rs
+++ b/clients/agent-runtime/src/gateway/mod.rs
@@ -1701,7 +1701,11 @@ async fn finalize_generated_session_if_needed(
 
     let workspace_dir = state.config.lock().workspace_dir.clone();
     if let Err(error) = crate::memory::record_session_completion(&workspace_dir, session_id) {
-        tracing::debug!("dream session completion recording failed: {error}");
+        tracing::debug!(
+            session_id = session_id,
+            ?error,
+            "dream session completion recording failed"
+        );
         return;
     }
     if let Err(error) = crate::memory::run_dream_if_triggered(&workspace_dir) {

--- a/clients/agent-runtime/src/memory/dream.rs
+++ b/clients/agent-runtime/src/memory/dream.rs
@@ -1,16 +1,19 @@
 use anyhow::Result;
 use chrono::{Duration, Local, Utc};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
-use std::fs;
+use std::fs::{self, File};
 use std::path::{Path, PathBuf};
+
+use crate::config::DreamTriggerConfig;
 
 const DREAM_STATE_FILE: &str = "dream_state.json";
 const DREAM_LOCK_FILE: &str = "dream.lock";
 const DREAM_MEMORY_LINE_BUDGET: usize = 200;
 const DREAM_MEMORY_BYTE_BUDGET: usize = 25 * 1024;
-const DREAM_SESSION_TRIGGER_COUNT: usize = 5;
-const DREAM_TIME_TRIGGER_HOURS: i64 = 24;
+
+pub type DreamConfig = DreamTriggerConfig;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -118,8 +121,15 @@ pub enum DreamEligibility {
 }
 
 pub fn run_if_triggered(workspace_dir: &Path) -> Result<Option<MemoryConsolidationReport>> {
+    run_if_triggered_with_config(workspace_dir, &DreamConfig::default())
+}
+
+pub fn run_if_triggered_with_config(
+    workspace_dir: &Path,
+    config: &DreamConfig,
+) -> Result<Option<MemoryConsolidationReport>> {
     let state = load_state(workspace_dir)?;
-    let Some(trigger_reason) = due_trigger_reason(&state)? else {
+    let Some(trigger_reason) = due_trigger_reason(&state, config)? else {
         return Ok(None);
     };
     run_now(workspace_dir, trigger_reason)
@@ -194,10 +204,8 @@ pub fn run_now(
     }
 
     let mut session_reports = Vec::new();
-    let mut artifact_refs = Vec::new();
     for session_id in &session_ids {
         let artifact_ref = artifact_ref_for_session(session_id);
-        artifact_refs.push(artifact_ref.clone());
         merged_lines.push(format!("Dream summary for completed session {session_id}"));
         session_reports.push(DreamSessionReport {
             session_id: session_id.clone(),
@@ -221,6 +229,15 @@ pub fn run_now(
     let pruned = prune_to_budget(&deduped.lines);
     let retained_lines = pruned.len();
 
+    let completed_session_ids: Vec<String> = session_ids
+        .iter()
+        .filter(|session_id| {
+            let expected = format!("Dream summary for completed session {session_id}");
+            pruned.iter().any(|line| line == &expected)
+        })
+        .cloned()
+        .collect();
+
     let mut rendered = String::from("# Long-Term Memory\n\n");
     for line in &pruned {
         rendered.push_str("- ");
@@ -237,7 +254,7 @@ pub fn run_now(
         touched_files: vec![display_path(&core_path)],
     });
 
-    mark_sessions_completed(&mut state, &session_ids, &artifact_refs, &trigger_reason);
+    mark_sessions_completed(&mut state, &completed_session_ids, &trigger_reason);
 
     let report = MemoryConsolidationReport {
         trigger_reason,
@@ -251,8 +268,20 @@ pub fn run_now(
         retained_lines,
         launch_contract: launch_contract(workspace_dir),
         sessions_considered: session_ids.len(),
-        sessions_processed: session_ids.len(),
-        session_reports,
+        sessions_processed: completed_session_ids.len(),
+        session_reports: session_reports
+            .into_iter()
+            .map(|mut report| {
+                if !completed_session_ids
+                    .iter()
+                    .any(|id| id == &report.session_id)
+                {
+                    report.status = DreamSessionStatus::Pending;
+                    report.artifact_refs.clear();
+                }
+                report
+            })
+            .collect(),
     };
 
     state.last_successful_run_at = report.finished_at.clone();
@@ -267,18 +296,32 @@ pub fn record_session_completion(
     workspace_dir: &Path,
     session_id: &str,
 ) -> Result<DreamSessionStateRecord> {
+    let Some(_lock_guard) = DreamLockGuard::acquire(workspace_dir)? else {
+        return Ok(load_state(workspace_dir)?
+            .completed_sessions
+            .into_iter()
+            .find(|record| record.session_id == session_id)
+            .unwrap_or_else(|| DreamSessionStateRecord {
+                session_id: session_id.to_string(),
+                status: DreamSessionStatus::Pending,
+                trigger_reason: DreamTriggerReason::SessionCount,
+                completion_recorded_at: Utc::now().to_rfc3339(),
+                last_attempt_at: None,
+                completed_at: None,
+                artifact_refs: vec![],
+                failure_reason: Some("dream lock busy while recording completion".to_string()),
+            }));
+    };
+
     let mut state = load_state(workspace_dir)?;
     let now = Utc::now().to_rfc3339();
     let artifact_ref = artifact_ref_for_session(session_id);
 
     let core_path = workspace_dir.join("MEMORY.md");
+    let expected_line = format!("- Dream summary for completed session {session_id}");
     let artifact_already_written = core_path.exists()
         && fs::read_to_string(&core_path)
-            .map(|content| {
-                content.contains(&format!(
-                    "- Dream summary for completed session {session_id}"
-                ))
-            })
+            .map(|content| content.lines().any(|line| line.trim() == expected_line))
             .unwrap_or(false);
 
     if let Some(existing) = state
@@ -341,7 +384,10 @@ pub fn dream_eligibility(workspace_dir: &Path, session_id: &str) -> Result<Dream
     )
 }
 
-fn due_trigger_reason(state: &DreamState) -> Result<Option<DreamTriggerReason>> {
+fn due_trigger_reason(
+    state: &DreamState,
+    config: &DreamConfig,
+) -> Result<Option<DreamTriggerReason>> {
     let pending_count = state
         .completed_sessions
         .iter()
@@ -352,7 +398,7 @@ fn due_trigger_reason(state: &DreamState) -> Result<Option<DreamTriggerReason>> 
             )
         })
         .count();
-    if pending_count >= DREAM_SESSION_TRIGGER_COUNT {
+    if pending_count >= config.session_count {
         return Ok(Some(DreamTriggerReason::SessionCount));
     }
 
@@ -366,7 +412,7 @@ fn due_trigger_reason(state: &DreamState) -> Result<Option<DreamTriggerReason>> 
 
     let parsed = chrono::DateTime::parse_from_rfc3339(last_run_at)?.with_timezone(&Utc);
     if pending_count > 0
-        && Utc::now().signed_duration_since(parsed) >= Duration::hours(DREAM_TIME_TRIGGER_HOURS)
+        && Utc::now().signed_duration_since(parsed) >= Duration::hours(config.time_hours)
     {
         return Ok(Some(DreamTriggerReason::TimeElapsed));
     }
@@ -391,7 +437,6 @@ fn pending_session_ids(state: &DreamState) -> Vec<String> {
 fn mark_sessions_completed(
     state: &mut DreamState,
     session_ids: &[String],
-    artifact_refs: &[String],
     trigger_reason: &DreamTriggerReason,
 ) {
     let completed_at = Utc::now().to_rfc3339();
@@ -409,7 +454,6 @@ fn mark_sessions_completed(
             record.failure_reason = None;
         }
     }
-    let _ = artifact_refs;
 }
 
 fn artifact_ref_for_session(session_id: &str) -> String {
@@ -543,7 +587,10 @@ fn display_path(path: &Path) -> String {
 }
 
 struct DreamLockGuard {
+    #[allow(dead_code)]
     path: PathBuf,
+    #[allow(dead_code)]
+    file: File,
 }
 
 impl DreamLockGuard {
@@ -552,21 +599,24 @@ impl DreamLockGuard {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        match fs::OpenOptions::new()
+        let file = fs::OpenOptions::new()
+            .read(true)
             .write(true)
-            .create_new(true)
-            .open(&path)
-        {
-            Ok(_) => Ok(Some(Self { path })),
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(None),
+            .create(true)
+            .truncate(false)
+            .open(&path)?;
+        match file.try_lock_exclusive() {
+            Ok(()) => Ok(Some(Self { path, file })),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::AlreadyExists
+                ) =>
+            {
+                Ok(None)
+            }
             Err(error) => Err(error.into()),
         }
-    }
-}
-
-impl Drop for DreamLockGuard {
-    fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
     }
 }
 
@@ -616,6 +666,73 @@ mod tests {
         let eligibility = dream_eligibility(tmp.path(), "sess-123").unwrap();
         assert_eq!(eligibility, DreamEligibility::AlreadyConsolidated);
         assert!(run_if_triggered(tmp.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn run_if_triggered_honors_non_default_trigger_config() {
+        let tmp = TempDir::new().unwrap();
+        record_session_completion(tmp.path(), "sess-a").unwrap();
+        record_session_completion(tmp.path(), "sess-b").unwrap();
+        let config = DreamConfig {
+            session_count: 2,
+            time_hours: 999,
+        };
+
+        let report = run_if_triggered_with_config(tmp.path(), &config)
+            .unwrap()
+            .unwrap();
+        assert_eq!(report.trigger_reason, DreamTriggerReason::SessionCount);
+
+        let tmp = TempDir::new().unwrap();
+        record_session_completion(tmp.path(), "sess-a").unwrap();
+        record_session_completion(tmp.path(), "sess-b").unwrap();
+        let state_path = tmp.path().join("state").join(DREAM_STATE_FILE);
+        let raw = fs::read_to_string(&state_path).unwrap();
+        let mut state: DreamState = serde_json::from_str(&raw).unwrap();
+        state.last_successful_run_at = Some(Utc::now().to_rfc3339());
+        fs::write(&state_path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+        let config = DreamConfig {
+            session_count: 3,
+            time_hours: 999,
+        };
+
+        assert!(run_if_triggered_with_config(tmp.path(), &config)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn record_session_completion_uses_exact_summary_line_match() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("MEMORY.md"),
+            "# Long-Term Memory\n\n- Dream summary for completed session sess-123-extra\n",
+        )
+        .unwrap();
+
+        let record = record_session_completion(tmp.path(), "sess-123").unwrap();
+
+        assert_eq!(record.status, DreamSessionStatus::Pending);
+    }
+
+    #[test]
+    fn concurrent_record_session_completion_preserves_all_entries() {
+        let tmp = TempDir::new().unwrap();
+        std::thread::scope(|scope| {
+            for session_id in ["sess-1", "sess-2", "sess-3", "sess-4"] {
+                let workspace = tmp.path().to_path_buf();
+                scope.spawn(move || {
+                    record_session_completion(&workspace, session_id).unwrap();
+                });
+            }
+        });
+
+        for session_id in ["sess-1", "sess-2", "sess-3", "sess-4"] {
+            assert_eq!(
+                dream_eligibility(tmp.path(), session_id).unwrap(),
+                DreamEligibility::Eligible
+            );
+        }
     }
 
     #[test]

--- a/clients/agent-runtime/src/memory/dream.rs
+++ b/clients/agent-runtime/src/memory/dream.rs
@@ -296,22 +296,7 @@ pub fn record_session_completion(
     workspace_dir: &Path,
     session_id: &str,
 ) -> Result<DreamSessionStateRecord> {
-    let Some(_lock_guard) = DreamLockGuard::acquire(workspace_dir)? else {
-        return Ok(load_state(workspace_dir)?
-            .completed_sessions
-            .into_iter()
-            .find(|record| record.session_id == session_id)
-            .unwrap_or_else(|| DreamSessionStateRecord {
-                session_id: session_id.to_string(),
-                status: DreamSessionStatus::Pending,
-                trigger_reason: DreamTriggerReason::SessionCount,
-                completion_recorded_at: Utc::now().to_rfc3339(),
-                last_attempt_at: None,
-                completed_at: None,
-                artifact_refs: vec![],
-                failure_reason: Some("dream lock busy while recording completion".to_string()),
-            }));
-    };
+    let _lock_guard = DreamLockGuard::acquire_blocking(workspace_dir)?;
 
     let mut state = load_state(workspace_dir)?;
     let now = Utc::now().to_rfc3339();
@@ -617,6 +602,21 @@ impl DreamLockGuard {
             }
             Err(error) => Err(error.into()),
         }
+    }
+
+    fn acquire_blocking(workspace_dir: &Path) -> Result<Self> {
+        let path = dream_lock_path(workspace_dir);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)?;
+        file.lock_exclusive()?;
+        Ok(Self { path, file })
     }
 }
 

--- a/clients/agent-runtime/src/memory/dream.rs
+++ b/clients/agent-runtime/src/memory/dream.rs
@@ -116,6 +116,7 @@ struct DreamState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DreamEligibility {
     Eligible,
+    RetryAfterFailure,
     NotCompleted,
     AlreadyConsolidated,
 }
@@ -140,6 +141,9 @@ pub fn run_now(
     trigger_reason: DreamTriggerReason,
 ) -> Result<Option<MemoryConsolidationReport>> {
     let Some(lock_guard) = DreamLockGuard::acquire(workspace_dir)? else {
+        let pending_count = load_state(workspace_dir)
+            .map(|state| pending_session_ids(&state).len())
+            .unwrap_or(0);
         return Ok(Some(MemoryConsolidationReport {
             trigger_reason,
             status: DreamRunStatus::Skipped,
@@ -151,7 +155,7 @@ pub fn run_now(
             duplicates_removed: 0,
             retained_lines: 0,
             launch_contract: launch_contract(workspace_dir),
-            sessions_considered: 0,
+            sessions_considered: pending_count,
             sessions_processed: 0,
             session_reports: vec![],
         }));
@@ -364,6 +368,9 @@ pub fn dream_eligibility(workspace_dir: &Path, session_id: &str) -> Result<Dream
             Some(record) if record.status == DreamSessionStatus::Completed => {
                 DreamEligibility::AlreadyConsolidated
             }
+            Some(record) if record.status == DreamSessionStatus::Failed => {
+                DreamEligibility::RetryAfterFailure
+            }
             Some(_) => DreamEligibility::Eligible,
         },
     )
@@ -554,8 +561,10 @@ fn load_state(workspace_dir: &Path) -> Result<DreamState> {
     if !path.exists() {
         return Ok(DreamState::default());
     }
-    let raw = fs::read_to_string(path)?;
-    Ok(serde_json::from_str(&raw).unwrap_or_default())
+    let raw = fs::read_to_string(&path)?;
+    serde_json::from_str(&raw).map_err(|error| {
+        anyhow::anyhow!("failed to parse Dream state '{}': {error}", path.display())
+    })
 }
 
 fn store_state(workspace_dir: &Path, state: &DreamState) -> Result<()> {
@@ -666,6 +675,27 @@ mod tests {
         let eligibility = dream_eligibility(tmp.path(), "sess-123").unwrap();
         assert_eq!(eligibility, DreamEligibility::AlreadyConsolidated);
         assert!(run_if_triggered(tmp.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn failed_session_is_marked_retry_after_failure() {
+        let tmp = TempDir::new().unwrap();
+        let record = record_session_completion(tmp.path(), "sess-failed").unwrap();
+        let state_path = tmp.path().join("state").join(DREAM_STATE_FILE);
+        let raw = fs::read_to_string(&state_path).unwrap();
+        let mut state: DreamState = serde_json::from_str(&raw).unwrap();
+        let failed = state
+            .completed_sessions
+            .iter_mut()
+            .find(|entry| entry.session_id == "sess-failed")
+            .unwrap();
+        failed.status = DreamSessionStatus::Failed;
+        failed.last_attempt_at = Some(record.completion_recorded_at.clone());
+        failed.failure_reason = Some("transient backend error".to_string());
+        fs::write(&state_path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+
+        let eligibility = dream_eligibility(tmp.path(), "sess-failed").unwrap();
+        assert_eq!(eligibility, DreamEligibility::RetryAfterFailure);
     }
 
     #[test]

--- a/clients/agent-runtime/src/memory/dream.rs
+++ b/clients/agent-runtime/src/memory/dream.rs
@@ -9,7 +9,7 @@ const DREAM_STATE_FILE: &str = "dream_state.json";
 const DREAM_LOCK_FILE: &str = "dream.lock";
 const DREAM_MEMORY_LINE_BUDGET: usize = 200;
 const DREAM_MEMORY_BYTE_BUDGET: usize = 25 * 1024;
-const DREAM_SESSION_TRIGGER_COUNT: u64 = 5;
+const DREAM_SESSION_TRIGGER_COUNT: usize = 5;
 const DREAM_TIME_TRIGGER_HOURS: i64 = 24;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -59,6 +59,34 @@ pub struct DreamLaunchContract {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DreamSessionStatus {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DreamSessionStateRecord {
+    pub session_id: String,
+    pub status: DreamSessionStatus,
+    pub trigger_reason: DreamTriggerReason,
+    pub completion_recorded_at: String,
+    pub last_attempt_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub artifact_refs: Vec<String>,
+    pub failure_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DreamSessionReport {
+    pub session_id: String,
+    pub status: DreamSessionStatus,
+    pub artifact_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemoryConsolidationReport {
     pub trigger_reason: DreamTriggerReason,
     pub status: DreamRunStatus,
@@ -70,13 +98,23 @@ pub struct MemoryConsolidationReport {
     pub duplicates_removed: u64,
     pub retained_lines: usize,
     pub launch_contract: DreamLaunchContract,
+    pub sessions_considered: usize,
+    pub sessions_processed: usize,
+    pub session_reports: Vec<DreamSessionReport>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct DreamState {
     last_successful_run_at: Option<String>,
-    sessions_since_last_run: u64,
+    completed_sessions: Vec<DreamSessionStateRecord>,
     last_report: Option<MemoryConsolidationReport>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DreamEligibility {
+    Eligible,
+    NotCompleted,
+    AlreadyConsolidated,
 }
 
 pub fn run_if_triggered(workspace_dir: &Path) -> Result<Option<MemoryConsolidationReport>> {
@@ -103,9 +141,14 @@ pub fn run_now(
             duplicates_removed: 0,
             retained_lines: 0,
             launch_contract: launch_contract(workspace_dir),
+            sessions_considered: 0,
+            sessions_processed: 0,
+            session_reports: vec![],
         }));
     };
 
+    let mut state = load_state(workspace_dir)?;
+    let session_ids = pending_session_ids(&state);
     let started_at = Utc::now().to_rfc3339();
     let memory_dir = workspace_dir.join("memory");
     fs::create_dir_all(&memory_dir)?;
@@ -115,7 +158,10 @@ pub fn run_now(
     let touched = vec![display_path(&core_path), display_path(&memory_dir)];
     phases.push(DreamPhaseResult {
         phase: DreamPhase::Orientation,
-        summary: "Scanned memory root, core memory file, and recent signal sources.".to_string(),
+        summary: format!(
+            "Scanned memory root, core memory file, and {} pending Dream session(s).",
+            session_ids.len()
+        ),
         touched_files: touched.clone(),
     });
 
@@ -146,11 +192,26 @@ pub fn run_now(
             merged_lines.push(normalized);
         }
     }
+
+    let mut session_reports = Vec::new();
+    let mut artifact_refs = Vec::new();
+    for session_id in &session_ids {
+        let artifact_ref = artifact_ref_for_session(session_id);
+        artifact_refs.push(artifact_ref.clone());
+        merged_lines.push(format!("Dream summary for completed session {session_id}"));
+        session_reports.push(DreamSessionReport {
+            session_id: session_id.clone(),
+            status: DreamSessionStatus::Completed,
+            artifact_refs: vec![artifact_ref],
+        });
+    }
+
     phases.push(DreamPhaseResult {
         phase: DreamPhase::Consolidation,
         summary: format!(
-            "Merged {} candidate memory lines into the consolidation set.",
-            merged_lines.len()
+            "Merged {} candidate memory lines across {} completed session(s).",
+            merged_lines.len(),
+            session_ids.len()
         ),
         touched_files: vec![display_path(&core_path)],
     });
@@ -176,6 +237,8 @@ pub fn run_now(
         touched_files: vec![display_path(&core_path)],
     });
 
+    mark_sessions_completed(&mut state, &session_ids, &artifact_refs, &trigger_reason);
+
     let report = MemoryConsolidationReport {
         trigger_reason,
         status: DreamRunStatus::Completed,
@@ -187,11 +250,12 @@ pub fn run_now(
         duplicates_removed,
         retained_lines,
         launch_contract: launch_contract(workspace_dir),
+        sessions_considered: session_ids.len(),
+        sessions_processed: session_ids.len(),
+        session_reports,
     };
 
-    let mut state = load_state(workspace_dir)?;
     state.last_successful_run_at = report.finished_at.clone();
-    state.sessions_since_last_run = 0;
     state.last_report = Some(report.clone());
     store_state(workspace_dir, &state)?;
     drop(lock_guard);
@@ -199,29 +263,157 @@ pub fn run_now(
     Ok(Some(report))
 }
 
-pub fn record_session_completion(workspace_dir: &Path) -> Result<u64> {
+pub fn record_session_completion(
+    workspace_dir: &Path,
+    session_id: &str,
+) -> Result<DreamSessionStateRecord> {
     let mut state = load_state(workspace_dir)?;
-    state.sessions_since_last_run = state.sessions_since_last_run.saturating_add(1);
-    let count = state.sessions_since_last_run;
+    let now = Utc::now().to_rfc3339();
+    let artifact_ref = artifact_ref_for_session(session_id);
+
+    let core_path = workspace_dir.join("MEMORY.md");
+    let artifact_already_written = core_path.exists()
+        && fs::read_to_string(&core_path)
+            .map(|content| {
+                content.contains(&format!(
+                    "- Dream summary for completed session {session_id}"
+                ))
+            })
+            .unwrap_or(false);
+
+    if let Some(existing) = state
+        .completed_sessions
+        .iter_mut()
+        .find(|record| record.session_id == session_id)
+    {
+        if existing.status != DreamSessionStatus::Completed && artifact_already_written {
+            existing.status = DreamSessionStatus::Completed;
+            existing.completed_at = Some(now.clone());
+            existing.last_attempt_at = Some(now.clone());
+            existing.artifact_refs = vec![artifact_ref];
+            existing.failure_reason = None;
+        }
+        let existing = existing.clone();
+        store_state(workspace_dir, &state)?;
+        return Ok(existing);
+    }
+
+    let record = DreamSessionStateRecord {
+        session_id: session_id.to_string(),
+        status: if artifact_already_written {
+            DreamSessionStatus::Completed
+        } else {
+            DreamSessionStatus::Pending
+        },
+        trigger_reason: DreamTriggerReason::SessionCount,
+        completion_recorded_at: now.clone(),
+        last_attempt_at: artifact_already_written.then(|| now.clone()),
+        completed_at: artifact_already_written.then(|| now.clone()),
+        artifact_refs: if artifact_already_written {
+            vec![artifact_ref]
+        } else {
+            vec![]
+        },
+        failure_reason: None,
+    };
+    state.completed_sessions.push(record.clone());
+    state
+        .completed_sessions
+        .sort_by(|a, b| a.session_id.cmp(&b.session_id));
     store_state(workspace_dir, &state)?;
-    Ok(count)
+    Ok(record)
+}
+
+pub fn dream_eligibility(workspace_dir: &Path, session_id: &str) -> Result<DreamEligibility> {
+    let state = load_state(workspace_dir)?;
+    Ok(
+        match state
+            .completed_sessions
+            .iter()
+            .find(|record| record.session_id == session_id)
+        {
+            None => DreamEligibility::NotCompleted,
+            Some(record) if record.status == DreamSessionStatus::Completed => {
+                DreamEligibility::AlreadyConsolidated
+            }
+            Some(_) => DreamEligibility::Eligible,
+        },
+    )
 }
 
 fn due_trigger_reason(state: &DreamState) -> Result<Option<DreamTriggerReason>> {
-    if state.sessions_since_last_run >= DREAM_SESSION_TRIGGER_COUNT {
+    let pending_count = state
+        .completed_sessions
+        .iter()
+        .filter(|record| {
+            matches!(
+                record.status,
+                DreamSessionStatus::Pending | DreamSessionStatus::Failed
+            )
+        })
+        .count();
+    if pending_count >= DREAM_SESSION_TRIGGER_COUNT {
         return Ok(Some(DreamTriggerReason::SessionCount));
     }
 
     let Some(last_run_at) = state.last_successful_run_at.as_deref() else {
-        return Ok(Some(DreamTriggerReason::TimeElapsed));
+        return if pending_count > 0 {
+            Ok(Some(DreamTriggerReason::TimeElapsed))
+        } else {
+            Ok(None)
+        };
     };
 
     let parsed = chrono::DateTime::parse_from_rfc3339(last_run_at)?.with_timezone(&Utc);
-    if Utc::now().signed_duration_since(parsed) >= Duration::hours(DREAM_TIME_TRIGGER_HOURS) {
+    if pending_count > 0
+        && Utc::now().signed_duration_since(parsed) >= Duration::hours(DREAM_TIME_TRIGGER_HOURS)
+    {
         return Ok(Some(DreamTriggerReason::TimeElapsed));
     }
 
     Ok(None)
+}
+
+fn pending_session_ids(state: &DreamState) -> Vec<String> {
+    state
+        .completed_sessions
+        .iter()
+        .filter(|record| {
+            matches!(
+                record.status,
+                DreamSessionStatus::Pending | DreamSessionStatus::Failed
+            )
+        })
+        .map(|record| record.session_id.clone())
+        .collect()
+}
+
+fn mark_sessions_completed(
+    state: &mut DreamState,
+    session_ids: &[String],
+    artifact_refs: &[String],
+    trigger_reason: &DreamTriggerReason,
+) {
+    let completed_at = Utc::now().to_rfc3339();
+    for session_id in session_ids {
+        if let Some(record) = state
+            .completed_sessions
+            .iter_mut()
+            .find(|record| record.session_id == *session_id)
+        {
+            record.status = DreamSessionStatus::Completed;
+            record.trigger_reason = trigger_reason.clone();
+            record.last_attempt_at = Some(completed_at.clone());
+            record.completed_at = Some(completed_at.clone());
+            record.artifact_refs = vec![artifact_ref_for_session(session_id)];
+            record.failure_reason = None;
+        }
+    }
+    let _ = artifact_refs;
+}
+
+fn artifact_ref_for_session(session_id: &str) -> String {
+    format!("dream/session/{session_id}")
 }
 
 fn extract_memory_lines(content: &str) -> Vec<String> {
@@ -384,22 +576,59 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
+    fn rejects_active_session_without_recorded_completion() {
+        let tmp = TempDir::new().unwrap();
+
+        let eligibility = dream_eligibility(tmp.path(), "sess-active").unwrap();
+
+        assert_eq!(eligibility, DreamEligibility::NotCompleted);
+        assert!(run_if_triggered(tmp.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn accepts_recorded_completed_session_and_creates_deterministic_artifact_ref() {
+        let tmp = TempDir::new().unwrap();
+        record_session_completion(tmp.path(), "sess-123").unwrap();
+
+        let eligibility = dream_eligibility(tmp.path(), "sess-123").unwrap();
+        assert_eq!(eligibility, DreamEligibility::Eligible);
+
+        let report = run_if_triggered(tmp.path()).unwrap().unwrap();
+        assert_eq!(report.trigger_reason, DreamTriggerReason::TimeElapsed);
+        assert_eq!(report.sessions_processed, 1);
+        assert_eq!(
+            report.session_reports[0].artifact_refs,
+            vec!["dream/session/sess-123".to_string()]
+        );
+    }
+
+    #[test]
+    fn suppresses_duplicate_triggers_by_session_id() {
+        let tmp = TempDir::new().unwrap();
+        let first = record_session_completion(tmp.path(), "sess-123").unwrap();
+        let second = record_session_completion(tmp.path(), "sess-123").unwrap();
+
+        assert_eq!(first.session_id, second.session_id);
+
+        let first_report = run_if_triggered(tmp.path()).unwrap().unwrap();
+        assert_eq!(first_report.sessions_processed, 1);
+
+        let eligibility = dream_eligibility(tmp.path(), "sess-123").unwrap();
+        assert_eq!(eligibility, DreamEligibility::AlreadyConsolidated);
+        assert!(run_if_triggered(tmp.path()).unwrap().is_none());
+    }
+
+    #[test]
     fn session_trigger_fires_after_five_sessions() {
         let tmp = TempDir::new().unwrap();
-        for _ in 0..5 {
-            record_session_completion(tmp.path()).unwrap();
+        for index in 0..5 {
+            record_session_completion(tmp.path(), &format!("sess-{index}")).unwrap();
         }
 
         let report = run_if_triggered(tmp.path()).unwrap().unwrap();
         assert_eq!(report.trigger_reason, DreamTriggerReason::SessionCount);
         assert_eq!(report.status, DreamRunStatus::Completed);
-    }
-
-    #[test]
-    fn time_trigger_fires_without_prior_state() {
-        let tmp = TempDir::new().unwrap();
-        let report = run_if_triggered(tmp.path()).unwrap().unwrap();
-        assert_eq!(report.trigger_reason, DreamTriggerReason::TimeElapsed);
+        assert_eq!(report.sessions_processed, 5);
     }
 
     #[test]
@@ -416,6 +645,7 @@ mod tests {
     #[test]
     fn dream_normalizes_relative_dates_and_prunes_duplicates() {
         let tmp = TempDir::new().unwrap();
+        record_session_completion(tmp.path(), "sess-123").unwrap();
         fs::create_dir_all(tmp.path().join("memory")).unwrap();
         fs::write(
             tmp.path().join("memory").join("2026-04-22.md"),
@@ -431,5 +661,73 @@ mod tests {
         assert!(report.normalized_dates >= 2);
         assert!(report.duplicates_removed >= 1);
         assert!(memory.contains("on "));
+        assert!(memory.contains("Dream summary for completed session sess-123"));
+    }
+
+    #[test]
+    fn retries_failed_session_after_manual_recovery_and_keeps_single_logical_result() {
+        let tmp = TempDir::new().unwrap();
+        let record = record_session_completion(tmp.path(), "sess-retry").unwrap();
+        let state_path = tmp.path().join("state").join(DREAM_STATE_FILE);
+        let raw = fs::read_to_string(&state_path).unwrap();
+        let mut state: DreamState = serde_json::from_str(&raw).unwrap();
+        let failed = state
+            .completed_sessions
+            .iter_mut()
+            .find(|entry| entry.session_id == "sess-retry")
+            .unwrap();
+        failed.status = DreamSessionStatus::Failed;
+        failed.last_attempt_at = Some(record.completion_recorded_at.clone());
+        failed.failure_reason = Some("transient backend error".to_string());
+        fs::write(&state_path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+
+        let report = run_now(tmp.path(), DreamTriggerReason::Manual)
+            .unwrap()
+            .unwrap();
+        let recovered = record_session_completion(tmp.path(), "sess-retry").unwrap();
+        let memory = fs::read_to_string(tmp.path().join("MEMORY.md")).unwrap();
+        let dream_summary_count = memory
+            .lines()
+            .filter(|line| line.contains("Dream summary for completed session sess-retry"))
+            .count();
+
+        assert_eq!(report.sessions_processed, 1);
+        assert_eq!(report.session_reports.len(), 1);
+        assert_eq!(
+            report.session_reports[0].artifact_refs,
+            vec!["dream/session/sess-retry".to_string()]
+        );
+        assert_eq!(recovered.status, DreamSessionStatus::Completed);
+        assert!(recovered.failure_reason.is_none());
+        assert_eq!(dream_summary_count, 1);
+    }
+
+    #[test]
+    fn busy_run_does_not_consume_pending_session_and_succeeds_after_lock_release() {
+        let tmp = TempDir::new().unwrap();
+        record_session_completion(tmp.path(), "sess-busy").unwrap();
+
+        let busy_guard = DreamLockGuard::acquire(tmp.path()).unwrap().unwrap();
+        let busy = run_now(tmp.path(), DreamTriggerReason::Manual)
+            .unwrap()
+            .unwrap();
+        assert_eq!(busy.lock_state, DreamLockState::Busy);
+        assert_eq!(busy.sessions_processed, 0);
+        assert_eq!(
+            dream_eligibility(tmp.path(), "sess-busy").unwrap(),
+            DreamEligibility::Eligible
+        );
+
+        drop(busy_guard);
+
+        let completed = run_now(tmp.path(), DreamTriggerReason::Manual)
+            .unwrap()
+            .unwrap();
+        assert_eq!(completed.status, DreamRunStatus::Completed);
+        assert_eq!(completed.sessions_processed, 1);
+        assert_eq!(
+            dream_eligibility(tmp.path(), "sess-busy").unwrap(),
+            DreamEligibility::AlreadyConsolidated
+        );
     }
 }

--- a/clients/agent-runtime/src/memory/hygiene.rs
+++ b/clients/agent-runtime/src/memory/hygiene.rs
@@ -1,4 +1,5 @@
 use crate::config::MemoryConfig;
+use crate::memory;
 use anyhow::Result;
 use chrono::{DateTime, Duration, Local, NaiveDate, Utc};
 use rusqlite::{params, Connection};
@@ -360,11 +361,33 @@ fn close_stale_sessions(workspace_dir: &Path, threshold_hours: i64) -> Result<u6
     let cutoff = (now - Duration::hours(threshold_hours)).to_rfc3339();
     let now = now.to_rfc3339();
 
+    let mut stale_ids = Vec::new();
+    {
+        let mut stmt = conn.prepare(
+            "SELECT id FROM sessions
+             WHERE status = 'active' AND ended_at IS NULL AND last_activity < ?1",
+        )?;
+        let rows = stmt.query_map(params![cutoff], |row| row.get::<_, String>(0))?;
+        for row in rows {
+            stale_ids.push(row?);
+        }
+    }
+
+    if stale_ids.is_empty() {
+        return Ok(0);
+    }
+
     let affected = conn.execute(
         "UPDATE sessions SET status = 'ended', ended_at = ?1
          WHERE status = 'active' AND ended_at IS NULL AND last_activity < ?2",
         params![now, cutoff],
     )?;
+
+    drop(conn);
+
+    for session_id in stale_ids.iter().take(affected) {
+        memory::record_session_completion(workspace_dir, session_id)?;
+    }
 
     Ok(u64::try_from(affected).unwrap_or(0))
 }
@@ -545,6 +568,33 @@ mod tests {
 
         assert!(!old_file.exists(), "old archived file should be purged");
         assert!(keep_file.exists(), "recent archived file should remain");
+    }
+
+    #[tokio::test]
+    async fn close_stale_sessions_records_dream_completion_input() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+
+        let mem = SqliteMemory::new(workspace).unwrap();
+        mem.upsert_session("stale-dream-sess", None).await.unwrap();
+        drop(mem);
+
+        let db_path = workspace.join("memory").join("brain.db");
+        let conn = Connection::open(&db_path).unwrap();
+        let old_time = (chrono::Utc::now() - Duration::hours(48)).to_rfc3339();
+        conn.execute(
+            "UPDATE sessions SET last_activity = ?1 WHERE id = 'stale-dream-sess'",
+            params![old_time],
+        )
+        .unwrap();
+        drop(conn);
+
+        let closed = close_stale_sessions(workspace, 24).unwrap();
+        assert_eq!(closed, 1);
+        assert_eq!(
+            crate::memory::dream_eligibility(workspace, "stale-dream-sess").unwrap(),
+            crate::memory::DreamEligibility::Eligible
+        );
     }
 
     #[tokio::test]

--- a/clients/agent-runtime/src/memory/hygiene.rs
+++ b/clients/agent-runtime/src/memory/hygiene.rs
@@ -587,7 +587,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn close_stale_sessions_records_dream_completion_input() {
+    async fn close_stale_sessions_marks_session_dream_eligible() {
         let tmp = TempDir::new().unwrap();
         let workspace = tmp.path();
 

--- a/clients/agent-runtime/src/memory/hygiene.rs
+++ b/clients/agent-runtime/src/memory/hygiene.rs
@@ -361,35 +361,51 @@ fn close_stale_sessions(workspace_dir: &Path, threshold_hours: i64) -> Result<u6
     let cutoff = (now - Duration::hours(threshold_hours)).to_rfc3339();
     let now = now.to_rfc3339();
 
-    let mut stale_ids = Vec::new();
-    {
-        let mut stmt = conn.prepare(
-            "SELECT id FROM sessions
-             WHERE status = 'active' AND ended_at IS NULL AND last_activity < ?1",
+    let updated_ids = {
+        let tx = conn.unchecked_transaction()?;
+        let mut stale_ids = Vec::new();
+        {
+            let mut stmt = tx.prepare(
+                "SELECT id FROM sessions
+                 WHERE status = 'active' AND ended_at IS NULL AND last_activity < ?1",
+            )?;
+            let rows = stmt.query_map(params![cutoff], |row| row.get::<_, String>(0))?;
+            for row in rows {
+                stale_ids.push(row?);
+            }
+        }
+
+        if stale_ids.is_empty() {
+            tx.rollback()?;
+            return Ok(0);
+        }
+
+        tx.execute(
+            "UPDATE sessions SET status = 'ended', ended_at = ?1
+             WHERE status = 'active' AND ended_at IS NULL AND last_activity < ?2",
+            params![now, cutoff],
         )?;
-        let rows = stmt.query_map(params![cutoff], |row| row.get::<_, String>(0))?;
-        for row in rows {
-            stale_ids.push(row?);
+        tx.commit()?;
+        stale_ids
+    };
+
+    let mut failed_recordings = Vec::new();
+    for session_id in &updated_ids {
+        if let Err(error) = memory::record_session_completion(workspace_dir, session_id) {
+            tracing::warn!(
+                session_id = session_id.as_str(),
+                ?error,
+                "failed to record Dream completion for stale session"
+            );
+            failed_recordings.push(session_id.clone());
         }
     }
 
-    if stale_ids.is_empty() {
-        return Ok(0);
+    if !failed_recordings.is_empty() {
+        tracing::warn!(failed_sessions = ?failed_recordings, "one or more stale sessions were auto-closed without Dream completion metadata");
     }
 
-    let affected = conn.execute(
-        "UPDATE sessions SET status = 'ended', ended_at = ?1
-         WHERE status = 'active' AND ended_at IS NULL AND last_activity < ?2",
-        params![now, cutoff],
-    )?;
-
-    drop(conn);
-
-    for session_id in stale_ids.iter().take(affected) {
-        memory::record_session_completion(workspace_dir, session_id)?;
-    }
-
-    Ok(u64::try_from(affected).unwrap_or(0))
+    Ok(u64::try_from(updated_ids.len()).unwrap_or(0))
 }
 
 fn memory_date_from_filename(filename: &str) -> Option<NaiveDate> {

--- a/clients/agent-runtime/src/memory/mod.rs
+++ b/clients/agent-runtime/src/memory/mod.rs
@@ -20,8 +20,8 @@ pub use backend::{
 #[allow(unused_imports)]
 pub use dream::{
     dream_eligibility, record_session_completion, run_if_triggered as run_dream_if_triggered,
-    run_now as run_dream_now, DreamEligibility, DreamLaunchContract, DreamLockState, DreamPhase,
-    DreamPhaseResult, DreamRunStatus, DreamSessionReport, DreamSessionStateRecord,
+    run_now as run_dream_now, DreamConfig, DreamEligibility, DreamLaunchContract, DreamLockState,
+    DreamPhase, DreamPhaseResult, DreamRunStatus, DreamSessionReport, DreamSessionStateRecord,
     DreamSessionStatus, DreamTriggerReason, MemoryConsolidationReport,
 };
 pub use lucid::LucidMemory;

--- a/clients/agent-runtime/src/memory/mod.rs
+++ b/clients/agent-runtime/src/memory/mod.rs
@@ -19,9 +19,10 @@ pub use backend::{
 };
 #[allow(unused_imports)]
 pub use dream::{
-    record_session_completion, run_if_triggered as run_dream_if_triggered,
-    run_now as run_dream_now, DreamLaunchContract, DreamLockState, DreamPhase, DreamPhaseResult,
-    DreamRunStatus, DreamTriggerReason, MemoryConsolidationReport,
+    dream_eligibility, record_session_completion, run_if_triggered as run_dream_if_triggered,
+    run_now as run_dream_now, DreamEligibility, DreamLaunchContract, DreamLockState, DreamPhase,
+    DreamPhaseResult, DreamRunStatus, DreamSessionReport, DreamSessionStateRecord,
+    DreamSessionStatus, DreamTriggerReason, MemoryConsolidationReport,
 };
 pub use lucid::LucidMemory;
 pub use markdown::MarkdownMemory;

--- a/clients/agent-runtime/src/memory/snapshot.rs
+++ b/clients/agent-runtime/src/memory/snapshot.rs
@@ -219,13 +219,19 @@ fn export_dream_state_snapshot(workspace_dir: &Path) -> Result<()> {
     let snapshot_path = dream_snapshot_state_path(workspace_dir);
 
     if !state_path.exists() {
-        let _ = fs::remove_file(snapshot_path);
+        match fs::remove_file(&snapshot_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                tracing::debug!(path = %snapshot_path.display(), ?error, "failed to remove Dream snapshot sidecar");
+            }
+        }
         return Ok(());
     }
 
-    let raw = fs::read_to_string(state_path)?;
-    let json: serde_json::Value = serde_json::from_str(&raw)?;
-    fs::write(snapshot_path, serde_json::to_vec_pretty(&json)?)?;
+    let raw = fs::read_to_string(&state_path)?;
+    let _: serde_json::Value = serde_json::from_str(&raw)?;
+    fs::copy(&state_path, &snapshot_path)?;
     Ok(())
 }
 
@@ -236,7 +242,7 @@ fn restore_dream_state_snapshot(workspace_dir: &Path) -> Result<()> {
     }
 
     let raw = fs::read_to_string(&snapshot_path)?;
-    let _records = parse_dream_state_snapshot(&raw)?;
+    validate_dream_state_snapshot(&raw)?;
 
     let state_path = dream_state_path(workspace_dir);
     if let Some(parent) = state_path.parent() {
@@ -268,15 +274,15 @@ fn parse_snapshot(input: &str) -> Vec<(String, String)> {
     entries
 }
 
-fn parse_dream_state_snapshot(input: &str) -> Result<Vec<DreamSessionStateRecord>> {
+fn validate_dream_state_snapshot(input: &str) -> Result<()> {
     #[derive(serde::Deserialize)]
     struct DreamStateEnvelope {
         #[serde(default)]
         completed_sessions: Vec<DreamSessionStateRecord>,
     }
 
-    let state: DreamStateEnvelope = serde_json::from_str(input)?;
-    Ok(state.completed_sessions)
+    let _state: DreamStateEnvelope = serde_json::from_str(input)?;
+    Ok(())
 }
 
 fn extract_key_from_line(line: &str) -> Option<String> {
@@ -425,14 +431,14 @@ Rule 3: Protect the user.
 
         export_dream_state_snapshot(workspace).unwrap();
         let exported = fs::read_to_string(workspace.join(DREAM_SNAPSHOT_STATE_FILENAME)).unwrap();
-        let restored = parse_dream_state_snapshot(&exported).unwrap();
+        validate_dream_state_snapshot(&exported).unwrap();
 
-        assert_eq!(restored.len(), 1);
-        assert_eq!(restored[0].session_id, "sess-123");
         assert_eq!(
-            restored[0].artifact_refs,
-            vec!["dream/session/sess-123".to_string()]
+            exported,
+            fs::read_to_string(workspace.join("state").join("dream_state.json")).unwrap()
         );
+        assert!(exported.contains("sess-123"));
+        assert!(exported.contains("dream/session/sess-123"));
     }
 
     #[test]
@@ -600,10 +606,9 @@ Rule 3: Protect the user.
         restore_dream_state_snapshot(workspace).unwrap();
         let restored =
             fs::read_to_string(workspace.join("state").join("dream_state.json")).unwrap();
-        let records = parse_dream_state_snapshot(&restored).unwrap();
+        validate_dream_state_snapshot(&restored).unwrap();
 
-        assert_eq!(records.len(), 1);
-        assert_eq!(records[0].session_id, "sess-restore");
+        assert!(restored.contains("sess-restore"));
     }
 
     #[test]

--- a/clients/agent-runtime/src/memory/snapshot.rs
+++ b/clients/agent-runtime/src/memory/snapshot.rs
@@ -6,6 +6,7 @@
 //! **Auto-Hydration**: if `brain.db` is missing but `MEMORY_SNAPSHOT.md` exists,
 //! re-indexes all entries back into a fresh SQLite database.
 
+use crate::memory::dream::DreamSessionStateRecord;
 use anyhow::Result;
 use chrono::Local;
 use rusqlite::{params, Connection};
@@ -15,6 +16,7 @@ use std::path::{Path, PathBuf};
 
 /// Filename for the snapshot (lives at workspace root for Git visibility).
 pub const SNAPSHOT_FILENAME: &str = "MEMORY_SNAPSHOT.md";
+pub const DREAM_SNAPSHOT_STATE_FILENAME: &str = "DREAM_STATE_SNAPSHOT.json";
 
 /// Header written at the top of every snapshot file.
 const SNAPSHOT_HEADER: &str = "# 🧠 Corvus Memory Snapshot\n\n\
@@ -79,6 +81,8 @@ pub fn export_snapshot(workspace_dir: &Path) -> Result<usize> {
 
     let snapshot_path = snapshot_path(workspace_dir);
     fs::write(&snapshot_path, output)?;
+
+    export_dream_state_snapshot(workspace_dir)?;
 
     tracing::info!(
         "📸 Memory snapshot exported: {} core memories → {}",
@@ -168,6 +172,8 @@ pub fn hydrate_from_snapshot(workspace_dir: &Path) -> Result<usize> {
         }
     }
 
+    restore_dream_state_snapshot(workspace_dir)?;
+
     tracing::info!(
         "🧬 Memory hydration complete: {} entries restored from {}",
         hydrated,
@@ -203,7 +209,50 @@ fn snapshot_path(workspace_dir: &Path) -> PathBuf {
     workspace_dir.join(SNAPSHOT_FILENAME)
 }
 
+fn dream_state_path(workspace_dir: &Path) -> PathBuf {
+    workspace_dir.join("state").join("dream_state.json")
+}
+
+fn dream_snapshot_state_path(workspace_dir: &Path) -> PathBuf {
+    workspace_dir.join(DREAM_SNAPSHOT_STATE_FILENAME)
+}
+
 /// Parse the structured markdown snapshot back into (key, content) pairs.
+fn export_dream_state_snapshot(workspace_dir: &Path) -> Result<()> {
+    let state_path = dream_state_path(workspace_dir);
+    let snapshot_path = dream_snapshot_state_path(workspace_dir);
+
+    if !state_path.exists() {
+        let _ = fs::remove_file(snapshot_path);
+        return Ok(());
+    }
+
+    let raw = fs::read_to_string(state_path)?;
+    let json: serde_json::Value = serde_json::from_str(&raw)?;
+    fs::write(snapshot_path, serde_json::to_vec_pretty(&json)?)?;
+    Ok(())
+}
+
+fn restore_dream_state_snapshot(workspace_dir: &Path) -> Result<()> {
+    let snapshot_path = dream_snapshot_state_path(workspace_dir);
+    if !snapshot_path.exists() {
+        return Ok(());
+    }
+
+    let raw = fs::read_to_string(&snapshot_path)?;
+    let records = parse_dream_state_snapshot(&raw)?;
+    if records.is_empty() {
+        return Ok(());
+    }
+
+    let state_path = dream_state_path(workspace_dir);
+    if let Some(parent) = state_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(state_path, raw)?;
+    Ok(())
+}
+
 fn parse_snapshot(input: &str) -> Vec<(String, String)> {
     let mut entries = Vec::new();
     let mut current_key: Option<String> = None;
@@ -224,6 +273,17 @@ fn parse_snapshot(input: &str) -> Vec<(String, String)> {
 
     flush_current_entry(&mut entries, &mut current_key, &current_content);
     entries
+}
+
+fn parse_dream_state_snapshot(input: &str) -> Result<Vec<DreamSessionStateRecord>> {
+    #[derive(serde::Deserialize)]
+    struct DreamStateEnvelope {
+        #[serde(default)]
+        completed_sessions: Vec<DreamSessionStateRecord>,
+    }
+
+    let state: DreamStateEnvelope = serde_json::from_str(input)?;
+    Ok(state.completed_sessions)
 }
 
 fn extract_key_from_line(line: &str) -> Option<String> {
@@ -275,7 +335,21 @@ fn flush_current_entry(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::memory::dream::{DreamSessionStatus, DreamTriggerReason};
     use tempfile::TempDir;
+
+    fn sample_dream_record(session_id: &str) -> DreamSessionStateRecord {
+        DreamSessionStateRecord {
+            session_id: session_id.to_string(),
+            status: DreamSessionStatus::Completed,
+            trigger_reason: DreamTriggerReason::Manual,
+            completion_recorded_at: "2026-04-26T10:00:00Z".into(),
+            last_attempt_at: Some("2026-04-26T10:05:00Z".into()),
+            completed_at: Some("2026-04-26T10:05:00Z".into()),
+            artifact_refs: vec![format!("dream/session/{session_id}")],
+            failure_reason: None,
+        }
+    }
 
     #[test]
     fn parse_snapshot_basic() {
@@ -338,6 +412,34 @@ Rule 3: Protect the user.
         assert_eq!(entries.len(), 1);
         assert!(entries[0].1.contains("Rule 1"));
         assert!(entries[0].1.contains("Rule 3"));
+    }
+
+    #[test]
+    fn snapshot_dream_state_sidecar_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+        fs::create_dir_all(workspace.join("state")).unwrap();
+        let payload = serde_json::json!({
+            "completed_sessions": [sample_dream_record("sess-123")],
+            "last_successful_run_at": "2026-04-26T10:05:00Z",
+            "last_report": null
+        });
+        fs::write(
+            workspace.join("state").join("dream_state.json"),
+            serde_json::to_vec_pretty(&payload).unwrap(),
+        )
+        .unwrap();
+
+        export_dream_state_snapshot(workspace).unwrap();
+        let exported = fs::read_to_string(workspace.join(DREAM_SNAPSHOT_STATE_FILENAME)).unwrap();
+        let restored = parse_dream_state_snapshot(&exported).unwrap();
+
+        assert_eq!(restored.len(), 1);
+        assert_eq!(restored[0].session_id, "sess-123");
+        assert_eq!(
+            restored[0].artifact_refs,
+            vec!["dream/session/sess-123".to_string()]
+        );
     }
 
     #[test]
@@ -475,7 +577,31 @@ Rule 3: Protect the user.
     }
 
     #[test]
-    fn hydrate_no_snapshot_returns_zero() {
+    fn hydrate_from_snapshot_restores_dream_state_sidecar() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+        fs::write(
+            workspace.join(DREAM_SNAPSHOT_STATE_FILENAME),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "completed_sessions": [sample_dream_record("sess-restore")],
+                "last_successful_run_at": "2026-04-26T10:05:00Z",
+                "last_report": null
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        restore_dream_state_snapshot(workspace).unwrap();
+        let restored =
+            fs::read_to_string(workspace.join("state").join("dream_state.json")).unwrap();
+        let records = parse_dream_state_snapshot(&restored).unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].session_id, "sess-restore");
+    }
+
+    #[test]
+    fn hydrate_from_missing_snapshot_returns_zero() {
         let tmp = TempDir::new().unwrap();
         let count = hydrate_from_snapshot(tmp.path()).unwrap();
         assert_eq!(count, 0);

--- a/clients/agent-runtime/src/memory/snapshot.rs
+++ b/clients/agent-runtime/src/memory/snapshot.rs
@@ -28,6 +28,8 @@ const SNAPSHOT_HEADER: &str = "# 🧠 Corvus Memory Snapshot\n\n\
 ///
 /// Returns the number of entries exported.
 pub fn export_snapshot(workspace_dir: &Path) -> Result<usize> {
+    export_dream_state_snapshot(workspace_dir)?;
+
     let db_path = workspace_dir.join("memory").join("brain.db");
     if !db_path.exists() {
         tracing::debug!("snapshot export skipped: brain.db does not exist");
@@ -81,8 +83,6 @@ pub fn export_snapshot(workspace_dir: &Path) -> Result<usize> {
 
     let snapshot_path = snapshot_path(workspace_dir);
     fs::write(&snapshot_path, output)?;
-
-    export_dream_state_snapshot(workspace_dir)?;
 
     tracing::info!(
         "📸 Memory snapshot exported: {} core memories → {}",
@@ -144,7 +144,6 @@ pub fn hydrate_from_snapshot(workspace_dir: &Path) -> Result<usize> {
     )?;
 
     let now = Local::now().to_rfc3339();
-    let mut hydrated = 0;
 
     for (key, content) in &entries {
         let id = uuid::Uuid::new_v4().to_string();
@@ -161,7 +160,6 @@ pub fn hydrate_from_snapshot(workspace_dir: &Path) -> Result<usize> {
                     "INSERT INTO memories_fts(key, content) VALUES (?1, ?2)",
                     params![key, content],
                 );
-                hydrated += 1;
             }
             Ok(_) => {
                 tracing::debug!("hydrate: key '{key}' already exists, skipping");
@@ -172,15 +170,13 @@ pub fn hydrate_from_snapshot(workspace_dir: &Path) -> Result<usize> {
         }
     }
 
-    restore_dream_state_snapshot(workspace_dir)?;
-
-    tracing::info!(
-        "🧬 Memory hydration complete: {} entries restored from {}",
-        hydrated,
-        snapshot.display()
-    );
-
-    Ok(hydrated)
+    if let Err(error) = restore_dream_state_snapshot(workspace_dir) {
+        tracing::warn!(
+            ?error,
+            "dream state snapshot restore skipped during hydration"
+        );
+    }
+    Ok(entries.len())
 }
 
 /// Check if we should auto-hydrate on startup.
@@ -240,10 +236,7 @@ fn restore_dream_state_snapshot(workspace_dir: &Path) -> Result<()> {
     }
 
     let raw = fs::read_to_string(&snapshot_path)?;
-    let records = parse_dream_state_snapshot(&raw)?;
-    if records.is_empty() {
-        return Ok(());
-    }
+    let _records = parse_dream_state_snapshot(&raw)?;
 
     let state_path = dream_state_path(workspace_dir);
     if let Some(parent) = state_path.parent() {
@@ -445,8 +438,21 @@ Rule 3: Protect the user.
     #[test]
     fn export_no_db_returns_zero() {
         let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("state")).unwrap();
+        fs::write(
+            tmp.path().join("state").join("dream_state.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "completed_sessions": [sample_dream_record("sess-export")],
+                "last_successful_run_at": null,
+                "last_report": null
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
         let count = export_snapshot(tmp.path()).unwrap();
         assert_eq!(count, 0);
+        assert!(tmp.path().join(DREAM_SNAPSHOT_STATE_FILENAME).exists());
     }
 
     #[test]
@@ -598,6 +604,31 @@ Rule 3: Protect the user.
 
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].session_id, "sess-restore");
+    }
+
+    #[test]
+    fn restore_dream_state_snapshot_preserves_metadata_with_empty_records() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+        fs::write(
+            workspace.join(DREAM_SNAPSHOT_STATE_FILENAME),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "completed_sessions": [],
+                "last_successful_run_at": "2026-04-26T10:05:00Z",
+                "last_report": {"status": "completed"}
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        restore_dream_state_snapshot(workspace).unwrap();
+        let restored =
+            fs::read_to_string(workspace.join("state").join("dream_state.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&restored).unwrap();
+
+        assert_eq!(json["last_successful_run_at"], "2026-04-26T10:05:00Z");
+        assert_eq!(json["completed_sessions"], serde_json::json!([]));
+        assert!(json.get("last_report").is_some());
     }
 
     #[test]

--- a/clients/agent-runtime/src/memory/sqlite.rs
+++ b/clients/agent-runtime/src/memory/sqlite.rs
@@ -10,7 +10,8 @@ use anyhow::Context;
 use async_trait::async_trait;
 use chrono::Local;
 use parking_lot::Mutex;
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::sync::Arc;
@@ -21,6 +22,35 @@ use uuid::Uuid;
 /// Maximum allowed open timeout (seconds) to avoid unreasonable waits.
 const SQLITE_OPEN_TIMEOUT_CAP_SECS: u64 = 300;
 const MAX_LIST_LIMIT: u32 = 1_000;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum DreamSessionDbStatus {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum DreamTriggerDbReason {
+    TimeElapsed,
+    SessionCount,
+    Manual,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DreamSessionRow {
+    session_id: String,
+    status: DreamSessionDbStatus,
+    trigger_reason: DreamTriggerDbReason,
+    completion_recorded_at: String,
+    last_attempt_at: Option<String>,
+    completed_at: Option<String>,
+    artifact_refs: Vec<String>,
+    failure_reason: Option<String>,
+}
 
 /// SQLite-backed persistent memory — the brain
 ///
@@ -261,6 +291,24 @@ impl SqliteMemory {
                  ON tasks(priority, created_at DESC, id ASC);",
         )?;
 
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS dream_sessions (
+                 session_id              TEXT PRIMARY KEY,
+                 status                  TEXT NOT NULL CHECK (status IN ('pending', 'running', 'completed', 'failed')),
+                 trigger_reason          TEXT NOT NULL CHECK (trigger_reason IN ('time_elapsed', 'session_count', 'manual')),
+                 completion_recorded_at  TEXT NOT NULL,
+                 last_attempt_at         TEXT,
+                 completed_at            TEXT,
+                 artifact_refs           TEXT NOT NULL DEFAULT '[]',
+                 failure_reason          TEXT,
+                 FOREIGN KEY(session_id) REFERENCES sessions(id)
+             );
+             CREATE INDEX IF NOT EXISTS idx_dream_sessions_status
+                 ON dream_sessions(status);
+             CREATE INDEX IF NOT EXISTS idx_dream_sessions_completed_at
+                 ON dream_sessions(completed_at DESC);",
+        )?;
+
         Ok(())
     }
 
@@ -367,6 +415,119 @@ impl SqliteMemory {
         if exists == 0 {
             anyhow::bail!("unknown session: {session_id}");
         }
+        Ok(())
+    }
+
+    fn dream_status_to_str(status: &DreamSessionDbStatus) -> &'static str {
+        match status {
+            DreamSessionDbStatus::Pending => "pending",
+            DreamSessionDbStatus::Running => "running",
+            DreamSessionDbStatus::Completed => "completed",
+            DreamSessionDbStatus::Failed => "failed",
+        }
+    }
+
+    fn dream_status_from_row(value: String) -> rusqlite::Result<DreamSessionDbStatus> {
+        match value.as_str() {
+            "pending" => Ok(DreamSessionDbStatus::Pending),
+            "running" => Ok(DreamSessionDbStatus::Running),
+            "completed" => Ok(DreamSessionDbStatus::Completed),
+            "failed" => Ok(DreamSessionDbStatus::Failed),
+            _ => Err(rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unknown dream status value: {value}"),
+                )),
+            )),
+        }
+    }
+
+    fn dream_trigger_reason_to_str(reason: &DreamTriggerDbReason) -> &'static str {
+        match reason {
+            DreamTriggerDbReason::TimeElapsed => "time_elapsed",
+            DreamTriggerDbReason::SessionCount => "session_count",
+            DreamTriggerDbReason::Manual => "manual",
+        }
+    }
+
+    fn dream_trigger_reason_from_row(value: String) -> rusqlite::Result<DreamTriggerDbReason> {
+        match value.as_str() {
+            "time_elapsed" => Ok(DreamTriggerDbReason::TimeElapsed),
+            "session_count" => Ok(DreamTriggerDbReason::SessionCount),
+            "manual" => Ok(DreamTriggerDbReason::Manual),
+            _ => Err(rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unknown dream trigger reason value: {value}"),
+                )),
+            )),
+        }
+    }
+
+    fn load_dream_session_row(
+        conn: &Connection,
+        session_id: &str,
+    ) -> anyhow::Result<Option<DreamSessionRow>> {
+        conn.query_row(
+            "SELECT session_id, status, trigger_reason, completion_recorded_at,
+                    last_attempt_at, completed_at, artifact_refs, failure_reason
+             FROM dream_sessions WHERE session_id = ?1",
+            params![session_id],
+            |row| {
+                let artifact_refs: String = row.get(6)?;
+                let refs =
+                    serde_json::from_str::<Vec<String>>(&artifact_refs).map_err(|error| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            6,
+                            rusqlite::types::Type::Text,
+                            Box::new(error),
+                        )
+                    })?;
+                Ok(DreamSessionRow {
+                    session_id: row.get(0)?,
+                    status: Self::dream_status_from_row(row.get::<_, String>(1)?)?,
+                    trigger_reason: Self::dream_trigger_reason_from_row(row.get::<_, String>(2)?)?,
+                    completion_recorded_at: row.get(3)?,
+                    last_attempt_at: row.get(4)?,
+                    completed_at: row.get(5)?,
+                    artifact_refs: refs,
+                    failure_reason: row.get(7)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(Into::into)
+    }
+
+    fn upsert_dream_session_row(tx: &Transaction<'_>, row: &DreamSessionRow) -> anyhow::Result<()> {
+        tx.execute(
+            "INSERT INTO dream_sessions (
+                session_id, status, trigger_reason, completion_recorded_at,
+                last_attempt_at, completed_at, artifact_refs, failure_reason
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(session_id) DO UPDATE SET
+                status = excluded.status,
+                trigger_reason = excluded.trigger_reason,
+                completion_recorded_at = excluded.completion_recorded_at,
+                last_attempt_at = excluded.last_attempt_at,
+                completed_at = excluded.completed_at,
+                artifact_refs = excluded.artifact_refs,
+                failure_reason = excluded.failure_reason",
+            params![
+                row.session_id,
+                Self::dream_status_to_str(&row.status),
+                Self::dream_trigger_reason_to_str(&row.trigger_reason),
+                row.completion_recorded_at,
+                row.last_attempt_at,
+                row.completed_at,
+                serde_json::to_string(&row.artifact_refs)?,
+                row.failure_reason,
+            ],
+        )?;
         Ok(())
     }
 
@@ -1978,6 +2139,233 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mem = SqliteMemory::new(tmp.path()).unwrap();
         (tmp, mem)
+    }
+
+    #[test]
+    fn sqlite_dream_state_persists_per_session_and_survives_reopen() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+        let mem = SqliteMemory::new(workspace).unwrap();
+
+        {
+            let conn = mem.conn.lock();
+            conn.execute(
+                "INSERT INTO sessions (id, started_at, status, message_count, last_activity)
+                 VALUES (?1, ?2, 'ended', 1, ?2)",
+                params!["sess-123", "2026-04-26T10:00:00Z"],
+            )
+            .unwrap();
+        }
+
+        let core_key = "dream/session/sess-123";
+        let core_content = "Dream summary for completed session sess-123";
+
+        {
+            let conn = mem.conn.lock();
+            let tx = conn.unchecked_transaction().unwrap();
+            tx.execute(
+                "INSERT INTO memories (id, key, content, category, session_id, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, 'core', ?4, ?5, ?5)",
+                params![
+                    "artifact-1",
+                    core_key,
+                    core_content,
+                    "sess-123",
+                    "2026-04-26T10:05:00Z"
+                ],
+            )
+            .unwrap();
+            tx.execute(
+                "INSERT INTO dream_sessions (
+                    session_id, status, trigger_reason, completion_recorded_at,
+                    last_attempt_at, completed_at, artifact_refs, failure_reason
+                 ) VALUES (?1, 'completed', 'manual', ?2, ?3, ?3, ?4, NULL)
+                 ON CONFLICT(session_id) DO UPDATE SET
+                    status = excluded.status,
+                    trigger_reason = excluded.trigger_reason,
+                    completion_recorded_at = excluded.completion_recorded_at,
+                    last_attempt_at = excluded.last_attempt_at,
+                    completed_at = excluded.completed_at,
+                    artifact_refs = excluded.artifact_refs,
+                    failure_reason = excluded.failure_reason",
+                params![
+                    "sess-123",
+                    "2026-04-26T10:00:00Z",
+                    "2026-04-26T10:05:00Z",
+                    "[\"dream/session/sess-123\"]"
+                ],
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+
+        drop(mem);
+        let reopened = SqliteMemory::new(workspace).unwrap();
+        let conn = reopened.conn.lock();
+        let row: (String, String, String) = conn
+            .query_row(
+                "SELECT status, trigger_reason, artifact_refs FROM dream_sessions WHERE session_id = ?1",
+                params!["sess-123"],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(row.0, "completed");
+        assert_eq!(row.1, "manual");
+        assert_eq!(row.2, "[\"dream/session/sess-123\"]");
+
+        let memory: (String, String) = conn
+            .query_row(
+                "SELECT key, content FROM memories WHERE session_id = ?1",
+                params!["sess-123"],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(memory.0, core_key);
+        assert_eq!(memory.1, core_content);
+    }
+
+    #[test]
+    fn sqlite_dream_metadata_and_artifact_write_is_atomic() {
+        let (_tmp, mem) = temp_sqlite();
+        {
+            let conn = mem.conn.lock();
+            conn.execute(
+                "INSERT INTO sessions (id, started_at, status, message_count, last_activity)
+                 VALUES (?1, ?2, 'ended', 1, ?2)",
+                params!["sess-atomic", "2026-04-26T10:00:00Z"],
+            )
+            .unwrap();
+        }
+
+        let conn = mem.conn.lock();
+        let tx = conn.unchecked_transaction().unwrap();
+        tx.execute(
+            "INSERT INTO memories (id, key, content, category, session_id, created_at, updated_at)
+             VALUES (?1, ?2, ?3, 'core', ?4, ?5, ?5)",
+            params![
+                "artifact-atomic",
+                "dream/session/sess-atomic",
+                "atomic write",
+                "sess-atomic",
+                "2026-04-26T10:05:00Z"
+            ],
+        )
+        .unwrap();
+        tx.execute(
+            "INSERT INTO dream_sessions (session_id, status, trigger_reason, completion_recorded_at, artifact_refs)
+             VALUES (?1, 'running', 'manual', ?2, ?3)",
+            params![
+                "sess-atomic",
+                "2026-04-26T10:00:00Z",
+                "[\"dream/session/sess-atomic\"]"
+            ],
+        )
+        .unwrap();
+        tx.rollback().unwrap();
+
+        let artifact_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE session_id = ?1",
+                params!["sess-atomic"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let metadata_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM dream_sessions WHERE session_id = ?1",
+                params!["sess-atomic"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(artifact_count, 0);
+        assert_eq!(metadata_count, 0);
+    }
+
+    #[test]
+    fn sqlite_dream_duplicate_session_metadata_is_suppressed() {
+        let (_tmp, mem) = temp_sqlite();
+        {
+            let conn = mem.conn.lock();
+            conn.execute(
+                "INSERT INTO sessions (id, started_at, status, message_count, last_activity)
+                 VALUES (?1, ?2, 'ended', 1, ?2)",
+                params!["sess-dup", "2026-04-26T10:00:00Z"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO dream_sessions (session_id, status, trigger_reason, completion_recorded_at, artifact_refs)
+                 VALUES (?1, 'completed', 'manual', ?2, ?3)",
+                params![
+                    "sess-dup",
+                    "2026-04-26T10:00:00Z",
+                    "[\"dream/session/sess-dup\"]"
+                ],
+            )
+            .unwrap();
+        }
+
+        let conn = mem.conn.lock();
+        let duplicate = conn.execute(
+            "INSERT INTO dream_sessions (session_id, status, trigger_reason, completion_recorded_at, artifact_refs)
+             VALUES (?1, 'completed', 'manual', ?2, ?3)",
+            params![
+                "sess-dup",
+                "2026-04-26T10:00:00Z",
+                "[\"dream/session/sess-dup\"]"
+            ],
+        );
+        assert!(duplicate.is_err());
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM dream_sessions WHERE session_id = ?1",
+                params!["sess-dup"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn sqlite_dream_retry_candidates_include_failed_and_pending_but_not_completed() {
+        let (_tmp, mem) = temp_sqlite();
+        let conn = mem.conn.lock();
+        for (session_id, status) in [
+            ("sess-pending", "pending"),
+            ("sess-failed", "failed"),
+            ("sess-completed", "completed"),
+        ] {
+            conn.execute(
+                "INSERT INTO sessions (id, started_at, status, message_count, last_activity)
+                 VALUES (?1, ?2, 'ended', 1, ?2)",
+                params![session_id, "2026-04-26T10:00:00Z"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO dream_sessions (session_id, status, trigger_reason, completion_recorded_at, artifact_refs, failure_reason)
+                 VALUES (?1, ?2, 'manual', ?3, '[]', CASE WHEN ?2 = 'failed' THEN 'transient' ELSE NULL END)",
+                params![session_id, status, "2026-04-26T10:00:00Z"],
+            )
+            .unwrap();
+        }
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT session_id FROM dream_sessions
+                 WHERE status IN ('pending', 'failed')
+                 ORDER BY session_id ASC",
+            )
+            .unwrap();
+        let ids: Vec<String> = stmt
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .map(|row| row.unwrap())
+            .collect();
+
+        assert_eq!(
+            ids,
+            vec!["sess-failed".to_string(), "sess-pending".to_string()]
+        );
     }
 
     #[tokio::test]

--- a/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/design.md
+++ b/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/design.md
@@ -1,0 +1,689 @@
+# Technical Design: Dream System — Long-Term Memory Consolidation
+
+> **Change:** 2026-04-26-dream-system
+> **Issue:** #526
+> **Date:** 2026-04-26
+> **Status:** Design
+
+---
+
+## 1. Technical Approach
+
+Implement Dream as a **runtime-owned post-session consolidation pipeline** centered in
+`clients/agent-runtime/src/memory/`. The gateway remains a trigger source, sessions remain the
+lifecycle source for completion state, and Dream itself becomes the source-of-truth for
+eligibility, consolidation, persistence, replay safety, and backend parity.
+
+The design intentionally upgrades the existing seed implementation in `memory/dream.rs` rather than
+introducing a new subsystem. The current file-oriented consolidation flow and state file/lock file
+mechanics provide the implementation seam, but the behavior shifts from coarse workspace-level
+maintenance into **per-completed-session deterministic consolidation**.
+
+**Implementation phases:**
+
+1. **Dream runtime contract** — define per-session eligibility, artifact shape, and Dream state
+2. **Session-integrated triggering** — ensure completion recording precedes Dream evaluation
+3. **Backend parity** — persist/hydrate/export Dream artifacts and replay state across sqlite,
+   markdown, and snapshot flows
+4. **Hardening** — locking, idempotency, observability, and end-to-end tests
+
+All changes are additive and rollback-safe. Existing session completion continues to work if Dream is
+skipped or disabled.
+
+---
+
+## 2. Architecture Decisions
+
+### ADR-1: Dream belongs to the memory/runtime domain, not gateway
+
+**Decision:** The primary behavioral contract for Dream will live in runtime memory modules and be
+specified under the gateway source-of-truth already used for runtime memory behavior, with gateway
+changes limited to trigger integration.
+
+**Rationale:**
+
+- Proposal and delta specs require gateway to be trigger-only.
+- Current hooks already call `record_session_completion` and `run_dream_if_triggered` from gateway,
+  which is sufficient as an integration seam.
+- Consolidation semantics, backend persistence, hydration, and replay are memory concerns, not HTTP
+  concerns.
+
+**Consequence:**
+
+- Gateway code should not decide whether a session is Dream-eligible.
+- Gateway code should not format or persist Dream artifacts directly.
+- Runtime modules define ordering and idempotency; gateway only invokes them.
+
+### ADR-2: Dream is keyed by completed session identity
+
+**Decision:** The unit of consolidation is a single recorded completed session, identified by
+`session_id`.
+
+**Rationale:**
+
+- The delta specs require Dream to target a specific completed session.
+- Per-session identity gives a natural idempotency key and simplifies replay safety.
+- It lets the runtime distinguish “completion observed”, “consolidation in progress”, and
+  “consolidation completed” for the same session.
+
+**Consequence:**
+
+- `record_session_completion` must evolve from a global counter update into a session-aware write.
+- Dream state must include enough information to determine whether a given `session_id` is pending,
+  running, completed, or failed.
+- Trigger logic can still batch or defer work, but artifact ownership remains session-scoped.
+
+### ADR-3: Consolidation output is distilled memory plus replay metadata
+
+**Decision:** Dream produces two durable outputs:
+
+1. **long-term memory artifacts** containing distilled high-value information, and
+2. **Dream replay metadata** describing the consolidation outcome for that completed session.
+
+**Rationale:**
+
+- The gateway spec requires durable distilled memory, not transcript retention.
+- The same spec also requires enough persisted state to avoid ambiguous replay.
+- Separating memory artifact content from execution metadata keeps retrieval surfaces clean while
+  preserving exact replay semantics.
+
+**Consequence:**
+
+- Dream artifacts are stored as normal long-term memory entries/files.
+- Replay metadata is stored separately and never treated as user-facing knowledge.
+- Snapshot/export flows must preserve both.
+
+### ADR-4: Deterministic ordering is completion-recorded-first, Dream-evaluated-second
+
+**Decision:** The runtime contract is:
+
+1. session completion is recorded in the session system,
+2. Dream completion state is recorded or enqueued against that completed session,
+3. Dream evaluates eligibility and consolidates afterward.
+
+**Rationale:**
+
+- Required by the sessions and gateway integration deltas.
+- Avoids in-flight notions of completion derived only from transport success.
+- Makes stale-session auto-close compatible with the same post-completion path.
+
+**Consequence:**
+
+- `end_session` and stale auto-close become valid producers of the same Dream trigger input.
+- Dream must refuse sessions that are not present as recorded completed sessions.
+- Retry paths can safely re-run because recorded completion is the durable precondition.
+
+### ADR-5: Locking is two-level: global runner lock plus per-session idempotency state
+
+**Decision:** Dream will use:
+
+- a **global runner lock** to serialize filesystem/maintenance-style Dream execution where needed,
+  and
+- **per-session durable status markers** to prevent duplicate consolidation for individual sessions.
+
+**Rationale:**
+
+- Current `dream.lock` behavior is already useful for coarse serialization.
+- A global lock alone is insufficient for replay-safe idempotency.
+- A per-session state machine makes repeated gateway callbacks and post-restore retries safe.
+
+**Consequence:**
+
+- “Busy” remains a valid Dream result when another run is already active.
+- Retrying after a busy/failed state consults per-session Dream state first.
+- Global serialization can be relaxed later without changing the session-level contract.
+
+### ADR-6: Backend parity means preserving artifacts and Dream replay state, not identical storage format
+
+**Decision:** SQLite, markdown, and snapshot support may persist Dream differently, but all supported
+backends must preserve:
+
+- durable Dream artifacts,
+- mapping from artifact(s) to completed session identity, and
+- enough Dream replay state to keep repeat triggers unambiguous after restart/export/hydration.
+
+**Rationale:**
+
+- Specs require behavioral parity, not identical implementation details.
+- SQLite naturally supports relational state; markdown requires explicit sidecar/state-file
+  conventions; snapshot needs an exportable representation.
+
+**Consequence:**
+
+- We keep one semantic contract across backends.
+- We do not force markdown into a relational shape, but we do require explicit persisted replay
+  metadata.
+
+---
+
+## 3. Runtime and Data Flow
+
+### 3.1 Primary Dream trigger flow
+
+```text
+┌─────────────┐     request/session end     ┌─────────────┐
+│ Gateway /   │ ───────────────────────────►│ Sessions /  │
+│ Hygiene     │                             │ Memory API  │
+└──────┬──────┘                             └──────┬──────┘
+       │                                           │
+       │ record completed session                  │
+       │                                           ▼
+       │                                   sessions table / recorded
+       │                                   completed session state
+       │                                           │
+       │ call Dream trigger hook                   │
+       ▼                                           ▼
+┌─────────────┐                             ┌──────────────┐
+│ dream.rs    │ ─ eligibility lookup ────► │ transcript + │
+│ coordinator │                             │ session data │
+└──────┬──────┘                             └──────┬───────┘
+       │                                           │
+       │ synthesize distilled memories             │
+       ▼                                           │
+┌──────────────┐                                   │
+│ backend      │ ◄──────── persist artifacts ──────┘
+│ persistence  │
+└──────┬───────┘
+       │ persist replay metadata
+       ▼
+┌──────────────┐
+│ Dream state  │
+│ completed    │
+└──────────────┘
+```
+
+### 3.2 Completion-to-Dream ordering
+
+1. A runtime path ends a session (`end_session`) or the hygiene pass auto-closes a stale session.
+2. The runtime persists completed-session state (`ended_at`, `status='ended'`).
+3. Dream trigger input is recorded for that `session_id`.
+4. Dream checks whether that completed session has already been consolidated.
+5. If not consolidated, Dream loads session transcript and relevant contextual memory.
+6. Dream distills stable high-value facts/summaries.
+7. Dream writes memory artifacts through the active backend.
+8. Dream writes replay metadata marking the session as completed for Dream purposes.
+
+### 3.3 Eligibility model
+
+For MVP, Dream eligibility is intentionally simple and deterministic:
+
+- session must exist,
+- session must be recorded completed,
+- session must not already have a successful Dream completion record,
+- required source material for consolidation must be readable,
+- optional trigger thresholds may decide **when** to run, but not **whether** the already completed
+  session is conceptually a candidate.
+
+This keeps the spec-aligned distinction between:
+
+- **candidate selection**: based on recorded completed sessions, and
+- **scheduler timing**: whether the runtime executes immediately or as part of a due run.
+
+### 3.4 Consolidation behavior
+
+Dream does not store a raw transcript as the durable output. Instead it distills:
+
+- durable user preferences,
+- project facts and decisions,
+- unresolved follow-up items that matter beyond the session,
+- stable environment/context details worth future recall,
+- other high-signal summaries appropriate for long-term memory.
+
+MVP consolidation should bias toward predictable additive summaries rather than sophisticated
+ranking or aggressive pruning heuristics.
+
+### 3.5 Trigger batching vs session ownership
+
+The current seed implementation uses session-count/time thresholds and a workspace-wide run. This can
+be retained as the **scheduler policy**, but the consolidation contract changes to session ownership:
+
+- the scheduler decides when Dream work wakes up,
+- Dream then drains eligible completed sessions deterministically,
+- each drained session gets exactly one logical Dream result.
+
+This allows today’s `sessions_since_last_run` / time-based triggers to survive as an implementation
+optimization without remaining the logical source-of-truth.
+
+---
+
+## 4. File and Module Changes Likely Needed
+
+### 4.1 `clients/agent-runtime/src/memory/dream.rs`
+
+**Primary changes:**
+
+- Introduce session-aware Dream state types, likely including:
+  - pending/completed/failed per-session records
+  - artifact references
+  - timestamps / last-attempt metadata
+- Refactor `record_session_completion(workspace_dir)` into a session-aware API, likely accepting at
+  least `session_id`
+- Refactor `run_if_triggered(workspace_dir)` to enumerate eligible completed sessions rather than
+  only doing workspace-level line merging
+- Preserve current lock semantics where useful, but apply them around session draining
+- Emit a Dream report that can summarize per-run and per-session outcomes
+
+**Why:** This file is already the seed implementation and exported as the canonical Dream module.
+
+### 4.2 `clients/agent-runtime/src/memory/mod.rs`
+
+**Likely changes:**
+
+- Re-export revised Dream APIs/types
+- Invoke the new Dream trigger API in startup or due-run paths without changing ownership
+- Keep hydration/export sequencing compatible with Dream state restore
+
+### 4.3 `clients/agent-runtime/src/memory/sqlite.rs`
+
+**Likely changes:**
+
+- Add Dream persistence schema, likely a `dream_runs` and/or `dream_sessions` table
+- Store Dream artifact references and Dream status by `session_id`
+- Expose helper methods used by Dream to:
+  - discover completed sessions without completed Dream state,
+  - read session-scoped memories/transcript inputs,
+  - persist Dream artifacts and replay metadata atomically where possible
+- Extend migration logic additively
+
+**Possible schema direction:**
+
+```sql
+CREATE TABLE IF NOT EXISTS dream_sessions (
+    session_id         TEXT PRIMARY KEY,
+    status             TEXT NOT NULL,         -- pending | running | completed | failed
+    trigger_reason     TEXT,
+    artifact_refs      TEXT,                  -- JSON array or normalized child rows
+    last_attempt_at    TEXT,
+    completed_at       TEXT,
+    failure_reason     TEXT,
+    FOREIGN KEY(session_id) REFERENCES sessions(id)
+);
+CREATE INDEX IF NOT EXISTS idx_dream_sessions_status ON dream_sessions(status);
+```
+
+The exact schema can vary, but the important part is durable replay-safe session identity.
+
+### 4.4 `clients/agent-runtime/src/memory/markdown.rs`
+
+**Likely changes:**
+
+- Define where Dream metadata lives for markdown-backed persistence
+- Preserve Dream artifact/session association in a file-compatible way
+- Continue storing user-facing long-term memory in markdown while keeping replay metadata separate
+
+**Recommended layout:**
+
+```text
+workspace/
+├── MEMORY.md
+├── memory/
+│   ├── 2026-04-26.md
+│   └── ...
+└── .corvus/
+    └── dream_state.json
+```
+
+The current `dream_state.json` is a reasonable sidecar for markdown replay metadata. If Dream
+artifacts need explicit per-session structure, that can also be captured in sidecar JSON while
+keeping `MEMORY.md` human-readable.
+
+### 4.5 `clients/agent-runtime/src/memory/snapshot.rs`
+
+**Likely changes:**
+
+- Export Dream artifacts as part of snapshot-visible long-term memory
+- Export enough Dream replay state for later hydration/restart safety
+- Hydrate Dream replay metadata when restoring a workspace
+
+Because the current snapshot exports only core memories, the design needs either:
+
+1. embedding Dream artifacts directly as core memory entries plus a Dream metadata section, or
+2. extending snapshot export to include a sidecar state file alongside `MEMORY_SNAPSHOT.md`.
+
+The simplest MVP is to keep `MEMORY_SNAPSHOT.md` for user-visible memory and add a machine-readable
+Dream state companion file if required.
+
+### 4.6 `clients/agent-runtime/src/memory/hygiene.rs`
+
+**Likely changes:**
+
+- After stale-session auto-close, ensure those closed sessions can enter the same Dream trigger path
+- Optionally return affected session IDs, not only an affected count, if Dream needs direct enqueue
+  semantics
+
+Today hygiene closes stale sessions in SQL but does not identify which sessions now require Dream
+follow-up. This is the main integration gap for spec compliance.
+
+### 4.7 Gateway integration points
+
+**Likely changes:**
+
+- Update `gateway/mod.rs` completion path around lines already invoking `record_session_completion`
+  and `run_dream_if_triggered`
+- Pass `session_id` into the Dream completion-record API
+- Keep gateway behavior best-effort and trigger-only
+
+### 4.8 Session service / command modules
+
+Even though there is no dedicated `src/session/` directory, session lifecycle behavior exists across
+SQLite/session command services and must align with Dream:
+
+- consistent end-of-session semantics,
+- consistent idempotent completion recording,
+- optional helper to fetch completed session transcript/source content.
+
+---
+
+## 5. Backend Behavior Across SQLite, Markdown, Snapshot Hydration, and Export
+
+### 5.1 SQLite backend
+
+SQLite is the strongest backend for Dream and should be treated as the reference implementation.
+
+**Behavior:**
+
+- Session completion is read from the `sessions` table.
+- Dream replay state is persisted in dedicated Dream tables.
+- Dream memory artifacts are stored either in `memories` with a Dream-distinguishing key/category
+  convention or in a normalized Dream artifact table plus memory entry rows.
+- Artifact creation and Dream completion metadata should be written in one transaction where
+  practical.
+
+**Recommended invariant:** after a successful transaction, both the artifact and the completed Dream
+status are visible together.
+
+### 5.2 Markdown backend
+
+Markdown cannot rely on SQL transactions, so parity is semantic rather than structural.
+
+**Behavior:**
+
+- Distilled Dream output is appended/merged into `MEMORY.md` or another established long-term memory
+  markdown file.
+- Replay metadata persists separately in `dream_state.json` (or a similar sidecar file) keyed by
+  `session_id`.
+- On restart, Dream reads replay metadata before considering a completed session eligible again.
+
+**Recommended invariant:** if artifact write succeeds but replay metadata write fails, the next run
+must reconcile conservatively and avoid producing ambiguous duplicate output.
+
+A practical recovery strategy is to store artifact references or a deterministic Dream key derived
+from `session_id`, allowing Dream to detect that the durable artifact already exists before writing a
+second one.
+
+### 5.3 Snapshot export
+
+Snapshot export currently focuses on core memory visibility. Dream extends the export surface.
+
+**Behavior required:**
+
+- Dream artifacts that are part of durable long-term memory must appear in exportable state.
+- Dream replay metadata must also be exportable or reconstructable.
+
+**Preferred MVP:**
+
+- continue exporting user-visible durable memory to `MEMORY_SNAPSHOT.md`,
+- add a machine-readable Dream metadata companion if existing markdown snapshot format is too limited
+  for replay state.
+
+### 5.4 Snapshot hydration
+
+Hydration must restore enough state that repeated Dream triggers do not treat already consolidated
+sessions as fresh work.
+
+**Behavior required:**
+
+- restore Dream artifacts into the target backend,
+- restore Dream replay metadata, or reconstruct it unambiguously from imported Dream artifacts.
+
+**Design bias:** explicit Dream replay metadata is safer than inference from prose memory content.
+
+### 5.5 Export/hydration non-goal
+
+We are **not** trying to make snapshot files an exhaustive forensic dump of every Dream internal.
+The requirement is only to preserve long-term memory outputs and enough replay state for idempotent
+behavior.
+
+---
+
+## 6. Idempotency and Locking Strategy
+
+### 6.1 Idempotency model
+
+Idempotency key: **`session_id` for a recorded completed session**.
+
+A session’s Dream lifecycle is:
+
+- `pending` — completion observed, Dream not yet finalized
+- `running` — Dream currently consolidating
+- `completed` — durable artifact(s) and replay metadata recorded
+- `failed` — last attempt failed; retry policy may re-enter deterministically
+
+### 6.2 Completion-path idempotency
+
+Repeated completion handling for the same session must be safe.
+
+**Rules:**
+
+- Recording completion in the session system must stay idempotent (`ended_at` not rewritten once set).
+- Recording Dream trigger input for the same `session_id` must be upsert-like.
+- If Dream already completed for the session, subsequent completion hooks are no-ops for
+  consolidation.
+
+### 6.3 Consolidation-path idempotency
+
+Before writing any output, Dream checks persisted replay state.
+
+- If `completed`, skip.
+- If `running`, skip or treat as busy depending on lock ownership.
+- If `pending`/`failed`, attempt deterministic consolidation.
+
+Artifacts should be written with deterministic references where feasible, for example a stable Dream
+key derived from `session_id`, so duplicate writes can be recognized by storage layers that lack full
+transactions.
+
+### 6.4 Locking strategy
+
+**Global lock:** retain a coarse lock such as `dream.lock` to serialize a Dream run over a workspace.
+This prevents overlapping scanners/pruners and is especially important for markdown/file backends.
+
+**Per-session state:** use durable state to prevent duplicate output even if:
+
+- gateway retries completion,
+- the process crashes after completion recording,
+- snapshot restore is followed by another Dream trigger,
+- stale-session auto-close re-enters the same logic.
+
+### 6.5 Failure windows and recovery
+
+Potential failure windows:
+
+1. completion recorded, Dream state not yet marked pending
+2. Dream pending/running marked, artifact not written
+3. artifact written, replay metadata not finalized
+
+**Recovery posture:**
+
+- favor deterministic artifact keys and replay metadata updates,
+- re-check storage before writing duplicate artifacts,
+- mark failed attempts explicitly so retries remain visible and bounded.
+
+This keeps the system conservative: better to skip duplicate work than to emit ambiguous duplicate
+memories.
+
+---
+
+## 7. Integration Boundaries with Sessions and Gateway
+
+### 7.1 Sessions boundary
+
+Sessions own:
+
+- whether a session exists,
+- whether it is active or completed,
+- completion timestamps and lifecycle state,
+- transcript/snapshot sources used by Dream as inputs.
+
+Dream owns:
+
+- whether a recorded completed session should be consolidated now,
+- what durable long-term artifact is produced,
+- replay metadata and duplicate suppression.
+
+**Boundary rule:** Dream never infers completion solely from message flow or gateway success; it only
+acts on recorded completion.
+
+### 7.2 Gateway boundary
+
+Gateway owns:
+
+- invoking session completion paths when generated sessions finish,
+- invoking Dream hooks in runtime-defined order,
+- preserving runtime idempotency by delegating duplicate safety downward.
+
+Gateway does **not** own:
+
+- Dream eligibility rules,
+- Dream content selection,
+- Dream persistence format,
+- public Dream-specific HTTP contracts for this slice.
+
+### 7.3 Hygiene boundary
+
+Hygiene is another completion producer, not a separate Dream implementation.
+
+When stale sessions are auto-closed, they must feed the same Dream trigger path as gateway-driven
+completion so there is one semantic notion of “completed session became a Dream candidate.”
+
+### 7.4 Session snapshots / slash-session lifecycle boundary
+
+Existing session snapshot/tldr/compact machinery may be used as Dream inputs, but this change does
+not redefine slash-session lifecycle behavior. Dream may consume those artifacts opportunistically
+when they are the best available summary source.
+
+---
+
+## 8. Testing Strategy
+
+### 8.1 Unit tests
+
+Add focused tests in `memory/dream.rs` and relevant backend modules for:
+
+- rejecting active/non-completed sessions,
+- recording completion for a specific `session_id`,
+- duplicate trigger suppression,
+- replay-safe behavior after state reload,
+- lock contention returning a safe busy/skipped result,
+- deterministic artifact key/reference generation.
+
+### 8.2 SQLite integration tests
+
+Add tests around SQLite-backed Dream state covering:
+
+- completed session becomes pending and then completed,
+- repeated completion hook does not create duplicate Dream rows or artifacts,
+- transaction/atomicity expectations for artifact + Dream metadata,
+- stale auto-closed session later gets Dream eligibility,
+- restore from snapshot/export does not reconsolidate ambiguously.
+
+### 8.3 Markdown backend tests
+
+Add tests covering:
+
+- Dream artifact persistence into markdown long-term memory,
+- replay metadata in sidecar state,
+- restart behavior using only persisted files,
+- conservative recovery if artifact exists but metadata is incomplete.
+
+### 8.4 Snapshot tests
+
+Add tests for:
+
+- export includes Dream-visible durable memory,
+- hydration restores enough Dream replay state,
+- post-hydration re-trigger remains idempotent.
+
+### 8.5 Gateway/session integration tests
+
+Add tests around the completion path already present in `gateway/mod.rs`:
+
+- gateway calls completion recording before Dream trigger,
+- retrying the same generated-session completion path stays safe,
+- no Dream-specific HTTP contract is required.
+
+### 8.6 Regression tests for hygiene
+
+Add tests ensuring:
+
+- stale session auto-close produces a valid downstream Dream trigger input,
+- hygiene-triggered completion and gateway-triggered completion converge on the same Dream semantics.
+
+### 8.7 Validation scope
+
+For code changes, the expected validation baseline is:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+If snapshot/export tests are expensive or platform-sensitive, document any scoped subset explicitly.
+
+---
+
+## 9. Explicit Non-Goals and Deferred Items
+
+### Non-goals for this change
+
+- Re-architecting orchestration around Dream
+- Adding a new public Dream-specific gateway API
+- Building operator/admin UX for Dream inspection beyond what existing runtime verification needs
+- Redesigning general memory retrieval/ranking outside consolidation requirements
+- Implementing speculative autonomous background schedulers beyond the approved trigger model
+- Storing full transcripts as the durable Dream output contract
+
+### Deferred items
+
+- richer heuristics for selecting/highlighting “important” memories,
+- multi-session thematic consolidation,
+- advanced scoring or semantic deduplication,
+- operator tooling to inspect Dream run history/artifacts,
+- orchestration reuse once the runtime contract stabilizes,
+- finer-grained concurrency beyond the initial global-lock + per-session-state model.
+
+---
+
+## 10. Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Current seed Dream implementation is workspace-oriented rather than session-oriented | Medium | Refactor around session identity while preserving trigger thresholds only as scheduler inputs |
+| Hygiene auto-close does not currently surface session IDs for Dream follow-up | Medium | Extend hygiene/session integration to return or enumerate newly completed sessions deterministically |
+| Markdown backend lacks transactional guarantees | Medium | Use deterministic artifact keys plus durable replay metadata sidecar and conservative recovery logic |
+| Snapshot export may not currently encode enough replay metadata | Medium | Add explicit Dream metadata export/hydration path rather than inferring from prose alone |
+| Gateway retries may re-enter completion logic | Medium | Keep completion recording idempotent and move duplicate suppression into runtime Dream state |
+| Distillation quality may vary | Low/Medium | Scope MVP to stable summaries/facts and defer advanced heuristics |
+
+---
+
+## 11. Rollout and Rollback Notes
+
+### Rollout
+
+- Land Dream state contract first.
+- Wire session-aware trigger recording next.
+- Add backend parity and hydration/export support.
+- Finish with end-to-end hardening tests.
+
+### Rollback
+
+If Dream produces incorrect or duplicate memories:
+
+1. disable Dream trigger invocation while leaving normal session completion intact,
+2. retain additive schema/state files where safe,
+3. ignore Dream replay metadata during runtime startup if necessary,
+4. stop producing new Dream artifacts until corrected.
+
+Because the design is additive, rollback should isolate Dream without regressing ordinary session and
+memory behavior.

--- a/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/design.md
+++ b/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/design.md
@@ -487,6 +487,9 @@ transactions.
 **Global lock:** retain a coarse lock such as `dream.lock` to serialize a Dream run over a workspace.
 This prevents overlapping scanners/pruners and is especially important for markdown/file backends.
 
+**Stale-lock recovery:** ADR-5, §6.4, and §11 require a documented recovery posture for `dream.lock`.
+Use OS-level advisory file locking where available so process death automatically releases the held lock even if the lock file path remains on disk. When a reclaim attempt detects an existing `dream.lock` file but cannot acquire the OS lock, treat the run as busy and log the refusal. If an operator suspects a stale file-path artifact, validate that no active Corvus process still holds the lock (for example via process inspection or a retry after the suspected owner exits) before deleting `dream.lock`. Any manual reclaim should log the workspace path, detection reason, and validation outcome so postmortems can distinguish a safe cleanup from a live-lock contention event.
+
 **Per-session state:** use durable state to prevent duplicate output even if:
 
 - gateway retries completion,

--- a/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/proposal.md
+++ b/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/proposal.md
@@ -1,0 +1,140 @@
+# Proposal: Dream System: Long-Term Memory Consolidation
+
+## Intent
+
+Issue #526 introduces a runtime-level "dream system" that consolidates completed session history into durable long-term memory so Corvus can preserve important knowledge without carrying full conversational transcripts forward indefinitely.
+
+Exploration confirms that Dream already has seed implementation in `clients/agent-runtime/src/memory/dream.rs`, is exported from `clients/agent-runtime/src/memory/mod.rs`, and is already hooked from gateway session-completion flows via `record_session_completion` and `run_dream_if_triggered`. The proposal therefore focuses on promoting Dream from partial plumbing to a defined runtime memory capability with clear consolidation semantics, durable backend behavior, and explicit integration boundaries for sessions and gateway.
+
+## Summary
+
+This change will define and complete Dream as a memory/runtime-oriented feature that:
+
+- detects eligible completed sessions,
+- consolidates high-value information from session history into durable long-term memory,
+- persists Dream artifacts across supported memory backends,
+- updates session/runtime integration so consolidation is deterministic and safe,
+- keeps gateway changes limited to integration points that trigger or expose runtime behavior.
+
+## Motivation
+
+Corvus currently has the primitives needed for long-term memory consolidation, but Dream is not yet specified as a first-class capability. Without a source-of-truth contract:
+
+- session completion may record closure without guaranteed long-term consolidation behavior,
+- different memory backends may diverge in how Dream artifacts persist or hydrate,
+- runtime and gateway responsibilities can blur,
+- future changes risk treating orchestration or HTTP entrypoints as the primary domain instead of memory/runtime.
+
+A dedicated proposal is needed to align implementation around the runtime memory model and to make issue #526 deliverable in phased, testable slices.
+
+## Scope
+
+### In Scope
+- Define Dream as a runtime memory-consolidation capability centered in `clients/agent-runtime/src/memory/`.
+- Specify how completed sessions become Dream candidates and when consolidation is triggered.
+- Specify the durable outputs Dream writes into long-term memory and/or Dream-specific persisted state.
+- Align SQLite, markdown, and snapshot hydration/export behavior so Dream artifacts survive restart, export, and reload flows.
+- Clarify session lifecycle integration points required to make consolidation deterministic after session completion.
+- Clarify gateway integration points that trigger runtime Dream flows without making gateway the behavioral source-of-truth.
+- Establish phased delivery intent for issue #526, including MVP consolidation first and optional follow-on refinements later.
+
+### Out of Scope / Non-Goals
+- Re-architecting multi-agent orchestration around Dream.
+- Making orchestration reuse the primary spec domain for this change.
+- Large new admin/operator UX surfaces for inspecting Dream artifacts unless required for existing runtime or gateway verification.
+- General memory ranking, retrieval, or recommendation redesign outside Dream consolidation needs.
+- Broad changes to unrelated gateway HTTP contracts except where needed to preserve integration correctness.
+- Implementing speculative autonomous background schedulers beyond the approved Dream trigger model.
+
+## Approach
+
+The change should be specified primarily under a memory/runtime-oriented domain, with gateway and sessions treated as affected integration domains rather than the source of truth.
+
+At a high level, Dream should:
+
+1. observe session completion or another explicit runtime-eligible trigger,
+2. identify whether the finished session satisfies Dream eligibility criteria,
+3. read the relevant session transcript/memory context,
+4. synthesize durable long-term memory artifacts from that session,
+5. persist those artifacts through supported backends and snapshot/export paths,
+6. record enough Dream state to avoid duplicate or ambiguous consolidation for the same session.
+
+The proposal intentionally biases toward additive behavior that reuses the existing seed implementation and hooks already present in the runtime and gateway.
+
+## Affected Spec Domains
+
+| Domain | Role in Change | Why |
+|---|---|---|
+| `memory` / new Dream-focused runtime memory domain | Primary | Dream is fundamentally a long-term memory consolidation feature and should be specified where memory behavior lives. |
+| `sessions` | Modified | Session completion, eligibility, and deduplication rules need explicit integration with Dream. |
+| `gateway` | Modified (integration only) | Gateway already invokes Dream-related hooks and may need contract updates for runtime-triggered completion behavior. |
+| `memory-visibility` | Possible follow-up | Only if existing admin visibility needs to expose Dream outputs for verification or operations. |
+| `multi-agent-orchestration` | No primary change | Reuse is optional and explicitly not the main domain for this slice. |
+
+## Affected Modules / Packages
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `clients/agent-runtime/src/memory/dream.rs` | Modified | Promote seed Dream logic into the canonical runtime consolidation path. |
+| `clients/agent-runtime/src/memory/mod.rs` | Modified | Maintain Dream exports and memory module integration. |
+| `clients/agent-runtime/src/memory/` backend implementations | Modified | Ensure SQLite, markdown, and snapshot-related backends persist and reload Dream artifacts consistently. |
+| `clients/agent-runtime/src/session/` or equivalent session lifecycle modules | Modified | Ensure completion state, idempotency, and Dream eligibility are coordinated with session closure. |
+| `clients/agent-runtime` snapshot hydration/export paths | Modified | Preserve Dream outputs across hydration, export, and restore flows. |
+| Gateway integration points calling `record_session_completion` and `run_dream_if_triggered` | Modified | Keep trigger wiring aligned with runtime-defined Dream behavior. |
+
+## Phased Intent
+
+### Phase 1: Dream Contract and Runtime MVP
+- Define Dream eligibility, trigger timing, and persistence expectations.
+- Ensure one completed session can be consolidated deterministically into long-term memory.
+- Make duplicate-trigger behavior explicit and safe.
+
+### Phase 2: Backend and Snapshot Parity
+- Guarantee Dream artifacts survive SQLite persistence, markdown storage where supported, and snapshot hydration/export.
+- Ensure restored runtimes do not lose Dream state or replay ambiguously.
+
+### Phase 3: Integration Hardening
+- Align session lifecycle and gateway integration behavior with the Dream contract.
+- Add any minimal observability or verification hooks required to validate consolidation end-to-end.
+
+### Deferred / Future Considerations
+- Rich operator inspection workflows for Dream outputs.
+- More advanced consolidation heuristics, scoring, or background scheduling.
+- Optional orchestration-driven reuse once the memory/runtime contract is stable.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Dream behavior duplicates or re-consolidates the same session multiple times | Medium | Require explicit idempotency markers or persisted Dream state tied to session completion. |
+| Backends diverge in Dream persistence semantics | Medium | Specify minimum persistence and hydration/export guarantees across supported backends. |
+| Gateway becomes the accidental source-of-truth for Dream behavior | Medium | Keep behavioral requirements in the memory/runtime domain and limit gateway spec changes to trigger integration. |
+| Session closure semantics conflict with consolidation timing | Medium | Define exact ordering between session completion recording and Dream triggering in the sessions integration spec. |
+| Consolidated memories are too lossy or too verbose | Medium | Scope MVP to stable, high-value summaries/facts and defer advanced heuristics to later phases. |
+
+## Rollback Plan
+
+If Dream consolidation causes incorrect memory persistence, duplicate outputs, or destabilizes session completion:
+
+1. disable Dream triggering at the runtime integration points,
+2. preserve ordinary session completion behavior without consolidation,
+3. retain additive schema/backend changes where safe, but stop producing new Dream artifacts,
+4. remove or ignore Dream-specific reads from restore/hydration paths until corrected.
+
+Because the intended change is additive and runtime-centered, rollback should be able to preserve existing memory/session behavior while isolating Dream-specific execution.
+
+## Dependencies
+
+- Existing session completion hooks already calling `record_session_completion` and `run_dream_if_triggered`.
+- Existing Dream seed implementation in `clients/agent-runtime/src/memory/dream.rs`.
+- Existing memory backend support for SQLite, markdown, and snapshot hydration/export.
+- Follow-on spec work to create delta specs in the primary Dream/memory domain plus sessions and gateway integration domains.
+
+## Success Criteria
+
+- [ ] OpenSpec delta specs define Dream primarily as a memory/runtime capability rather than a gateway feature.
+- [ ] The change specifies deterministic trigger timing and idempotent consolidation for completed sessions.
+- [ ] Supported backends have explicit persistence and hydration/export expectations for Dream artifacts.
+- [ ] Session lifecycle integration clearly defines how completion and Dream triggering interact.
+- [ ] Gateway impact is limited to integration requirements and does not become the behavioral source-of-truth.
+- [ ] The phased plan provides a clear MVP path for issue #526 with advanced heuristics and orchestration reuse deferred.

--- a/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/specs/gateway-integration/spec.md
+++ b/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/specs/gateway-integration/spec.md
@@ -1,0 +1,48 @@
+# Delta for Gateway
+
+## ADDED Requirements
+
+### Requirement: Gateway Dream Integration Is Trigger-Only
+
+Gateway behavior for Dream MUST be limited to invoking the runtime-defined session completion and
+Dream trigger integration points.
+
+The gateway MUST NOT become the behavioral source-of-truth for Dream eligibility, consolidation
+content, or persistence semantics.
+
+#### Scenario: Gateway delegates Dream semantics to runtime
+
+- GIVEN the gateway completes a request flow that reaches the runtime session-completion path
+- WHEN the gateway invokes the completion and Dream trigger integration points
+- THEN the gateway MUST rely on the runtime to determine Dream eligibility and consolidation behavior
+- AND the gateway MUST NOT define independent Dream eligibility rules.
+
+#### Scenario: Gateway acceptance does not require Dream-specific transport contract
+
+- GIVEN the runtime exposes Dream only through existing completion-trigger integration points
+- WHEN a gateway-served request completes successfully
+- THEN the gateway MUST remain valid without adding a new Dream-specific public HTTP contract
+- AND Dream behavior MUST remain an internal runtime concern unless another spec adds a public surface.
+
+### Requirement: Gateway Completion Hooks MUST Preserve Runtime Ordering and Idempotency
+
+When the gateway participates in a session flow that records completion and triggers Dream, it MUST
+invoke those runtime integration points in the runtime-defined order.
+
+The gateway MUST preserve the runtime contract that completion recording happens before Dream
+trigger evaluation, and repeated gateway completion handling for the same session MUST NOT require
+gateway-defined duplicate-consolidation logic.
+
+#### Scenario: Gateway calls completion recording before Dream trigger
+
+- GIVEN a gateway-served session `sess-123` reaches its completion path
+- WHEN the gateway invokes runtime integration for that completion
+- THEN the completion-recording hook MUST run before the Dream-trigger hook
+- AND Dream evaluation MUST consume the runtime-recorded completion state.
+
+#### Scenario: Replayed gateway completion path stays safe through runtime idempotency
+
+- GIVEN the gateway re-enters the same completion path for session `sess-123`
+- WHEN it invokes the runtime completion and Dream hooks again
+- THEN the gateway MUST rely on runtime idempotency for the completed session
+- AND the repeated gateway path MUST NOT require a second independent Dream result.

--- a/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/specs/gateway/spec.md
+++ b/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/specs/gateway/spec.md
@@ -1,0 +1,113 @@
+# Dream Specification
+
+## Purpose
+
+This specification defines Dream as Corvus's runtime-level long-term memory consolidation capability.
+Dream converts eligible completed session history into durable long-term memory artifacts while
+keeping session transcripts and gateway transport concerns separate from the Dream behavioral
+source-of-truth.
+
+## Requirements
+
+### Requirement: Dream Eligibility for Completed Sessions
+
+The runtime MUST treat Dream as a post-session consolidation capability that evaluates completed
+sessions for Dream eligibility.
+
+A Dream run MUST target a specific completed session identity. Dream MUST NOT consolidate sessions
+that have not been recorded as completed.
+
+The eligibility decision MUST be deterministic for the same completed session inputs and runtime
+configuration.
+
+#### Scenario: Completed session becomes a Dream candidate
+
+- GIVEN a session `sess-123` has been recorded as completed
+- AND the runtime can access the relevant session history for `sess-123`
+- WHEN Dream eligibility is evaluated for `sess-123`
+- THEN the runtime MUST treat `sess-123` as a Dream candidate
+- AND the eligibility result MUST be derived from the completed session inputs rather than gateway transport details.
+
+#### Scenario: Active session is not Dream-eligible
+
+- GIVEN a session `sess-123` is still active and has not been recorded as completed
+- WHEN Dream eligibility is evaluated for `sess-123`
+- THEN the runtime MUST reject Dream consolidation for that session
+- AND no Dream artifact MUST be persisted.
+
+### Requirement: Dream Consolidation Output Contract
+
+For an eligible completed session, Dream MUST synthesize durable long-term memory artifacts that
+capture stable high-value knowledge from the completed session.
+
+The Dream output MUST be additive. Dream MUST NOT require preserving the full session transcript as
+the durable long-term memory artifact itself.
+
+The runtime SHOULD favor stable summaries, facts, or other high-value distilled outputs over
+verbatim transcript retention.
+
+#### Scenario: Eligible completed session produces durable distilled memory
+
+- GIVEN a completed session `sess-123` is Dream-eligible
+- WHEN Dream consolidates the session
+- THEN the runtime MUST produce one or more durable long-term memory artifacts for `sess-123`
+- AND those artifacts MUST represent distilled high-value information from the session
+- AND the artifacts MUST be persisted independently of the original request/response transport flow.
+
+#### Scenario: Dream does not require verbatim transcript persistence as output
+
+- GIVEN a completed session `sess-123` contains a multi-turn transcript
+- WHEN Dream completes consolidation for `sess-123`
+- THEN the durable Dream output MUST be allowed to omit verbatim transcript reproduction
+- AND the Dream contract MUST remain satisfied so long as stable high-value information is preserved.
+
+### Requirement: Dream Persistence Across Supported Backends
+
+Dream artifacts MUST survive restart, export, and reload flows across supported memory backends.
+
+For this change, supported backends are the runtime backends that already participate in Corvus
+memory persistence and snapshot hydration/export behavior, including SQLite, markdown, and runtime
+snapshot flows where supported.
+
+A backend that claims Dream support MUST persist both Dream artifacts and enough Dream state to
+avoid ambiguous replay for the same completed session.
+
+#### Scenario: Dream artifacts survive runtime restart and reload
+
+- GIVEN Dream has successfully consolidated completed session `sess-123`
+- AND the runtime persists Dream through a supported backend
+- WHEN the runtime is restarted and its persisted state is reloaded
+- THEN the Dream artifacts for `sess-123` MUST still be available
+- AND the runtime MUST preserve enough Dream state to avoid treating `sess-123` as unconsolidated solely because of the restart.
+
+#### Scenario: Snapshot export and hydration preserve Dream state
+
+- GIVEN Dream artifacts and Dream replay state exist for completed session `sess-123`
+- WHEN the runtime exports its persisted state and later hydrates from that exported state
+- THEN the hydrated runtime MUST restore the Dream artifacts for `sess-123`
+- AND it MUST restore enough Dream state to keep consolidation behavior unambiguous for that session.
+
+### Requirement: Dream Idempotency per Completed Session
+
+Dream consolidation for a completed session MUST be idempotent.
+
+The runtime MUST record enough Dream state to determine whether a completed session has already
+been consolidated or is otherwise no longer eligible for duplicate consolidation.
+
+Repeated Dream triggering for the same completed session MUST NOT create duplicate or ambiguous
+consolidation results.
+
+#### Scenario: Duplicate Dream trigger for completed session is suppressed
+
+- GIVEN completed session `sess-123` has already been successfully consolidated by Dream
+- WHEN Dream is triggered again for `sess-123`
+- THEN the runtime MUST detect that `sess-123` has already been consolidated
+- AND it MUST NOT create a second ambiguous consolidation result for the same completion event.
+
+#### Scenario: Repeated trigger after restore remains idempotent
+
+- GIVEN completed session `sess-123` was consolidated before runtime export or shutdown
+- AND the persisted Dream state is later restored
+- WHEN Dream is triggered again for `sess-123` after restore
+- THEN the runtime MUST preserve idempotent behavior for that session
+- AND it MUST NOT treat the restored runtime as permission to reconsolidate the same completion ambiguously.

--- a/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/specs/sessions/spec.md
+++ b/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/specs/sessions/spec.md
@@ -1,0 +1,75 @@
+# Delta for Sessions
+
+## MODIFIED Requirements
+
+### Requirement: SESS-5: Stale Session Auto-Close
+
+The memory hygiene pass MUST auto-close stale sessions.
+
+- A session is **stale** when `ended_at` IS NULL AND `last_activity` is older than the configured
+  threshold.
+- The default stale threshold MUST be 24 hours.
+- The threshold SHOULD be configurable via runtime config.
+- Auto-close MUST set `ended_at` to the current UTC timestamp, not the `last_activity` time.
+- When a session is auto-closed or otherwise recorded as completed, that completed state MUST be a
+  valid Dream trigger input for downstream runtime Dream evaluation.
+
+(Previously: SESS-5 defined stale-session detection and auto-close timing, but it did not define
+how a recorded completion participates in downstream Dream triggering.)
+
+#### Scenario: Hygiene pass closes stale session and produces a Dream trigger input
+
+- GIVEN an active session `old-session` with last_activity `2026-03-27T08:00:00Z`
+- AND the stale session threshold is 24 hours
+- WHEN the hygiene pass runs at `2026-03-28T10:00:00Z`
+- THEN session `old-session` MUST have ended_at set to `2026-03-28T10:00:00Z`
+- AND the completed state MUST be available for downstream Dream evaluation as a recorded completion.
+
+## ADDED Requirements
+
+### Requirement: Session Completion Must Produce a Deterministic Dream Trigger Input
+
+The runtime MUST record session completion before Dream is evaluated for that session.
+
+Dream evaluation MUST use the recorded completed-session state as its trigger input rather than an
+in-flight or inferred gateway-only notion of completion.
+
+The runtime MUST ensure the completion-to-Dream ordering is deterministic for the same session.
+
+#### Scenario: Dream runs only after completion is recorded
+
+- GIVEN session `sess-123` is reaching the end of its lifecycle
+- WHEN the runtime records session completion for `sess-123`
+- THEN the session MUST first exist in a completed recorded state
+- AND only after that recorded completion MAY Dream be evaluated for `sess-123`.
+
+#### Scenario: Failed or missing completion record blocks Dream evaluation
+
+- GIVEN no recorded completed-session state exists for `sess-123`
+- WHEN Dream would otherwise be evaluated for `sess-123`
+- THEN the runtime MUST NOT consolidate that session
+- AND it MUST treat the missing completion record as a failed trigger precondition.
+
+### Requirement: Session Completion and Dream Triggering Must Be Idempotent Together
+
+The runtime MUST coordinate session completion recording and Dream triggering so repeated completion
+handling for the same session does not create duplicate Dream work.
+
+If the same completion event is observed more than once for a session, the runtime MUST preserve a
+single logical completed session outcome for Dream purposes.
+
+#### Scenario: Repeated completion handling does not duplicate Dream work
+
+- GIVEN session `sess-123` has already been recorded as completed
+- AND Dream has already evaluated or consolidated that completion
+- WHEN the same completion handling path runs again for `sess-123`
+- THEN the runtime MUST preserve a single logical completion outcome
+- AND it MUST NOT create duplicate Dream consolidation for that session.
+
+#### Scenario: Duplicate completion record without prior Dream result remains safe
+
+- GIVEN session `sess-123` has already been recorded as completed
+- AND Dream has not yet produced a durable result for that session
+- WHEN the completion handling path is retried for `sess-123`
+- THEN the runtime MUST keep completion recording idempotent
+- AND any subsequent Dream evaluation MUST remain unambiguous for that same session.

--- a/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/state.yaml
+++ b/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/state.yaml
@@ -1,0 +1,6 @@
+phase: propose
+completed_phases:
+  - explore
+  - propose
+change_name: 2026-04-26-dream-system
+artifact_store: openspec

--- a/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/tasks.md
+++ b/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: Dream System — Long-Term Memory Consolidation
+
+## Phase 1: Runtime Dream contract and TDD foundation
+
+- [x] 1.1 Add RED tests in `clients/agent-runtime/src/memory/dream.rs` for rejecting active sessions, accepting recorded completed sessions, and suppressing duplicate triggers by `session_id`.
+- [x] 1.2 Refactor `clients/agent-runtime/src/memory/dream.rs` to replace the session counter API with session-aware Dream state (`pending|running|completed|failed`), deterministic artifact keys, and per-session reports.
+- [x] 1.3 Update `clients/agent-runtime/src/memory/mod.rs` exports and runtime wiring to expose the new Dream APIs without moving ownership out of memory/runtime.
+- [x] 1.4 Verify Phase 1 with focused Rust tests covering Dream eligibility, replay-state transitions, busy-lock behavior, and deterministic artifact/reference generation.
+
+## Phase 2: Session and gateway integration ordering
+
+- [x] 2.1 Add RED tests around `clients/agent-runtime/src/gateway/mod.rs` and related session service paths proving `end_session`/recorded completion happens before Dream evaluation for generated sessions.
+- [x] 2.2 Update `clients/agent-runtime/src/gateway/mod.rs` to pass `session_id` into the Dream completion-record API and keep gateway logic trigger-only with runtime-owned idempotency.
+- [x] 2.3 Update `clients/agent-runtime/src/memory/hygiene.rs` and any touched session/SQLite helpers so stale auto-close yields recorded completed sessions that enter the same Dream trigger path.
+- [x] 2.4 Verify Phase 2 with integration tests for repeated completion handling, missing completion preconditions blocking Dream, and hygiene-triggered completions matching gateway semantics.
+
+## Phase 3: Backend parity for SQLite, markdown, and snapshot flows
+
+- [x] 3.1 Add RED tests in `clients/agent-runtime/src/memory/sqlite.rs` for per-session Dream persistence, atomic artifact+metadata writes, duplicate suppression, and retry after failed/pending state.
+- [x] 3.2 Implement additive SQLite Dream schema/helpers in `clients/agent-runtime/src/memory/sqlite.rs` to persist Dream replay metadata and artifact references keyed by `session_id`.
+- [x] 3.3 Extend `clients/agent-runtime/src/memory/markdown.rs` and `clients/agent-runtime/src/memory/dream.rs` to persist durable Dream artifacts plus sidecar replay metadata (`dream_state.json`) with conservative recovery when metadata lags artifact writes.
+- [x] 3.4 Extend `clients/agent-runtime/src/memory/snapshot.rs` to export/hydrate Dream-visible artifacts and replay metadata so restored runtimes remain idempotent.
+- [x] 3.5 Verify Phase 3 with backend-specific tests for restart/reload survival, snapshot export/hydration parity, and no ambiguous reconsolidation after restore.
+
+## Phase 4: Hardening and full verification
+
+- [x] 4.1 Add end-to-end and regression coverage across `clients/agent-runtime/src/memory/` and gateway/session tests for lock contention, failed-attempt recovery, and one logical Dream result per completed session.
+- [x] 4.2 Run verification: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`; document any scoped exceptions if snapshot/export tests need narrower invocation.

--- a/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/verify-report.md
+++ b/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/verify-report.md
@@ -70,13 +70,13 @@ No incomplete tasks were found in `openspec/changes/2026-04-26-dream-system/task
 | Gateway Dream Integration Is Trigger-Only | Gateway acceptance does not require Dream-specific transport contract | `clients/agent-runtime/src/gateway/mod.rs > generated_session_completion_records_before_dream_evaluation` | ⚠️ PARTIAL |
 | Gateway Completion Hooks MUST Preserve Runtime Ordering and Idempotency | Gateway calls completion recording before Dream trigger | `clients/agent-runtime/src/gateway/mod.rs > generated_session_completion_records_before_dream_evaluation` | ✅ COMPLIANT |
 | Gateway Completion Hooks MUST Preserve Runtime Ordering and Idempotency | Replayed gateway completion path stays safe through runtime idempotency | `clients/agent-runtime/src/gateway/mod.rs > generated_session_completion_remains_runtime_idempotent_on_repeat` | ✅ COMPLIANT |
-| SESS-5: Stale Session Auto-Close | Hygiene pass closes stale session and produces a Dream trigger input | `clients/agent-runtime/src/memory/hygiene.rs > close_stale_sessions_records_dream_completion_input` | ✅ COMPLIANT |
+| SESS-5: Stale Session Auto-Close | Hygiene pass closes stale session and produces a Dream trigger input | `clients/agent-runtime/src/memory/hygiene.rs > close_stale_sessions_marks_session_dream_eligible` | ✅ COMPLIANT |
 | Session Completion Must Produce a Deterministic Dream Trigger Input | Dream runs only after completion is recorded | `clients/agent-runtime/src/gateway/mod.rs > generated_session_completion_records_before_dream_evaluation` | ✅ COMPLIANT |
 | Session Completion Must Produce a Deterministic Dream Trigger Input | Failed or missing completion record blocks Dream evaluation | `clients/agent-runtime/src/gateway/mod.rs > generated_session_completion_blocks_dream_without_recorded_completion` | ✅ COMPLIANT |
 | Session Completion and Dream Triggering Must Be Idempotent Together | Repeated completion handling does not duplicate Dream work | `clients/agent-runtime/src/gateway/mod.rs > generated_session_completion_remains_runtime_idempotent_on_repeat` | ✅ COMPLIANT |
 | Session Completion and Dream Triggering Must Be Idempotent Together | Duplicate completion record without prior Dream result remains safe | `clients/agent-runtime/src/memory/dream.rs > busy_run_does_not_consume_pending_session_and_succeeds_after_lock_release` | ⚠️ PARTIAL |
 
-**Compliance summary**: 10/17 scenarios compliant, 7 partial, 0 failing, 0 untested.
+**Compliance summary**: 10/17 scenarios compliant, 6 partial, 0 failing, 0 untested.
 
 **Remaining partial scenarios**
 

--- a/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/verify-report.md
+++ b/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/verify-report.md
@@ -96,7 +96,7 @@ No incomplete tasks were found in `openspec/changes/2026-04-26-dream-system/task
 | Dream Eligibility for Completed Sessions | ✅ Implemented | `dream_eligibility`, `record_session_completion`, and tests in `memory/dream.rs` enforce completed-session gating and deterministic session-based identity. |
 | Dream Consolidation Output Contract | ✅ Implemented | `run_now` writes distilled `Dream summary for completed session {session_id}` entries into `MEMORY.md`, using deterministic artifact refs rather than transcript persistence. |
 | Dream Persistence Across Supported Backends | ✅ Implemented | SQLite adds `dream_sessions`; snapshot exports `DREAM_STATE_SNAPSHOT.json`; state sidecar `dream_state.json` is restored on hydrate. |
-| Dream Idempotency per Completed Session | ✅ Implemented | Session state machine `pending|running|completed|failed` plus `artifact_ref_for_session` and repeated-trigger suppression are present. |
+| Dream Idempotency per Completed Session | ✅ Implemented | Session state machine `pending\|running\|completed\|failed` plus `artifact_ref_for_session` and repeated-trigger suppression are present. |
 | Gateway Dream Integration Is Trigger-Only | ✅ Implemented | Gateway finalization path ends session, records completion, then invokes Dream; no gateway-side eligibility logic or Dream-specific persistence logic was found. |
 | Gateway Completion Hooks MUST Preserve Runtime Ordering and Idempotency | ✅ Implemented | `finalize_generated_session_if_needed` calls `end_session` before `record_session_completion` before `run_dream_if_triggered`. |
 | SESS-5: Stale Session Auto-Close | ✅ Implemented | `close_stale_sessions` updates sessions, then calls `memory::record_session_completion` for each affected stale session. |

--- a/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/verify-report.md
+++ b/openspec/changes/archive/2025-08-07-2026-04-26-dream-system/verify-report.md
@@ -1,0 +1,147 @@
+# Verify Report — Dream System
+
+## Verification Report
+
+**Change**: `2026-04-26-dream-system`
+**Version**: N/A
+
+---
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 12 |
+| Tasks complete | 12 |
+| Tasks incomplete | 0 |
+
+No incomplete tasks were found in `openspec/changes/2026-04-26-dream-system/tasks.md`.
+
+---
+
+### Build & Tests Execution
+
+**Verification commands from `openspec/config.yaml`**
+
+| Command | Scope | Result | Evidence |
+|---|---|---|---|
+| `cargo fmt --all -- --check` | `clients/agent-runtime` | ✅ Passed | Previously verified; exit 0 |
+| `cargo clippy --all-targets -- -D warnings` | `clients/agent-runtime` | ✅ Passed | Previously verified; exit 0 |
+| `cargo test` | `clients/agent-runtime` | ✅ Passed | Updated evidence: fresh full run now passes completely |
+| `make web-test-all` | repo root | ✅ Passed | Previously verified; `BUILD SUCCESSFUL` |
+| `pnpm --dir clients/web check` | `clients/web` | ✅ Passed | Previously verified; workspace checks completed successfully |
+
+**Additional updated evidence**
+
+- The previously reported failing test `channels::tests::transcription_semaphore_enforces_serial_execution` now passes in isolation.
+- A fresh full `cargo test` run in `clients/agent-runtime` now passes completely.
+- This removes the prior blocking verification failure from the Rust workspace baseline.
+
+**Build / static quality gates**
+
+- `cargo fmt --all -- --check`: passed.
+- `cargo clippy --all-targets -- -D warnings`: passed.
+
+**Tests**
+
+- `cargo test`: ✅ passed on refreshed verification evidence
+  - Prior single-test failure is no longer reproducible from the new evidence set.
+  - Exact aggregate pass counts were not included in the refreshed evidence bundle, so only overall pass status is recorded here.
+- `make web-test-all`: ✅ passed
+- `pnpm --dir clients/web check`: ✅ passed
+
+**Coverage**: ➖ Not configured in `openspec/config.yaml`
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|---|---|---|---|
+| Dream Eligibility for Completed Sessions | Completed session becomes a Dream candidate | `clients/agent-runtime/src/memory/dream.rs > accepts_recorded_completed_session_and_creates_deterministic_artifact_ref` | ✅ COMPLIANT |
+| Dream Eligibility for Completed Sessions | Active session is not Dream-eligible | `clients/agent-runtime/src/memory/dream.rs > rejects_active_session_without_recorded_completion` | ✅ COMPLIANT |
+| Dream Consolidation Output Contract | Eligible completed session produces durable distilled memory | `clients/agent-runtime/src/memory/dream.rs > dream_normalizes_relative_dates_and_prunes_duplicates` | ⚠️ PARTIAL |
+| Dream Consolidation Output Contract | Dream does not require verbatim transcript persistence as output | `clients/agent-runtime/src/memory/dream.rs > dream_normalizes_relative_dates_and_prunes_duplicates` | ⚠️ PARTIAL |
+| Dream Persistence Across Supported Backends | Dream artifacts survive runtime restart and reload | `clients/agent-runtime/src/memory/sqlite.rs > sqlite_dream_state_persists_across_reopen` | ✅ COMPLIANT |
+| Dream Persistence Across Supported Backends | Snapshot export and hydration preserve Dream state | `clients/agent-runtime/src/memory/snapshot.rs > hydrate_from_snapshot_restores_dream_state_sidecar` | ⚠️ PARTIAL |
+| Dream Idempotency per Completed Session | Duplicate Dream trigger for completed session is suppressed | `clients/agent-runtime/src/memory/dream.rs > suppresses_duplicate_triggers_by_session_id` | ✅ COMPLIANT |
+| Dream Idempotency per Completed Session | Repeated trigger after restore remains idempotent | `clients/agent-runtime/src/memory/dream.rs > retries_failed_session_after_manual_recovery_and_keeps_single_logical_result` | ⚠️ PARTIAL |
+| Gateway Dream Integration Is Trigger-Only | Gateway delegates Dream semantics to runtime | `clients/agent-runtime/src/gateway/mod.rs > generated_session_completion_records_before_dream_evaluation` | ⚠️ PARTIAL |
+| Gateway Dream Integration Is Trigger-Only | Gateway acceptance does not require Dream-specific transport contract | `clients/agent-runtime/src/gateway/mod.rs > generated_session_completion_records_before_dream_evaluation` | ⚠️ PARTIAL |
+| Gateway Completion Hooks MUST Preserve Runtime Ordering and Idempotency | Gateway calls completion recording before Dream trigger | `clients/agent-runtime/src/gateway/mod.rs > generated_session_completion_records_before_dream_evaluation` | ✅ COMPLIANT |
+| Gateway Completion Hooks MUST Preserve Runtime Ordering and Idempotency | Replayed gateway completion path stays safe through runtime idempotency | `clients/agent-runtime/src/gateway/mod.rs > generated_session_completion_remains_runtime_idempotent_on_repeat` | ✅ COMPLIANT |
+| SESS-5: Stale Session Auto-Close | Hygiene pass closes stale session and produces a Dream trigger input | `clients/agent-runtime/src/memory/hygiene.rs > close_stale_sessions_records_dream_completion_input` | ✅ COMPLIANT |
+| Session Completion Must Produce a Deterministic Dream Trigger Input | Dream runs only after completion is recorded | `clients/agent-runtime/src/gateway/mod.rs > generated_session_completion_records_before_dream_evaluation` | ✅ COMPLIANT |
+| Session Completion Must Produce a Deterministic Dream Trigger Input | Failed or missing completion record blocks Dream evaluation | `clients/agent-runtime/src/gateway/mod.rs > generated_session_completion_blocks_dream_without_recorded_completion` | ✅ COMPLIANT |
+| Session Completion and Dream Triggering Must Be Idempotent Together | Repeated completion handling does not duplicate Dream work | `clients/agent-runtime/src/gateway/mod.rs > generated_session_completion_remains_runtime_idempotent_on_repeat` | ✅ COMPLIANT |
+| Session Completion and Dream Triggering Must Be Idempotent Together | Duplicate completion record without prior Dream result remains safe | `clients/agent-runtime/src/memory/dream.rs > busy_run_does_not_consume_pending_session_and_succeeds_after_lock_release` | ⚠️ PARTIAL |
+
+**Compliance summary**: 10/17 scenarios compliant, 7 partial, 0 failing, 0 untested.
+
+**Remaining partial scenarios**
+
+1. Distilled-memory quality is evidenced, but not by a scenario-named end-to-end assertion that inspects artifact content for a completed session across backends.
+2. Transcript-omission is implied by the artifact format and current test behavior, but not asserted directly against a preserved multi-turn transcript fixture.
+3. Snapshot coverage restores Dream replay metadata, but the current runtime evidence is lighter on export→hydrate→retrigger end-to-end artifact parity.
+4. Restore-time idempotency is indirectly covered by retry/recovery semantics, but not by a dedicated export/shutdown/restore/retrigger scenario.
+5. Gateway trigger-only behavior is structurally evident and indirectly exercised, but there is no dedicated test asserting the absence of a new Dream-specific public HTTP contract.
+6. Duplicate completion without prior Dream result is partially covered through lock/busy handling rather than an explicit duplicate completion-record retry case.
+
+---
+
+### Correctness (Static — Structural Evidence)
+
+| Requirement | Status | Notes |
+|---|---|---|
+| Dream Eligibility for Completed Sessions | ✅ Implemented | `dream_eligibility`, `record_session_completion`, and tests in `memory/dream.rs` enforce completed-session gating and deterministic session-based identity. |
+| Dream Consolidation Output Contract | ✅ Implemented | `run_now` writes distilled `Dream summary for completed session {session_id}` entries into `MEMORY.md`, using deterministic artifact refs rather than transcript persistence. |
+| Dream Persistence Across Supported Backends | ✅ Implemented | SQLite adds `dream_sessions`; snapshot exports `DREAM_STATE_SNAPSHOT.json`; state sidecar `dream_state.json` is restored on hydrate. |
+| Dream Idempotency per Completed Session | ✅ Implemented | Session state machine `pending|running|completed|failed` plus `artifact_ref_for_session` and repeated-trigger suppression are present. |
+| Gateway Dream Integration Is Trigger-Only | ✅ Implemented | Gateway finalization path ends session, records completion, then invokes Dream; no gateway-side eligibility logic or Dream-specific persistence logic was found. |
+| Gateway Completion Hooks MUST Preserve Runtime Ordering and Idempotency | ✅ Implemented | `finalize_generated_session_if_needed` calls `end_session` before `record_session_completion` before `run_dream_if_triggered`. |
+| SESS-5: Stale Session Auto-Close | ✅ Implemented | `close_stale_sessions` updates sessions, then calls `memory::record_session_completion` for each affected stale session. |
+| Session Completion Must Produce a Deterministic Dream Trigger Input | ✅ Implemented | Missing completion yields `DreamEligibility::NotCompleted`; recorded completion is the prerequisite for Dream eligibility and trigger evaluation. |
+| Session Completion and Dream Triggering Must Be Idempotent Together | ✅ Implemented | Repeated completion recording returns stable session records, and pending/busy/completed behavior preserves one logical Dream outcome. |
+
+---
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|---|---|---|
+| ADR-1: Dream belongs to memory/runtime domain, not gateway | ✅ Yes | Ownership remains in `memory/`; gateway only triggers runtime hooks. |
+| ADR-2: Dream is keyed by completed session identity | ✅ Yes | `DreamSessionStateRecord.session_id` and deterministic `dream/session/{session_id}` refs match the decision. |
+| ADR-3: Consolidation output is distilled memory plus replay metadata | ✅ Yes | Distilled memory goes to `MEMORY.md`; replay metadata persists in Dream state / `dream_sessions`. |
+| ADR-4: Completion-recorded-first, Dream-evaluated-second | ✅ Yes | Gateway and hygiene flows both record completion before Dream evaluation. |
+| ADR-5: Two-level locking (global runner lock plus per-session durable status) | ✅ Yes | `dream.lock` plus durable session status markers are both present. |
+| ADR-6: Backend parity preserves artifacts and replay state, not identical format | ✅ Yes | SQLite, sidecar JSON, and snapshot JSON preserve semantics while using different storage formats. |
+| File changes likely needed | ⚠️ Partial deviation | `memory/markdown.rs` appears less directly involved than design suggested; persistence is more centralized in `memory/dream.rs`. This is coherent with runtime ownership but should be noted. |
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+
+None.
+
+**WARNING** (should fix):
+
+1. Several scenarios remain only partially proven at runtime, especially export→hydrate→retrigger idempotency, transcript-omission as a direct assertion, and gateway non-expansion of public Dream HTTP surface.
+2. Markdown parity is implemented mainly through Dream-side state management rather than a richer `markdown.rs` backend contract, which may be acceptable but is less explicit than the design text implied.
+3. The previously observed `channels::tests::transcription_semaphore_enforces_serial_execution` failure is no longer reproducible in the refreshed evidence, but because it was previously observed, it remains a regression-monitoring concern rather than an active blocker.
+
+**SUGGESTION** (nice to have):
+
+1. Add direct scenario-named tests for the remaining partial matrix rows, especially export→hydrate→retrigger idempotency and public-surface non-expansion.
+2. Add a focused end-to-end snapshot test that performs export, cold restore, and repeated trigger for the same `session_id` in one runtime test.
+3. Add a gateway-facing test or assertion set that explicitly proves Dream integration does not introduce a new public HTTP contract.
+4. If intended, document in design or implementation notes that markdown backend Dream persistence is intentionally centralized in `memory/dream.rs` + sidecar state.
+
+---
+
+### Verdict
+
+**PASS WITH WARNINGS**
+
+The Dream change now clears the configured verification command baseline with the refreshed Rust test evidence, and the implementation remains complete, structurally correct, and design-coherent; however, several spec scenarios still have only partial runtime proof and should receive more explicit end-to-end coverage before archive confidence is considered maximized.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -34,8 +34,9 @@ rules:
       - cargo clippy --all-targets -- -D warnings
       - cargo test
       - make web-test-all
-      - pnpm check
+      - pnpm --dir clients/web check
     rules:
       - Compare implementation against every spec scenario
+      - Scope verification commands to the owning workspace when the repository is a monorepo
   archive:
     - Warn before merging destructive deltas (large removals)

--- a/openspec/specs/gateway/spec.md
+++ b/openspec/specs/gateway/spec.md
@@ -2378,6 +2378,154 @@ capture/replay semantics.
 
 ---
 
+### Requirement: Dream Eligibility for Completed Sessions
+
+The runtime MUST treat Dream as a post-session consolidation capability that evaluates completed
+sessions for Dream eligibility.
+
+A Dream run MUST target a specific completed session identity. Dream MUST NOT consolidate sessions
+that have not been recorded as completed.
+
+The eligibility decision MUST be deterministic for the same completed session inputs and runtime
+configuration.
+
+#### Scenario: Completed session becomes a Dream candidate
+
+- GIVEN a session `sess-123` has been recorded as completed
+- AND the runtime can access the relevant session history for `sess-123`
+- WHEN Dream eligibility is evaluated for `sess-123`
+- THEN the runtime MUST treat `sess-123` as a Dream candidate
+- AND the eligibility result MUST be derived from the completed session inputs rather than gateway transport details.
+
+#### Scenario: Active session is not Dream-eligible
+
+- GIVEN a session `sess-123` is still active and has not been recorded as completed
+- WHEN Dream eligibility is evaluated for `sess-123`
+- THEN the runtime MUST reject Dream consolidation for that session
+- AND no Dream artifact MUST be persisted.
+
+### Requirement: Dream Consolidation Output Contract
+
+For an eligible completed session, Dream MUST synthesize durable long-term memory artifacts that
+capture stable high-value knowledge from the completed session.
+
+The Dream output MUST be additive. Dream MUST NOT require preserving the full session transcript as
+the durable long-term memory artifact itself.
+
+The runtime SHOULD favor stable summaries, facts, or other high-value distilled outputs over
+verbatim transcript retention.
+
+#### Scenario: Eligible completed session produces durable distilled memory
+
+- GIVEN a completed session `sess-123` is Dream-eligible
+- WHEN Dream consolidates the session
+- THEN the runtime MUST produce one or more durable long-term memory artifacts for `sess-123`
+- AND those artifacts MUST represent distilled high-value information from the session
+- AND the artifacts MUST be persisted independently of the original request/response transport flow.
+
+#### Scenario: Dream does not require verbatim transcript persistence as output
+
+- GIVEN a completed session `sess-123` contains a multi-turn transcript
+- WHEN Dream completes consolidation for `sess-123`
+- THEN the durable Dream output MUST be allowed to omit verbatim transcript reproduction
+- AND the Dream contract MUST remain satisfied so long as stable high-value information is preserved.
+
+### Requirement: Dream Persistence Across Supported Backends
+
+Dream artifacts MUST survive restart, export, and reload flows across supported memory backends.
+
+For this change, supported backends are the runtime backends that already participate in Corvus
+memory persistence and snapshot hydration/export behavior, including SQLite, markdown, and runtime
+snapshot flows where supported.
+
+A backend that claims Dream support MUST persist both Dream artifacts and enough Dream state to
+avoid ambiguous replay for the same completed session.
+
+#### Scenario: Dream artifacts survive runtime restart and reload
+
+- GIVEN Dream has successfully consolidated completed session `sess-123`
+- AND the runtime persists Dream through a supported backend
+- WHEN the runtime is restarted and its persisted state is reloaded
+- THEN the Dream artifacts for `sess-123` MUST still be available
+- AND the runtime MUST preserve enough Dream state to avoid treating `sess-123` as unconsolidated solely because of the restart.
+
+#### Scenario: Snapshot export and hydration preserve Dream state
+
+- GIVEN Dream artifacts and Dream replay state exist for completed session `sess-123`
+- WHEN the runtime exports its persisted state and later hydrates from that exported state
+- THEN the hydrated runtime MUST restore the Dream artifacts for `sess-123`
+- AND it MUST restore enough Dream state to keep consolidation behavior unambiguous for that session.
+
+### Requirement: Dream Idempotency per Completed Session
+
+Dream consolidation for a completed session MUST be idempotent.
+
+The runtime MUST record enough Dream state to determine whether a completed session has already
+been consolidated or is otherwise no longer eligible for duplicate consolidation.
+
+Repeated Dream triggering for the same completed session MUST NOT create duplicate or ambiguous
+consolidation results.
+
+#### Scenario: Duplicate Dream trigger for completed session is suppressed
+
+- GIVEN completed session `sess-123` has already been successfully consolidated by Dream
+- WHEN Dream is triggered again for `sess-123`
+- THEN the runtime MUST detect that `sess-123` has already been consolidated
+- AND it MUST NOT create a second ambiguous consolidation result for the same completion event.
+
+#### Scenario: Repeated trigger after restore remains idempotent
+
+- GIVEN completed session `sess-123` was consolidated before runtime export or shutdown
+- AND the persisted Dream state is later restored
+- WHEN Dream is triggered again for `sess-123` after restore
+- THEN the runtime MUST preserve idempotent behavior for that session
+- AND it MUST NOT treat the restored runtime as permission to reconsolidate the same completion ambiguously.
+
+### Requirement: Gateway Dream Integration Is Trigger-Only
+
+Gateway behavior for Dream MUST be limited to invoking the runtime-defined session completion and
+Dream trigger integration points.
+
+The gateway MUST NOT become the behavioral source-of-truth for Dream eligibility, consolidation
+content, or persistence semantics.
+
+#### Scenario: Gateway delegates Dream semantics to runtime
+
+- GIVEN the gateway completes a request flow that reaches the runtime session-completion path
+- WHEN the gateway invokes the completion and Dream trigger integration points
+- THEN the gateway MUST rely on the runtime to determine Dream eligibility and consolidation behavior
+- AND the gateway MUST NOT define independent Dream eligibility rules.
+
+#### Scenario: Gateway acceptance does not require Dream-specific transport contract
+
+- GIVEN the runtime exposes Dream only through existing completion-trigger integration points
+- WHEN a gateway-served request completes successfully
+- THEN the gateway MUST remain valid without adding a new Dream-specific public HTTP contract
+- AND Dream behavior MUST remain an internal runtime concern unless another spec adds a public surface.
+
+### Requirement: Gateway Completion Hooks MUST Preserve Runtime Ordering and Idempotency
+
+When the gateway participates in a session flow that records completion and triggers Dream, it MUST
+invoke those runtime integration points in the runtime-defined order.
+
+The gateway MUST preserve the runtime contract that completion recording happens before Dream
+trigger evaluation, and repeated gateway completion handling for the same session MUST NOT require
+gateway-defined duplicate-consolidation logic.
+
+#### Scenario: Gateway calls completion recording before Dream trigger
+
+- GIVEN a gateway-served session `sess-123` reaches its completion path
+- WHEN the gateway invokes runtime integration for that completion
+- THEN the completion-recording hook MUST run before the Dream-trigger hook
+- AND Dream evaluation MUST consume the runtime-recorded completion state.
+
+#### Scenario: Replayed gateway completion path stays safe through runtime idempotency
+
+- GIVEN the gateway re-enters the same completion path for session `sess-123`
+- WHEN it invokes the runtime completion and Dream hooks again
+- THEN the gateway MUST rely on runtime idempotency for the completed session
+- AND the repeated gateway path MUST NOT require a second independent Dream result.
+
 ## Data Contracts
 
 ### ChatCompletionRequest (Input)

--- a/openspec/specs/sessions/spec.md
+++ b/openspec/specs/sessions/spec.md
@@ -408,6 +408,53 @@ any other mutation behavior. It MUST NOT expose rich row metadata beyond the min
 - AND the structured result MUST contain zero rows
 - AND no session lifecycle or snapshot state MUST be modified.
 
+### Requirement: Session Completion Must Produce a Deterministic Dream Trigger Input
+
+The runtime MUST record session completion before Dream is evaluated for that session.
+
+Dream evaluation MUST use the recorded completed-session state as its trigger input rather than an
+in-flight or inferred gateway-only notion of completion.
+
+The runtime MUST ensure the completion-to-Dream ordering is deterministic for the same session.
+
+#### Scenario: Dream runs only after completion is recorded
+
+- GIVEN session `sess-123` is reaching the end of its lifecycle
+- WHEN the runtime records session completion for `sess-123`
+- THEN the session MUST first exist in a completed recorded state
+- AND only after that recorded completion MAY Dream be evaluated for `sess-123`.
+
+#### Scenario: Failed or missing completion record blocks Dream evaluation
+
+- GIVEN no recorded completed-session state exists for `sess-123`
+- WHEN Dream would otherwise be evaluated for `sess-123`
+- THEN the runtime MUST NOT consolidate that session
+- AND it MUST treat the missing completion record as a failed trigger precondition.
+
+### Requirement: Session Completion and Dream Triggering Must Be Idempotent Together
+
+The runtime MUST coordinate session completion recording and Dream triggering so repeated completion
+handling for the same session does not create duplicate Dream work.
+
+If the same completion event is observed more than once for a session, the runtime MUST preserve a
+single logical completed session outcome for Dream purposes.
+
+#### Scenario: Repeated completion handling does not duplicate Dream work
+
+- GIVEN session `sess-123` has already been recorded as completed
+- AND Dream has already evaluated or consolidated that completion
+- WHEN the same completion handling path runs again for `sess-123`
+- THEN the runtime MUST preserve a single logical completion outcome
+- AND it MUST NOT create duplicate Dream consolidation for that session.
+
+#### Scenario: Duplicate completion record without prior Dream result remains safe
+
+- GIVEN session `sess-123` has already been recorded as completed
+- AND Dream has not yet produced a durable result for that session
+- WHEN the completion handling path is retried for `sess-123`
+- THEN the runtime MUST keep completion recording idempotent
+- AND any subsequent Dream evaluation MUST remain unambiguous for that same session.
+
 ### Requirement: Current Session Status Discoverability
 
 The system MUST make `/session status` a read-only compact summary view over the current session
@@ -592,15 +639,16 @@ The memory hygiene pass MUST auto-close stale sessions.
 - The default stale threshold MUST be 24 hours.
 - The threshold SHOULD be configurable via runtime config.
 - Auto-close MUST set `ended_at` to the current UTC timestamp, not the `last_activity` time.
+- When a session is auto-closed or otherwise recorded as completed, that completed state MUST be a
+  valid Dream trigger input for downstream runtime Dream evaluation.
 
-#### Scenario: Hygiene pass closes stale session
+#### Scenario: Hygiene pass closes stale session and produces a Dream trigger input
 
-```gherkin
-Given an active session "old-session" with last_activity "2026-03-27T08:00:00Z"
-And the stale session threshold is 24 hours
-When the hygiene pass runs at "2026-03-28T10:00:00Z"
-Then session "old-session" MUST have ended_at set to "2026-03-28T10:00:00Z"
-```
+- GIVEN an active session `old-session` with last_activity `2026-03-27T08:00:00Z`
+- AND the stale session threshold is 24 hours
+- WHEN the hygiene pass runs at `2026-03-28T10:00:00Z`
+- THEN session `old-session` MUST have ended_at set to `2026-03-28T10:00:00Z`
+- AND the completed state MUST be available for downstream Dream evaluation as a recorded completion.
 
 #### Scenario: Active session within threshold is not closed
 


### PR DESCRIPTION
## Related Issues

Fixes #526

---

## Summary

- implement the Dream System runtime contract for session-keyed long-term memory consolidation in `clients/agent-runtime`
- add deterministic completion, idempotency, locking, backend persistence, and snapshot replay support for Dream execution
- archive the completed OpenSpec change and sync the approved Dream requirements into the main `gateway` and `sessions` specs

---

## Tested Information

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `make web-test-all`
- `pnpm --dir clients/web check`

Verify status for the archived change is `PASS_WITH_WARNINGS`; remaining warnings are about some spec scenarios relying on partial evidence rather than dedicated end-to-end scenario tests.

---

## Documentation Impact

- Docs updated in:
  - `openspec/specs/gateway/spec.md`
  - `openspec/specs/sessions/spec.md`
  - `openspec/changes/archive/2025-08-07-2026-04-26-dream-system/`
- No docs update required because:
  - N/A
- I verified the documentation matches the current behavior.

---

## Breaking Changes

- None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/CONTRIBUTING.md).
- [x] My PR title follows the Conventional Commits style used by this repository.
- [x] I have performed a self-review of my own changes.
- [x] I have added or updated tests where applicable.
- [x] I have updated documentation where applicable.
- [x] I confirm this PR does not introduce unrelated changes.
