### PR TITLE
fix(rook): add config export and env overrides

### DIFF
--- a/clients/rook/README.md
+++ b/clients/rook/README.md
@@ -61,10 +61,111 @@ dependencies. It does **not** depend on the `corvus` binary or its internals.
 |---|---|
 | `corvus-traits` | Shared async provider/tool/memory trait contracts |
 
+## Configuration
+
+Rook resolves its effective runtime configuration through one shared pipeline used by both
+`rook serve` and `rook config export`.
+
+### Default config discovery
+
+Rook looks for `config.toml` in this order:
+
+1. `$XDG_CONFIG_HOME/rook/config.toml`
+2. `$HOME/.config/rook/config.toml`
+
+If no config file exists, Rook falls back to built-in defaults.
+
+### Built-in defaults
+
+- `host = "127.0.0.1"`
+- `port = 4141`
+- `enable_tui = false`
+- `db_path = "./rook.db"`
+
+This preserves the gateway's loopback-first bind posture by default.
+
+### Precedence
+
+When the same setting is provided by multiple sources, Rook applies them in this order:
+
+1. built-in defaults
+2. config file values
+3. `ROOK_*` environment overrides
+4. CLI flags
+
+That means CLI flags always win, environment overrides beat file values, and file values beat
+built-in defaults.
+
+### Supported `ROOK_*` environment overrides
+
+Top-level:
+
+- `ROOK_HOST`
+- `ROOK_PORT`
+- `ROOK_ENABLE_TUI`
+- `ROOK_DB_PATH`
+
+Inbound auth:
+
+- `ROOK_INBOUND_AUTH_ENABLED`
+- `ROOK_INBOUND_AUTH_TOKEN`
+
+Transport:
+
+- `ROOK_TRANSPORT_REQUEST_ID_INBOUND_HEADER_NAME`
+- `ROOK_TRANSPORT_REQUEST_ID_RESPONSE_HEADER_NAME`
+- `ROOK_TRANSPORT_REQUEST_ID_MAX_LENGTH`
+- `ROOK_TRANSPORT_TRUSTED_PROXY_ENABLED`
+- `ROOK_TRANSPORT_TRUSTED_PROXY_TRUSTED_CIDRS`
+- `ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_FORWARDED`
+- `ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_FOR`
+- `ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_HOST`
+- `ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_PROTO`
+- `ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_PORT`
+- `ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_REAL_IP`
+
+Rate limits:
+
+- `ROOK_API_RATE_LIMIT_MAX_REQUESTS`
+- `ROOK_API_RATE_LIMIT_WINDOW_SECONDS`
+- `ROOK_V1_MODELS_RATE_LIMIT_MAX_REQUESTS`
+- `ROOK_V1_MODELS_RATE_LIMIT_WINDOW_SECONDS`
+- `ROOK_V1_CHAT_RATE_LIMIT_MAX_REQUESTS`
+- `ROOK_V1_CHAT_RATE_LIMIT_WINDOW_SECONDS`
+
+Idempotency:
+
+- `ROOK_CHAT_IDEMPOTENCY_ENABLED`
+- `ROOK_CHAT_IDEMPOTENCY_REPLAY_WINDOW_SECONDS`
+
+### Validation behavior
+
+Rook validates the final effective configuration before startup and before exporting config.
+Invalid effective config fails closed with operator-facing errors. Examples include:
+
+- blank host or database path
+- enabled inbound auth without a token
+- invalid request ID header names
+- trusted proxy enabled without CIDRs
+- zero-valued rate limits or idempotency replay windows
+
+### Safe config export
+
+`rook config export` prints the validated effective configuration as JSON using the same resolution
+path as `rook serve`.
+
+Secret-bearing values are never printed raw. In particular, export redacts inbound bearer tokens and
+uses operator-safe rendering instead of exposing raw credentials.
+
+```bash
+cargo run --manifest-path clients/rook/Cargo.toml -- config export
+```
+
 ## Status
 
-This is the initial layout skeleton. All subcommands print
-`"not yet implemented"` stubs. Implementation follows per the Rook roadmap.
+Rook now includes shared config assembly, environment overrides, operator-safe config export,
+and validation for its current gateway/runtime configuration surface. Additional feature work
+continues per the Rook roadmap.
 
 **Note:** An official Spanish translation of this README is pending. Contributions
 and translations are welcome — please see the main Corvus repository for

--- a/clients/rook/README.md
+++ b/clients/rook/README.md
@@ -22,16 +22,16 @@ accounts using configurable strategies.
 # Check that it compiles
 cargo check --manifest-path clients/rook/Cargo.toml
 
-# Run the gateway (stub — not yet implemented)
+# Run the gateway
 cargo run --manifest-path clients/rook/Cargo.toml -- serve
 
 # Launch operator TUI (stub)
 cargo run --manifest-path clients/rook/Cargo.toml -- tui
 
-# Run diagnostics (stub — not yet implemented)
+# Run diagnostics
 cargo run --manifest-path clients/rook/Cargo.toml -- doctor
 
-# Export current config (stub — not yet implemented)
+# Export current validated config as JSON
 cargo run --manifest-path clients/rook/Cargo.toml -- config export
 ```
 

--- a/clients/rook/src/admin/handlers.rs
+++ b/clients/rook/src/admin/handlers.rs
@@ -1,16 +1,20 @@
-use crate::admin::{types::{
-    AccountView, AddPoolMemberRequest, AdminErrorResponse, AuditEventView, CreateAccountRequest,
-    CreatePoolRequest, CreateRouteRequest, HealthAccountView, HealthSummaryView,
-    ListAuditEventsQuery, PoolView, RouteView, SettingsView, UpdateAccountRequest,
-    UpdatePoolRequest, UpdateRouteRequest, UpdateSettingsRequest, UsageStatusView,
-}, AdminState};
-use crate::health::{HealthResponse, ReadinessResponse};
+use crate::admin::{
+    types::{
+        AccountView, AddPoolMemberRequest, AdminErrorResponse, AuditEventView,
+        CreateAccountRequest, CreatePoolRequest, CreateRouteRequest, HealthAccountView,
+        HealthSummaryView, ListAuditEventsQuery, PoolView, RouteView, SettingsView,
+        UpdateAccountRequest, UpdatePoolRequest, UpdateRouteRequest, UpdateSettingsRequest,
+        UsageStatusView,
+    },
+    AdminState,
+};
 use crate::db::audit::{AdminAuditListQuery, StoredAdminAuditEvent};
 use crate::domain::{ProviderAccount, ProviderPool, RookError};
+use crate::health::{HealthResponse, ReadinessResponse};
 use crate::registry::RookRegistry;
 use crate::services::{
-    account::AccountService as _, audit::AuditService as _, health::HealthService as _, pool::PoolService as _,
-    route::RouteService as _, settings::SettingsService as _,
+    account::AccountService as _, audit::AuditService as _, health::HealthService as _,
+    pool::PoolService as _, route::RouteService as _, settings::SettingsService as _,
 };
 use axum::{
     extract::Json as ExtractJson,
@@ -23,7 +27,7 @@ use axum::{
     Json,
 };
 use chrono::Utc;
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 use tracing::error;
 use uuid::Uuid;
 
@@ -228,9 +232,7 @@ pub async fn handle_ready_health(
     let readiness = startup.readiness();
     let status = match readiness.status {
         crate::health::HealthStatus::Fail => StatusCode::SERVICE_UNAVAILABLE,
-        crate::health::HealthStatus::Ok | crate::health::HealthStatus::Degraded => {
-            StatusCode::OK
-        }
+        crate::health::HealthStatus::Ok | crate::health::HealthStatus::Degraded => StatusCode::OK,
     };
 
     (status, Json(readiness))
@@ -721,9 +723,7 @@ pub async fn handle_list_account_health(
     Json(list_health_account_views(&registry).await)
 }
 
-pub async fn handle_health_summary(
-    State(state): State<AdminState>,
-) -> Json<HealthSummaryView> {
+pub async fn handle_health_summary(State(state): State<AdminState>) -> Json<HealthSummaryView> {
     let registry = state.registry;
     Json(build_health_summary_view(&registry).await)
 }
@@ -827,7 +827,10 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].action, "account_created");
         assert_eq!(events[0].resource_kind, "account");
-        assert_eq!(events[0].resource_id.as_deref(), Some(account_id.to_string().as_str()));
+        assert_eq!(
+            events[0].resource_id.as_deref(),
+            Some(account_id.to_string().as_str())
+        );
     }
 
     #[test]

--- a/clients/rook/src/admin/mod.rs
+++ b/clients/rook/src/admin/mod.rs
@@ -87,7 +87,6 @@ pub fn management_router(state: AdminState) -> Router {
         .with_state(state)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -155,9 +154,7 @@ mod tests {
         AdminState {
             registry,
             startup: std::sync::Arc::new(startup),
-            observability: std::sync::Arc::new(
-                crate::observability::Observability::bootstrap(),
-            ),
+            observability: std::sync::Arc::new(crate::observability::Observability::bootstrap()),
         }
     }
 
@@ -540,7 +537,8 @@ mod tests {
         let account_id = account.id;
         registry.accounts().create(account).await.unwrap();
 
-        let app = axum::Router::new().nest("/api", build_router(test_admin_state(registry.clone())));
+        let app =
+            axum::Router::new().nest("/api", build_router(test_admin_state(registry.clone())));
 
         let (update_status, update_json) = send_json(
             app,
@@ -578,7 +576,8 @@ mod tests {
         let account_id = account.id;
         registry.accounts().create(account).await.unwrap();
 
-        let app = axum::Router::new().nest("/api", build_router(test_admin_state(registry.clone())));
+        let app =
+            axum::Router::new().nest("/api", build_router(test_admin_state(registry.clone())));
 
         let (update_status, update_json) = send_json(
             app,

--- a/clients/rook/src/admin/types.rs
+++ b/clients/rook/src/admin/types.rs
@@ -1,15 +1,15 @@
+use crate::db::audit::StoredAdminAuditEvent;
 use crate::domain::{
     AccountId, ModelRoute, PoolId, ProviderAccount, ProviderPool, ProviderVendor, RookSettings,
     RouteId, RoutingPolicy, SelectionStrategy,
 };
-use crate::db::audit::StoredAdminAuditEvent;
 use crate::services::health::{AccountHealth, HealthStatus};
-use chrono::{DateTime, Utc};
 use axum::{
     http::{header::RETRY_AFTER, header::WWW_AUTHENTICATE, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 

--- a/clients/rook/src/config/mod.rs
+++ b/clients/rook/src/config/mod.rs
@@ -219,16 +219,6 @@ impl RookConfig {
         })
     }
 
-    pub fn from_sources_with_path_unvalidated(
-        file_path: Option<&Path>,
-        env: &HashMap<String, String>,
-    ) -> Result<Self, RookError> {
-        let mut config = Self::default();
-        load_file_overlay(file_path)?.apply_to(&mut config);
-        parse_env_overlay(env)?.apply_to(&mut config);
-        Ok(config)
-    }
-
     pub fn apply_env_overrides(&mut self, env: &HashMap<String, String>) -> Result<(), RookError> {
         parse_env_overlay(env)?.apply_to(self);
         Ok(())

--- a/clients/rook/src/config/mod.rs
+++ b/clients/rook/src/config/mod.rs
@@ -22,12 +22,19 @@ use std::str::FromStr;
 
 pub fn discover_default_config_path(env_map: &HashMap<String, String>) -> Option<PathBuf> {
     if let Some(xdg_config_home) = env_map.get("XDG_CONFIG_HOME") {
-        return Some(PathBuf::from(xdg_config_home).join("rook").join("config.toml"));
+        return Some(
+            PathBuf::from(xdg_config_home)
+                .join("rook")
+                .join("config.toml"),
+        );
     }
 
-    env_map
-        .get("HOME")
-        .map(|home| PathBuf::from(home).join(".config").join("rook").join("config.toml"))
+    env_map.get("HOME").map(|home| {
+        PathBuf::from(home)
+            .join(".config")
+            .join("rook")
+            .join("config.toml")
+    })
 }
 
 pub fn discover_default_config_path_from_env() -> Option<PathBuf> {
@@ -64,84 +71,102 @@ impl Default for RookConfig {
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-struct PartialRookConfig {
-    host: Option<String>,
-    port: Option<u16>,
-    enable_tui: Option<bool>,
-    db_path: Option<PathBuf>,
-    inbound_auth: Option<PartialInboundAuthConfig>,
-    transport: Option<PartialTransportConfig>,
-    rate_limits: Option<PartialRateLimitConfig>,
-    idempotency: Option<PartialIdempotencyConfig>,
+pub struct PartialRookConfig {
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub enable_tui: Option<bool>,
+    pub db_path: Option<PathBuf>,
+    pub inbound_auth: Option<PartialInboundAuthConfig>,
+    pub transport: Option<PartialTransportConfig>,
+    pub rate_limits: Option<PartialRateLimitConfig>,
+    pub idempotency: Option<PartialIdempotencyConfig>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-struct PartialInboundAuthConfig {
-    enabled: Option<bool>,
-    bearer_token: Option<String>,
+pub struct PartialInboundAuthConfig {
+    pub enabled: Option<bool>,
+    pub bearer_token: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-struct PartialTransportConfig {
-    request_id: Option<PartialRequestIdConfig>,
-    trusted_proxy: Option<PartialTrustedProxyConfig>,
+pub struct PartialTransportConfig {
+    pub request_id: Option<PartialRequestIdConfig>,
+    pub trusted_proxy: Option<PartialTrustedProxyConfig>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-struct PartialRequestIdConfig {
-    inbound_header_name: Option<String>,
-    response_header_name: Option<String>,
-    max_length: Option<usize>,
+pub struct PartialRequestIdConfig {
+    pub inbound_header_name: Option<String>,
+    pub response_header_name: Option<String>,
+    pub max_length: Option<usize>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-struct PartialTrustedProxyConfig {
-    enabled: Option<bool>,
-    trusted_cidrs: Option<Vec<String>>,
-    allowed_headers: Option<PartialTrustedForwardedHeaders>,
+pub struct PartialTrustedProxyConfig {
+    pub enabled: Option<bool>,
+    pub trusted_cidrs: Option<Vec<String>>,
+    pub allowed_headers: Option<PartialTrustedForwardedHeaders>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-struct PartialTrustedForwardedHeaders {
-    forwarded: Option<bool>,
-    x_forwarded_for: Option<bool>,
-    x_forwarded_host: Option<bool>,
-    x_forwarded_proto: Option<bool>,
-    x_forwarded_port: Option<bool>,
-    x_real_ip: Option<bool>,
+pub struct PartialTrustedForwardedHeaders {
+    pub forwarded: Option<bool>,
+    pub x_forwarded_for: Option<bool>,
+    pub x_forwarded_host: Option<bool>,
+    pub x_forwarded_proto: Option<bool>,
+    pub x_forwarded_port: Option<bool>,
+    pub x_real_ip: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-struct PartialRateLimitConfig {
-    api: Option<PartialSurfaceRateLimitPolicy>,
-    v1_models: Option<PartialSurfaceRateLimitPolicy>,
-    v1_chat_completions: Option<PartialSurfaceRateLimitPolicy>,
+pub struct PartialRateLimitConfig {
+    pub api: Option<PartialSurfaceRateLimitPolicy>,
+    pub v1_models: Option<PartialSurfaceRateLimitPolicy>,
+    pub v1_chat_completions: Option<PartialSurfaceRateLimitPolicy>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-struct PartialSurfaceRateLimitPolicy {
-    max_requests: Option<u32>,
-    window_seconds: Option<u64>,
+pub struct PartialSurfaceRateLimitPolicy {
+    pub max_requests: Option<u32>,
+    pub window_seconds: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-struct PartialIdempotencyConfig {
-    chat_completions: Option<PartialChatCompletionsIdempotencyConfig>,
+pub struct PartialIdempotencyConfig {
+    pub chat_completions: Option<PartialChatCompletionsIdempotencyConfig>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-struct PartialChatCompletionsIdempotencyConfig {
-    enabled: Option<bool>,
-    replay_window_seconds: Option<u64>,
+pub struct PartialChatCompletionsIdempotencyConfig {
+    pub enabled: Option<bool>,
+    pub replay_window_seconds: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CliRookConfigOverlay {
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub enable_tui: Option<bool>,
+    pub db_path: Option<PathBuf>,
+    pub inbound_auth: Option<PartialInboundAuthConfig>,
+    pub transport: Option<PartialTransportConfig>,
+    pub rate_limits: Option<PartialRateLimitConfig>,
+    pub idempotency: Option<PartialIdempotencyConfig>,
+}
+
+pub struct LoadRookConfigInput<'a> {
+    pub file_path: Option<&'a Path>,
+    pub env: &'a HashMap<String, String>,
+    pub cli: Option<CliRookConfigOverlay>,
 }
 
 impl RookConfig {
@@ -162,115 +187,23 @@ impl RookConfig {
             .map_err(|error| RookError::Config(format!("invalid rook config TOML: {error}")))?;
 
         let mut config = Self::default();
-
-        if let Some(host) = partial.host {
-            config.host = host;
-        }
-        if let Some(port) = partial.port {
-            config.port = port;
-        }
-        if let Some(enable_tui) = partial.enable_tui {
-            config.enable_tui = enable_tui;
-        }
-        if let Some(db_path) = partial.db_path {
-            config.db_path = db_path;
-        }
-        if let Some(inbound_auth) = partial.inbound_auth {
-            if let Some(enabled) = inbound_auth.enabled {
-                config.inbound_auth.enabled = enabled;
-            }
-            if let Some(bearer_token) = inbound_auth.bearer_token {
-                config.inbound_auth.bearer_token = Some(bearer_token);
-            }
-        }
-        if let Some(transport) = partial.transport {
-            if let Some(request_id) = transport.request_id {
-                if let Some(inbound_header_name) = request_id.inbound_header_name {
-                    config.transport.request_id.inbound_header_name = inbound_header_name;
-                }
-                if let Some(response_header_name) = request_id.response_header_name {
-                    config.transport.request_id.response_header_name = response_header_name;
-                }
-                if let Some(max_length) = request_id.max_length {
-                    config.transport.request_id.max_length = max_length;
-                }
-            }
-            if let Some(trusted_proxy) = transport.trusted_proxy {
-                if let Some(enabled) = trusted_proxy.enabled {
-                    config.transport.trusted_proxy.enabled = enabled;
-                }
-                if let Some(trusted_cidrs) = trusted_proxy.trusted_cidrs {
-                    config.transport.trusted_proxy.trusted_cidrs = trusted_cidrs;
-                }
-                if let Some(allowed_headers) = trusted_proxy.allowed_headers {
-                    if let Some(forwarded) = allowed_headers.forwarded {
-                        config.transport.trusted_proxy.allowed_headers.forwarded = forwarded;
-                    }
-                    if let Some(x_forwarded_for) = allowed_headers.x_forwarded_for {
-                        config.transport.trusted_proxy.allowed_headers.x_forwarded_for = x_forwarded_for;
-                    }
-                    if let Some(x_forwarded_host) = allowed_headers.x_forwarded_host {
-                        config.transport.trusted_proxy.allowed_headers.x_forwarded_host = x_forwarded_host;
-                    }
-                    if let Some(x_forwarded_proto) = allowed_headers.x_forwarded_proto {
-                        config.transport.trusted_proxy.allowed_headers.x_forwarded_proto = x_forwarded_proto;
-                    }
-                    if let Some(x_forwarded_port) = allowed_headers.x_forwarded_port {
-                        config.transport.trusted_proxy.allowed_headers.x_forwarded_port = x_forwarded_port;
-                    }
-                    if let Some(x_real_ip) = allowed_headers.x_real_ip {
-                        config.transport.trusted_proxy.allowed_headers.x_real_ip = x_real_ip;
-                    }
-                }
-            }
-        }
-        if let Some(rate_limits) = partial.rate_limits {
-            if let Some(api) = rate_limits.api {
-                if let Some(max_requests) = api.max_requests {
-                    config.rate_limits.api.max_requests = max_requests;
-                }
-                if let Some(window_seconds) = api.window_seconds {
-                    config.rate_limits.api.window_seconds = window_seconds;
-                }
-            }
-            if let Some(v1_models) = rate_limits.v1_models {
-                if let Some(max_requests) = v1_models.max_requests {
-                    config.rate_limits.v1_models.max_requests = max_requests;
-                }
-                if let Some(window_seconds) = v1_models.window_seconds {
-                    config.rate_limits.v1_models.window_seconds = window_seconds;
-                }
-            }
-            if let Some(v1_chat_completions) = rate_limits.v1_chat_completions {
-                if let Some(max_requests) = v1_chat_completions.max_requests {
-                    config.rate_limits.v1_chat_completions.max_requests = max_requests;
-                }
-                if let Some(window_seconds) = v1_chat_completions.window_seconds {
-                    config.rate_limits.v1_chat_completions.window_seconds = window_seconds;
-                }
-            }
-        }
-        if let Some(idempotency) = partial.idempotency {
-            if let Some(chat_completions) = idempotency.chat_completions {
-                if let Some(enabled) = chat_completions.enabled {
-                    config.idempotency.chat_completions.enabled = enabled;
-                }
-                if let Some(replay_window_seconds) = chat_completions.replay_window_seconds {
-                    config.idempotency.chat_completions.replay_window_seconds = replay_window_seconds;
-                }
-            }
-        }
-
+        partial.apply_to(&mut config);
         Ok(config)
     }
 
-    pub fn from_sources(file_toml: Option<&str>, env: &HashMap<String, String>) -> Result<Self, RookError> {
-        let mut config = match file_toml {
-            Some(file_toml) => Self::from_toml_str(file_toml)?,
-            None => Self::default(),
-        };
+    pub fn from_sources(
+        file_toml: Option<&str>,
+        env: &HashMap<String, String>,
+    ) -> Result<Self, RookError> {
+        let mut config = Self::default();
 
-        config.apply_env_overrides(env)?;
+        if let Some(file_toml) = file_toml {
+            let partial: PartialRookConfig = toml::from_str(file_toml)
+                .map_err(|error| RookError::Config(format!("invalid rook config TOML: {error}")))?;
+            partial.apply_to(&mut config);
+        }
+
+        parse_env_overlay(env)?.apply_to(&mut config);
         config.validate()?;
         Ok(config)
     }
@@ -279,154 +212,39 @@ impl RookConfig {
         file_path: Option<&Path>,
         env: &HashMap<String, String>,
     ) -> Result<Self, RookError> {
-        let config = Self::from_sources_with_path_unvalidated(file_path, env)?;
-        config.validate()?;
-        Ok(config)
+        load_effective_config(LoadRookConfigInput {
+            file_path,
+            env,
+            cli: None,
+        })
     }
 
     pub fn from_sources_with_path_unvalidated(
         file_path: Option<&Path>,
         env: &HashMap<String, String>,
     ) -> Result<Self, RookError> {
-        let mut config = Self::load_from_optional_file(file_path)?;
-        config.apply_env_overrides(env)?;
+        let mut config = Self::default();
+        load_file_overlay(file_path)?.apply_to(&mut config);
+        parse_env_overlay(env)?.apply_to(&mut config);
         Ok(config)
     }
 
     pub fn apply_env_overrides(&mut self, env: &HashMap<String, String>) -> Result<(), RookError> {
-        if let Some(host) = env.get("ROOK_HOST") {
-            self.host = host.clone();
-        }
-
-        if let Some(port) = override_from_env::<u16>(env, "ROOK_PORT")? {
-            self.port = port;
-        }
-
-        if let Some(enable_tui) = env.get("ROOK_ENABLE_TUI") {
-            self.enable_tui = parse_bool_env("ROOK_ENABLE_TUI", enable_tui)?;
-        }
-
-        if let Some(db_path) = env.get("ROOK_DB_PATH") {
-            self.db_path = PathBuf::from(db_path);
-        }
-
-        if let Some(enabled) = env.get("ROOK_INBOUND_AUTH_ENABLED") {
-            self.inbound_auth.enabled = parse_bool_env("ROOK_INBOUND_AUTH_ENABLED", enabled)?;
-        }
-
-        if let Some(token) = env.get("ROOK_INBOUND_AUTH_TOKEN") {
-            self.inbound_auth.bearer_token = Some(token.clone());
-        }
-
-        if let Some(inbound_header_name) = env.get("ROOK_TRANSPORT_REQUEST_ID_INBOUND_HEADER_NAME") {
-            self.transport.request_id.inbound_header_name = inbound_header_name.clone();
-        }
-
-        if let Some(response_header_name) = env.get("ROOK_TRANSPORT_REQUEST_ID_RESPONSE_HEADER_NAME") {
-            self.transport.request_id.response_header_name = response_header_name.clone();
-        }
-
-        if let Some(max_length) = override_from_env::<usize>(env, "ROOK_TRANSPORT_REQUEST_ID_MAX_LENGTH")? {
-            self.transport.request_id.max_length = max_length;
-        }
-
-        if let Some(enabled) = env.get("ROOK_TRANSPORT_TRUSTED_PROXY_ENABLED") {
-            self.transport.trusted_proxy.enabled =
-                parse_bool_env("ROOK_TRANSPORT_TRUSTED_PROXY_ENABLED", enabled)?;
-        }
-
-        if let Some(trusted_cidrs) = env.get("ROOK_TRANSPORT_TRUSTED_PROXY_TRUSTED_CIDRS") {
-            self.transport.trusted_proxy.trusted_cidrs = trusted_cidrs
-                .split(',')
-                .map(str::trim)
-                .filter(|cidr| !cidr.is_empty())
-                .map(ToOwned::to_owned)
-                .collect();
-        }
-
-        if let Some(forwarded) = env.get("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_FORWARDED") {
-            self.transport.trusted_proxy.allowed_headers.forwarded =
-                parse_bool_env("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_FORWARDED", forwarded)?;
-        }
-
-        if let Some(x_forwarded_for) = env.get("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_FOR") {
-            self.transport.trusted_proxy.allowed_headers.x_forwarded_for = parse_bool_env(
-                "ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_FOR",
-                x_forwarded_for,
-            )?;
-        }
-
-        if let Some(x_forwarded_host) = env.get("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_HOST") {
-            self.transport.trusted_proxy.allowed_headers.x_forwarded_host = parse_bool_env(
-                "ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_HOST",
-                x_forwarded_host,
-            )?;
-        }
-
-        if let Some(x_forwarded_proto) = env.get("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_PROTO") {
-            self.transport.trusted_proxy.allowed_headers.x_forwarded_proto = parse_bool_env(
-                "ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_PROTO",
-                x_forwarded_proto,
-            )?;
-        }
-
-        if let Some(x_forwarded_port) = env.get("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_PORT") {
-            self.transport.trusted_proxy.allowed_headers.x_forwarded_port = parse_bool_env(
-                "ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_PORT",
-                x_forwarded_port,
-            )?;
-        }
-
-        if let Some(x_real_ip) = env.get("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_REAL_IP") {
-            self.transport.trusted_proxy.allowed_headers.x_real_ip =
-                parse_bool_env("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_REAL_IP", x_real_ip)?;
-        }
-
-        if let Some(max_requests) = override_from_env::<u32>(env, "ROOK_API_RATE_LIMIT_MAX_REQUESTS")? {
-            self.rate_limits.api.max_requests = max_requests;
-        }
-
-        if let Some(window_seconds) = override_from_env::<u64>(env, "ROOK_API_RATE_LIMIT_WINDOW_SECONDS")? {
-            self.rate_limits.api.window_seconds = window_seconds;
-        }
-
-        if let Some(max_requests) = override_from_env::<u32>(env, "ROOK_V1_MODELS_RATE_LIMIT_MAX_REQUESTS")? {
-            self.rate_limits.v1_models.max_requests = max_requests;
-        }
-
-        if let Some(window_seconds) = override_from_env::<u64>(env, "ROOK_V1_MODELS_RATE_LIMIT_WINDOW_SECONDS")? {
-            self.rate_limits.v1_models.window_seconds = window_seconds;
-        }
-
-        if let Some(max_requests) = override_from_env::<u32>(env, "ROOK_V1_CHAT_RATE_LIMIT_MAX_REQUESTS")? {
-            self.rate_limits.v1_chat_completions.max_requests = max_requests;
-        }
-
-        if let Some(window_seconds) = override_from_env::<u64>(env, "ROOK_V1_CHAT_RATE_LIMIT_WINDOW_SECONDS")? {
-            self.rate_limits.v1_chat_completions.window_seconds = window_seconds;
-        }
-
-        if let Some(enabled) = env.get("ROOK_CHAT_IDEMPOTENCY_ENABLED") {
-            self.idempotency.chat_completions.enabled =
-                parse_bool_env("ROOK_CHAT_IDEMPOTENCY_ENABLED", enabled)?;
-        }
-
-        if let Some(replay_window_seconds) =
-            override_from_env::<u64>(env, "ROOK_CHAT_IDEMPOTENCY_REPLAY_WINDOW_SECONDS")?
-        {
-            self.idempotency.chat_completions.replay_window_seconds = replay_window_seconds;
-        }
-
+        parse_env_overlay(env)?.apply_to(self);
         Ok(())
     }
 
     pub fn validate(&self) -> Result<(), RookError> {
         if self.host.trim().is_empty() {
-            return Err(RookError::Config("server host must not be blank".to_string()));
+            return Err(RookError::Config(
+                "server host must not be blank".to_string(),
+            ));
         }
 
         if self.db_path.as_os_str().is_empty() {
-            return Err(RookError::Config("database path must not be blank".to_string()));
+            return Err(RookError::Config(
+                "database path must not be blank".to_string(),
+            ));
         }
 
         self.inbound_auth.validate()?;
@@ -447,6 +265,403 @@ impl RookConfig {
             rate_limits: self.rate_limits.clone(),
             idempotency: self.idempotency.clone(),
         }
+    }
+}
+
+impl PartialRookConfig {
+    fn apply_to(self, target: &mut RookConfig) {
+        if let Some(host) = self.host {
+            target.host = host;
+        }
+        if let Some(port) = self.port {
+            target.port = port;
+        }
+        if let Some(enable_tui) = self.enable_tui {
+            target.enable_tui = enable_tui;
+        }
+        if let Some(db_path) = self.db_path {
+            target.db_path = db_path;
+        }
+        if let Some(inbound_auth) = self.inbound_auth {
+            inbound_auth.apply_to(&mut target.inbound_auth);
+        }
+        if let Some(transport) = self.transport {
+            transport.apply_to(&mut target.transport);
+        }
+        if let Some(rate_limits) = self.rate_limits {
+            rate_limits.apply_to(&mut target.rate_limits);
+        }
+        if let Some(idempotency) = self.idempotency {
+            idempotency.apply_to(&mut target.idempotency);
+        }
+    }
+}
+
+impl PartialInboundAuthConfig {
+    fn apply_to(self, target: &mut InboundAuthConfig) {
+        if let Some(enabled) = self.enabled {
+            target.enabled = enabled;
+        }
+        if let Some(bearer_token) = self.bearer_token {
+            target.bearer_token = Some(bearer_token);
+        }
+    }
+}
+
+impl PartialTransportConfig {
+    fn apply_to(self, target: &mut TransportConfig) {
+        if let Some(request_id) = self.request_id {
+            request_id.apply_to(&mut target.request_id);
+        }
+        if let Some(trusted_proxy) = self.trusted_proxy {
+            trusted_proxy.apply_to(&mut target.trusted_proxy);
+        }
+    }
+}
+
+impl PartialRequestIdConfig {
+    fn apply_to(self, target: &mut RequestIdConfig) {
+        if let Some(inbound_header_name) = self.inbound_header_name {
+            target.inbound_header_name = inbound_header_name;
+        }
+        if let Some(response_header_name) = self.response_header_name {
+            target.response_header_name = response_header_name;
+        }
+        if let Some(max_length) = self.max_length {
+            target.max_length = max_length;
+        }
+    }
+}
+
+impl PartialTrustedProxyConfig {
+    fn apply_to(self, target: &mut TrustedProxyConfig) {
+        if let Some(enabled) = self.enabled {
+            target.enabled = enabled;
+        }
+        if let Some(trusted_cidrs) = self.trusted_cidrs {
+            target.trusted_cidrs = trusted_cidrs;
+        }
+        if let Some(allowed_headers) = self.allowed_headers {
+            allowed_headers.apply_to(&mut target.allowed_headers);
+        }
+    }
+}
+
+impl PartialTrustedForwardedHeaders {
+    fn apply_to(self, target: &mut TrustedForwardedHeaders) {
+        if let Some(forwarded) = self.forwarded {
+            target.forwarded = forwarded;
+        }
+        if let Some(x_forwarded_for) = self.x_forwarded_for {
+            target.x_forwarded_for = x_forwarded_for;
+        }
+        if let Some(x_forwarded_host) = self.x_forwarded_host {
+            target.x_forwarded_host = x_forwarded_host;
+        }
+        if let Some(x_forwarded_proto) = self.x_forwarded_proto {
+            target.x_forwarded_proto = x_forwarded_proto;
+        }
+        if let Some(x_forwarded_port) = self.x_forwarded_port {
+            target.x_forwarded_port = x_forwarded_port;
+        }
+        if let Some(x_real_ip) = self.x_real_ip {
+            target.x_real_ip = x_real_ip;
+        }
+    }
+}
+
+impl PartialRateLimitConfig {
+    fn apply_to(self, target: &mut RateLimitConfig) {
+        if let Some(api) = self.api {
+            api.apply_to(&mut target.api);
+        }
+        if let Some(v1_models) = self.v1_models {
+            v1_models.apply_to(&mut target.v1_models);
+        }
+        if let Some(v1_chat_completions) = self.v1_chat_completions {
+            v1_chat_completions.apply_to(&mut target.v1_chat_completions);
+        }
+    }
+}
+
+impl PartialSurfaceRateLimitPolicy {
+    fn apply_to(self, target: &mut SurfaceRateLimitPolicy) {
+        if let Some(max_requests) = self.max_requests {
+            target.max_requests = max_requests;
+        }
+        if let Some(window_seconds) = self.window_seconds {
+            target.window_seconds = window_seconds;
+        }
+    }
+}
+
+impl PartialIdempotencyConfig {
+    fn apply_to(self, target: &mut IdempotencyConfig) {
+        if let Some(chat_completions) = self.chat_completions {
+            chat_completions.apply_to(&mut target.chat_completions);
+        }
+    }
+}
+
+impl PartialChatCompletionsIdempotencyConfig {
+    fn apply_to(self, target: &mut ChatCompletionsIdempotencyConfig) {
+        if let Some(enabled) = self.enabled {
+            target.enabled = enabled;
+        }
+        if let Some(replay_window_seconds) = self.replay_window_seconds {
+            target.replay_window_seconds = replay_window_seconds;
+        }
+    }
+}
+
+impl CliRookConfigOverlay {
+    fn apply_to(self, target: &mut RookConfig) {
+        PartialRookConfig {
+            host: self.host,
+            port: self.port,
+            enable_tui: self.enable_tui,
+            db_path: self.db_path,
+            inbound_auth: self.inbound_auth,
+            transport: self.transport,
+            rate_limits: self.rate_limits,
+            idempotency: self.idempotency,
+        }
+        .apply_to(target);
+    }
+}
+
+fn load_file_overlay(file_path: Option<&Path>) -> Result<PartialRookConfig, RookError> {
+    match file_path {
+        Some(path) if path.exists() => {
+            let content = fs::read_to_string(path).map_err(RookError::Io)?;
+            toml::from_str(&content)
+                .map_err(|error| RookError::Config(format!("invalid rook config TOML: {error}")))
+        }
+        Some(_) | None => Ok(PartialRookConfig::default()),
+    }
+}
+
+fn parse_env_overlay(env: &HashMap<String, String>) -> Result<PartialRookConfig, RookError> {
+    Ok(PartialRookConfig {
+        host: env.get("ROOK_HOST").cloned(),
+        port: override_from_env::<u16>(env, "ROOK_PORT")?,
+        enable_tui: env
+            .get("ROOK_ENABLE_TUI")
+            .map(|value| parse_bool_env("ROOK_ENABLE_TUI", value))
+            .transpose()?,
+        db_path: env.get("ROOK_DB_PATH").map(PathBuf::from),
+        inbound_auth: partial_if_any(PartialInboundAuthConfig {
+            enabled: env
+                .get("ROOK_INBOUND_AUTH_ENABLED")
+                .map(|value| parse_bool_env("ROOK_INBOUND_AUTH_ENABLED", value))
+                .transpose()?,
+            bearer_token: env.get("ROOK_INBOUND_AUTH_TOKEN").cloned(),
+        }),
+        transport: partial_if_any(PartialTransportConfig {
+            request_id: partial_if_any(PartialRequestIdConfig {
+                inbound_header_name: env
+                    .get("ROOK_TRANSPORT_REQUEST_ID_INBOUND_HEADER_NAME")
+                    .cloned(),
+                response_header_name: env
+                    .get("ROOK_TRANSPORT_REQUEST_ID_RESPONSE_HEADER_NAME")
+                    .cloned(),
+                max_length: override_from_env::<usize>(
+                    env,
+                    "ROOK_TRANSPORT_REQUEST_ID_MAX_LENGTH",
+                )?,
+            }),
+            trusted_proxy: partial_if_any(PartialTrustedProxyConfig {
+                enabled: env
+                    .get("ROOK_TRANSPORT_TRUSTED_PROXY_ENABLED")
+                    .map(|value| parse_bool_env("ROOK_TRANSPORT_TRUSTED_PROXY_ENABLED", value))
+                    .transpose()?,
+                trusted_cidrs: env.get("ROOK_TRANSPORT_TRUSTED_PROXY_TRUSTED_CIDRS").map(
+                    |trusted_cidrs| {
+                        trusted_cidrs
+                            .split(',')
+                            .map(str::trim)
+                            .filter(|cidr| !cidr.is_empty())
+                            .map(ToOwned::to_owned)
+                            .collect()
+                    },
+                ),
+                allowed_headers: partial_if_any(PartialTrustedForwardedHeaders {
+                    forwarded: env
+                        .get("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_FORWARDED")
+                        .map(|value| {
+                            parse_bool_env("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_FORWARDED", value)
+                        })
+                        .transpose()?,
+                    x_forwarded_for: env
+                        .get("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_FOR")
+                        .map(|value| {
+                            parse_bool_env(
+                                "ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_FOR",
+                                value,
+                            )
+                        })
+                        .transpose()?,
+                    x_forwarded_host: env
+                        .get("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_HOST")
+                        .map(|value| {
+                            parse_bool_env(
+                                "ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_HOST",
+                                value,
+                            )
+                        })
+                        .transpose()?,
+                    x_forwarded_proto: env
+                        .get("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_PROTO")
+                        .map(|value| {
+                            parse_bool_env(
+                                "ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_PROTO",
+                                value,
+                            )
+                        })
+                        .transpose()?,
+                    x_forwarded_port: env
+                        .get("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_PORT")
+                        .map(|value| {
+                            parse_bool_env(
+                                "ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_FORWARDED_PORT",
+                                value,
+                            )
+                        })
+                        .transpose()?,
+                    x_real_ip: env
+                        .get("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_REAL_IP")
+                        .map(|value| {
+                            parse_bool_env("ROOK_TRANSPORT_TRUSTED_PROXY_ALLOW_X_REAL_IP", value)
+                        })
+                        .transpose()?,
+                }),
+            }),
+        }),
+        rate_limits: partial_if_any(PartialRateLimitConfig {
+            api: partial_if_any(PartialSurfaceRateLimitPolicy {
+                max_requests: override_from_env::<u32>(env, "ROOK_API_RATE_LIMIT_MAX_REQUESTS")?,
+                window_seconds: override_from_env::<u64>(
+                    env,
+                    "ROOK_API_RATE_LIMIT_WINDOW_SECONDS",
+                )?,
+            }),
+            v1_models: partial_if_any(PartialSurfaceRateLimitPolicy {
+                max_requests: override_from_env::<u32>(
+                    env,
+                    "ROOK_V1_MODELS_RATE_LIMIT_MAX_REQUESTS",
+                )?,
+                window_seconds: override_from_env::<u64>(
+                    env,
+                    "ROOK_V1_MODELS_RATE_LIMIT_WINDOW_SECONDS",
+                )?,
+            }),
+            v1_chat_completions: partial_if_any(PartialSurfaceRateLimitPolicy {
+                max_requests: override_from_env::<u32>(
+                    env,
+                    "ROOK_V1_CHAT_RATE_LIMIT_MAX_REQUESTS",
+                )?,
+                window_seconds: override_from_env::<u64>(
+                    env,
+                    "ROOK_V1_CHAT_RATE_LIMIT_WINDOW_SECONDS",
+                )?,
+            }),
+        }),
+        idempotency: partial_if_any(PartialIdempotencyConfig {
+            chat_completions: partial_if_any(PartialChatCompletionsIdempotencyConfig {
+                enabled: env
+                    .get("ROOK_CHAT_IDEMPOTENCY_ENABLED")
+                    .map(|value| parse_bool_env("ROOK_CHAT_IDEMPOTENCY_ENABLED", value))
+                    .transpose()?,
+                replay_window_seconds: override_from_env::<u64>(
+                    env,
+                    "ROOK_CHAT_IDEMPOTENCY_REPLAY_WINDOW_SECONDS",
+                )?,
+            }),
+        }),
+    })
+}
+
+pub fn load_effective_config(input: LoadRookConfigInput<'_>) -> Result<RookConfig, RookError> {
+    let mut config = RookConfig::default();
+    load_file_overlay(input.file_path)?.apply_to(&mut config);
+    parse_env_overlay(input.env)?.apply_to(&mut config);
+    if let Some(cli) = input.cli {
+        cli.apply_to(&mut config);
+    }
+    config.validate()?;
+    Ok(config)
+}
+
+trait PartialOverlay {
+    fn is_empty(&self) -> bool;
+}
+
+impl PartialOverlay for PartialInboundAuthConfig {
+    fn is_empty(&self) -> bool {
+        self.enabled.is_none() && self.bearer_token.is_none()
+    }
+}
+
+impl PartialOverlay for PartialRequestIdConfig {
+    fn is_empty(&self) -> bool {
+        self.inbound_header_name.is_none()
+            && self.response_header_name.is_none()
+            && self.max_length.is_none()
+    }
+}
+
+impl PartialOverlay for PartialTrustedForwardedHeaders {
+    fn is_empty(&self) -> bool {
+        self.forwarded.is_none()
+            && self.x_forwarded_for.is_none()
+            && self.x_forwarded_host.is_none()
+            && self.x_forwarded_proto.is_none()
+            && self.x_forwarded_port.is_none()
+            && self.x_real_ip.is_none()
+    }
+}
+
+impl PartialOverlay for PartialTrustedProxyConfig {
+    fn is_empty(&self) -> bool {
+        self.enabled.is_none() && self.trusted_cidrs.is_none() && self.allowed_headers.is_none()
+    }
+}
+
+impl PartialOverlay for PartialTransportConfig {
+    fn is_empty(&self) -> bool {
+        self.request_id.is_none() && self.trusted_proxy.is_none()
+    }
+}
+
+impl PartialOverlay for PartialSurfaceRateLimitPolicy {
+    fn is_empty(&self) -> bool {
+        self.max_requests.is_none() && self.window_seconds.is_none()
+    }
+}
+
+impl PartialOverlay for PartialRateLimitConfig {
+    fn is_empty(&self) -> bool {
+        self.api.is_none() && self.v1_models.is_none() && self.v1_chat_completions.is_none()
+    }
+}
+
+impl PartialOverlay for PartialChatCompletionsIdempotencyConfig {
+    fn is_empty(&self) -> bool {
+        self.enabled.is_none() && self.replay_window_seconds.is_none()
+    }
+}
+
+impl PartialOverlay for PartialIdempotencyConfig {
+    fn is_empty(&self) -> bool {
+        self.chat_completions.is_none()
+    }
+}
+
+fn partial_if_any<T: PartialOverlay>(partial: T) -> Option<T> {
+    if partial.is_empty() {
+        None
+    } else {
+        Some(partial)
     }
 }
 
@@ -562,7 +777,9 @@ impl RookConfigExportView {
             inbound_auth: InboundAuthExportView {
                 enabled: config.inbound_auth.enabled,
                 bearer_token: if config.inbound_auth.enabled {
-                    Some(redact_optional_secret(config.inbound_auth.bearer_token.as_deref()))
+                    Some(redact_optional_secret(
+                        config.inbound_auth.bearer_token.as_deref(),
+                    ))
                 } else {
                     None
                 },
@@ -873,15 +1090,176 @@ impl TransportConfig {
 #[cfg(test)]
 mod tests {
     use super::{
-        ChatCompletionsIdempotencyConfig, IdempotencyConfig, InboundAuthConfig,
-        InboundAuthOperatorState, RateLimitConfig, RequestIdConfig, SurfaceRateLimitPolicy,
-        TransportConfig, TrustedForwardedHeaders, TrustedProxyConfig,
+        load_effective_config, parse_env_overlay, ChatCompletionsIdempotencyConfig,
+        CliRookConfigOverlay, IdempotencyConfig, InboundAuthConfig, InboundAuthOperatorState,
+        LoadRookConfigInput, PartialChatCompletionsIdempotencyConfig, PartialIdempotencyConfig,
+        PartialInboundAuthConfig, PartialRateLimitConfig, PartialSurfaceRateLimitPolicy,
+        RateLimitConfig, RequestIdConfig, SurfaceRateLimitPolicy, TransportConfig,
+        TrustedForwardedHeaders, TrustedProxyConfig,
     };
     use serde_json::json;
 
     #[test]
     fn rook_config_default_will_exist_for_phase_1() {
         let _ = super::RookConfig::default();
+    }
+
+    #[test]
+    fn load_effective_config_applies_defaults_then_file_then_env_then_cli() {
+        let temp_dir = tempfile::tempdir().expect("temp dir should exist");
+        let config_path = temp_dir.path().join("rook.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+            host = "1.1.1.1"
+            port = 6464
+            db_path = "/file/rook.db"
+
+            [inbound_auth]
+            enabled = true
+            bearer_token = "file-token"
+
+            [rate_limits.api]
+            max_requests = 71
+            window_seconds = 41
+            "#,
+        )
+        .expect("config file should be written");
+
+        let env = std::collections::HashMap::from([
+            ("ROOK_HOST".to_string(), "2.2.2.2".to_string()),
+            ("ROOK_PORT".to_string(), "7474".to_string()),
+            ("ROOK_DB_PATH".to_string(), "/env/rook.db".to_string()),
+            (
+                "ROOK_INBOUND_AUTH_TOKEN".to_string(),
+                "env-token".to_string(),
+            ),
+            (
+                "ROOK_API_RATE_LIMIT_MAX_REQUESTS".to_string(),
+                "81".to_string(),
+            ),
+        ]);
+
+        let config = load_effective_config(LoadRookConfigInput {
+            file_path: Some(config_path.as_path()),
+            env: &env,
+            cli: Some(CliRookConfigOverlay {
+                host: Some("3.3.3.3".to_string()),
+                port: Some(8484),
+                enable_tui: Some(true),
+                db_path: Some(std::path::PathBuf::from("/cli/rook.db")),
+                inbound_auth: Some(PartialInboundAuthConfig {
+                    enabled: Some(true),
+                    bearer_token: Some("cli-token".to_string()),
+                }),
+                transport: None,
+                rate_limits: Some(PartialRateLimitConfig {
+                    api: Some(PartialSurfaceRateLimitPolicy {
+                        max_requests: Some(91),
+                        window_seconds: None,
+                    }),
+                    v1_models: None,
+                    v1_chat_completions: None,
+                }),
+                idempotency: Some(PartialIdempotencyConfig {
+                    chat_completions: Some(PartialChatCompletionsIdempotencyConfig {
+                        enabled: None,
+                        replay_window_seconds: Some(3600),
+                    }),
+                }),
+            }),
+        })
+        .expect("effective config should assemble");
+
+        assert_eq!(config.host, "3.3.3.3");
+        assert_eq!(config.port, 8484);
+        assert!(config.enable_tui);
+        assert_eq!(config.db_path, std::path::PathBuf::from("/cli/rook.db"));
+        assert_eq!(
+            config.inbound_auth.bearer_token.as_deref(),
+            Some("cli-token")
+        );
+        assert_eq!(config.rate_limits.api.max_requests, 91);
+        assert_eq!(config.rate_limits.api.window_seconds, 41);
+        assert_eq!(
+            config.idempotency.chat_completions.replay_window_seconds,
+            3600
+        );
+    }
+
+    #[test]
+    fn parse_env_overlay_maps_supported_rook_variables_and_ignores_unknown_ones() {
+        let env = std::collections::HashMap::from([
+            ("ROOK_ENABLE_TUI".to_string(), "yes".to_string()),
+            (
+                "ROOK_TRANSPORT_TRUSTED_PROXY_ENABLED".to_string(),
+                "true".to_string(),
+            ),
+            (
+                "ROOK_TRANSPORT_TRUSTED_PROXY_TRUSTED_CIDRS".to_string(),
+                "10.0.0.0/8, 192.168.0.0/16".to_string(),
+            ),
+            (
+                "ROOK_CHAT_IDEMPOTENCY_REPLAY_WINDOW_SECONDS".to_string(),
+                "1234".to_string(),
+            ),
+            ("ROOK_UNSUPPORTED".to_string(), "ignored".to_string()),
+        ]);
+
+        let overlay = parse_env_overlay(&env).expect("env overlay should parse");
+
+        assert_eq!(overlay.enable_tui, Some(true));
+        assert_eq!(
+            overlay
+                .transport
+                .as_ref()
+                .and_then(|transport| transport.trusted_proxy.as_ref())
+                .and_then(|proxy| proxy.enabled),
+            Some(true)
+        );
+        assert_eq!(
+            overlay
+                .transport
+                .as_ref()
+                .and_then(|transport| transport.trusted_proxy.as_ref())
+                .and_then(|proxy| proxy.trusted_cidrs.clone()),
+            Some(vec!["10.0.0.0/8".to_string(), "192.168.0.0/16".to_string()])
+        );
+        assert_eq!(
+            overlay
+                .idempotency
+                .as_ref()
+                .and_then(|idempotency| idempotency.chat_completions.as_ref())
+                .and_then(|chat| chat.replay_window_seconds),
+            Some(1234)
+        );
+    }
+
+    #[test]
+    fn rook_config_export_view_never_serializes_secret_like_literals() {
+        let output = serde_json::to_string(&super::RookConfigExportView::from_config(
+            &super::RookConfig {
+                inbound_auth: InboundAuthConfig {
+                    enabled: true,
+                    bearer_token: Some("super-secret-token".to_string()),
+                },
+                ..Default::default()
+            },
+        ))
+        .expect("export view should serialize");
+
+        for forbidden in [
+            "super-secret-token",
+            "sk-secret",
+            "Bearer secret-value",
+            "session_cookie=abc123",
+        ] {
+            assert!(
+                !output.contains(forbidden),
+                "export output leaked forbidden literal: {forbidden}"
+            );
+        }
+        assert!(output.contains("[redacted]"));
     }
 
     #[test]
@@ -895,7 +1273,10 @@ mod tests {
         });
 
         assert!(config.inbound_auth.enabled);
-        assert_eq!(config.inbound_auth.bearer_token.as_deref(), Some("[redacted]"));
+        assert_eq!(
+            config.inbound_auth.bearer_token.as_deref(),
+            Some("[redacted]")
+        );
     }
 
     #[test]
@@ -922,7 +1303,10 @@ mod tests {
             ..Default::default()
         });
 
-        assert_eq!(config.inbound_auth.bearer_token.as_deref(), Some("[not configured]"));
+        assert_eq!(
+            config.inbound_auth.bearer_token.as_deref(),
+            Some("[not configured]")
+        );
     }
 
     #[test]
@@ -970,7 +1354,10 @@ mod tests {
             ..Default::default()
         });
 
-        assert_eq!(config.transport.request_id.inbound_header_name, "x-correlation-id");
+        assert_eq!(
+            config.transport.request_id.inbound_header_name,
+            "x-correlation-id"
+        );
         assert_eq!(config.transport.request_id.max_length, 256);
         assert!(config.transport.trusted_proxy.enabled);
         assert_eq!(
@@ -1030,7 +1417,10 @@ mod tests {
         assert_eq!(config.host, "0.0.0.0");
         assert_eq!(config.port, 5151);
         assert!(config.enable_tui);
-        assert_eq!(config.db_path, std::path::PathBuf::from("/tmp/rook-test.db"));
+        assert_eq!(
+            config.db_path,
+            std::path::PathBuf::from("/tmp/rook-test.db")
+        );
     }
 
     #[test]
@@ -1043,7 +1433,9 @@ mod tests {
             ("ROOK_DB_PATH".to_string(), "/var/lib/rook.db".to_string()),
         ]);
 
-        config.apply_env_overrides(&env).expect("env overrides should apply");
+        config
+            .apply_env_overrides(&env)
+            .expect("env overrides should apply");
 
         assert_eq!(config.host, "0.0.0.0");
         assert_eq!(config.port, 5252);
@@ -1054,10 +1446,8 @@ mod tests {
     #[test]
     fn rook_config_apply_env_overrides_rejects_invalid_port() {
         let mut config = super::RookConfig::default();
-        let env = std::collections::HashMap::from([(
-            "ROOK_PORT".to_string(),
-            "not-a-port".to_string(),
-        )]);
+        let env =
+            std::collections::HashMap::from([("ROOK_PORT".to_string(), "not-a-port".to_string())]);
 
         let error = config
             .apply_env_overrides(&env)
@@ -1079,8 +1469,11 @@ mod tests {
 
         assert_eq!(server_config.host, "0.0.0.0");
         assert_eq!(server_config.port, 6262);
-        assert_eq!(server_config.enable_tui, true);
-        assert_eq!(server_config.db_path.as_deref(), Some("/tmp/rook-config.db"));
+        assert!(server_config.enable_tui);
+        assert_eq!(
+            server_config.db_path.as_deref(),
+            Some("/tmp/rook-config.db")
+        );
     }
 
     #[test]
@@ -1146,8 +1539,11 @@ mod tests {
         )
         .expect("toml config should parse nested fields");
 
-        assert_eq!(config.inbound_auth.enabled, true);
-        assert_eq!(config.inbound_auth.bearer_token.as_deref(), Some("file-token"));
+        assert!(config.inbound_auth.enabled);
+        assert_eq!(
+            config.inbound_auth.bearer_token.as_deref(),
+            Some("file-token")
+        );
         assert_eq!(config.rate_limits.api.max_requests, 71);
         assert_eq!(config.rate_limits.api.window_seconds, 41);
         assert_eq!(config.rate_limits.v1_models.max_requests, 72);
@@ -1159,17 +1555,29 @@ mod tests {
         let mut config = super::RookConfig::default();
         let env = std::collections::HashMap::from([
             ("ROOK_INBOUND_AUTH_ENABLED".to_string(), "true".to_string()),
-            ("ROOK_INBOUND_AUTH_TOKEN".to_string(), "env-token".to_string()),
-            ("ROOK_API_RATE_LIMIT_MAX_REQUESTS".to_string(), "81".to_string()),
-            ("ROOK_API_RATE_LIMIT_WINDOW_SECONDS".to_string(), "51".to_string()),
+            (
+                "ROOK_INBOUND_AUTH_TOKEN".to_string(),
+                "env-token".to_string(),
+            ),
+            (
+                "ROOK_API_RATE_LIMIT_MAX_REQUESTS".to_string(),
+                "81".to_string(),
+            ),
+            (
+                "ROOK_API_RATE_LIMIT_WINDOW_SECONDS".to_string(),
+                "51".to_string(),
+            ),
         ]);
 
         config
             .apply_env_overrides(&env)
             .expect("env overrides should apply nested fields");
 
-        assert_eq!(config.inbound_auth.enabled, true);
-        assert_eq!(config.inbound_auth.bearer_token.as_deref(), Some("env-token"));
+        assert!(config.inbound_auth.enabled);
+        assert_eq!(
+            config.inbound_auth.bearer_token.as_deref(),
+            Some("env-token")
+        );
         assert_eq!(config.rate_limits.api.max_requests, 81);
         assert_eq!(config.rate_limits.api.window_seconds, 51);
     }
@@ -1191,8 +1599,11 @@ mod tests {
 
         assert_eq!(config.rate_limits.v1_chat_completions.max_requests, 91);
         assert_eq!(config.rate_limits.v1_chat_completions.window_seconds, 61);
-        assert_eq!(config.idempotency.chat_completions.enabled, false);
-        assert_eq!(config.idempotency.chat_completions.replay_window_seconds, 1234);
+        assert!(!config.idempotency.chat_completions.enabled);
+        assert_eq!(
+            config.idempotency.chat_completions.replay_window_seconds,
+            1234
+        );
     }
 
     #[test]
@@ -1233,8 +1644,11 @@ mod tests {
         assert_eq!(config.rate_limits.v1_models.window_seconds, 52);
         assert_eq!(config.rate_limits.v1_chat_completions.max_requests, 83);
         assert_eq!(config.rate_limits.v1_chat_completions.window_seconds, 53);
-        assert_eq!(config.idempotency.chat_completions.enabled, false);
-        assert_eq!(config.idempotency.chat_completions.replay_window_seconds, 4321);
+        assert!(!config.idempotency.chat_completions.enabled);
+        assert_eq!(
+            config.idempotency.chat_completions.replay_window_seconds,
+            4321
+        );
     }
 
     #[test]
@@ -1256,8 +1670,11 @@ mod tests {
             .expect("config should load from file path");
 
         assert_eq!(config.host, "0.0.0.0");
-        assert_eq!(config.inbound_auth.enabled, true);
-        assert_eq!(config.inbound_auth.bearer_token.as_deref(), Some("file-token"));
+        assert!(config.inbound_auth.enabled);
+        assert_eq!(
+            config.inbound_auth.bearer_token.as_deref(),
+            Some("file-token")
+        );
     }
 
     #[test]
@@ -1279,8 +1696,8 @@ mod tests {
             temp_dir.path().display().to_string(),
         )]);
 
-        let path = super::discover_default_config_path(&env)
-            .expect("default config path should resolve");
+        let path =
+            super::discover_default_config_path(&env).expect("default config path should resolve");
 
         assert_eq!(path, temp_dir.path().join("rook").join("config.toml"));
     }
@@ -1306,13 +1723,28 @@ mod tests {
         )
         .expect("toml transport config should parse");
 
-        assert_eq!(config.transport.request_id.inbound_header_name, "x-correlation-id");
-        assert_eq!(config.transport.request_id.response_header_name, "x-correlation-id");
+        assert_eq!(
+            config.transport.request_id.inbound_header_name,
+            "x-correlation-id"
+        );
+        assert_eq!(
+            config.transport.request_id.response_header_name,
+            "x-correlation-id"
+        );
         assert_eq!(config.transport.request_id.max_length, 64);
         assert!(config.transport.trusted_proxy.enabled);
-        assert_eq!(config.transport.trusted_proxy.trusted_cidrs, vec!["10.0.0.0/8"]);
+        assert_eq!(
+            config.transport.trusted_proxy.trusted_cidrs,
+            vec!["10.0.0.0/8"]
+        );
         assert!(config.transport.trusted_proxy.allowed_headers.forwarded);
-        assert!(config.transport.trusted_proxy.allowed_headers.x_forwarded_for);
+        assert!(
+            config
+                .transport
+                .trusted_proxy
+                .allowed_headers
+                .x_forwarded_for
+        );
         assert!(config.transport.trusted_proxy.allowed_headers.x_real_ip);
     }
 
@@ -1350,8 +1782,14 @@ mod tests {
             .apply_env_overrides(&env)
             .expect("transport env overrides should apply");
 
-        assert_eq!(config.transport.request_id.inbound_header_name, "x-correlation-id");
-        assert_eq!(config.transport.request_id.response_header_name, "x-correlation-id");
+        assert_eq!(
+            config.transport.request_id.inbound_header_name,
+            "x-correlation-id"
+        );
+        assert_eq!(
+            config.transport.request_id.response_header_name,
+            "x-correlation-id"
+        );
         assert_eq!(config.transport.request_id.max_length, 64);
         assert!(config.transport.trusted_proxy.enabled);
         assert_eq!(

--- a/clients/rook/src/db/audit.rs
+++ b/clients/rook/src/db/audit.rs
@@ -217,6 +217,8 @@ mod tests {
 
         assert_eq!(filtered.len(), 3);
         assert!(filtered.iter().all(|row| row.resource_kind == "account"));
-        assert!(filtered.iter().all(|row| row.resource_id.as_deref() == Some("acc-1")));
+        assert!(filtered
+            .iter()
+            .all(|row| row.resource_id.as_deref() == Some("acc-1")));
     }
 }

--- a/clients/rook/src/db/mod.rs
+++ b/clients/rook/src/db/mod.rs
@@ -91,7 +91,9 @@ impl SqliteDb {
     pub async fn open_in_memory() -> Result<Self, RookError> {
         // max_connections(1) ensures a single connection so the in-memory
         // database is not dropped between pool checkouts.
-        let options = SqliteConnectOptions::new().in_memory(true).foreign_keys(true);
+        let options = SqliteConnectOptions::new()
+            .in_memory(true)
+            .foreign_keys(true);
 
         let pool = sqlx::pool::PoolOptions::<sqlx::Sqlite>::new()
             .max_connections(1)

--- a/clients/rook/src/doctor.rs
+++ b/clients/rook/src/doctor.rs
@@ -165,9 +165,19 @@ pub fn render_report(report: &DoctorReport) -> String {
 
 pub fn ensure_success(report: &DoctorReport) -> Result<(), RookError> {
     match report.overall_status() {
-        DoctorStatus::Fail => Err(RookError::Config(
-            "rook doctor found required check failures".to_string(),
-        )),
+        DoctorStatus::Fail => {
+            let failure_messages = report
+                .checks
+                .iter()
+                .filter(|check| matches!(check.status, DoctorStatus::Fail))
+                .map(|check| format!("{}: {}", check.name, check.message))
+                .collect::<Vec<_>>()
+                .join("; ");
+
+            Err(RookError::Config(format!(
+                "rook doctor found required check failures: {failure_messages}"
+            )))
+        }
         DoctorStatus::Pass | DoctorStatus::Warn => Ok(()),
     }
 }

--- a/clients/rook/src/doctor.rs
+++ b/clients/rook/src/doctor.rs
@@ -81,24 +81,25 @@ pub async fn run_with_config_path(
                 }
             };
 
-            let db_check = match RookRegistry::open_readonly(&config.db_path.to_string_lossy()).await {
-                Ok(_) => DoctorCheckResult {
-                    name: "database",
-                    status: DoctorStatus::Pass,
-                    message: format!(
-                        "registry connectivity verified in read-only mode at {}",
-                        config.db_path.display()
-                    ),
-                },
-                Err(error) => DoctorCheckResult {
-                    name: "database",
-                    status: DoctorStatus::Fail,
-                    message: format!(
-                        "failed to open registry read-only at {}: {error}",
-                        config.db_path.display()
-                    ),
-                },
-            };
+            let db_check =
+                match RookRegistry::open_readonly(&config.db_path.to_string_lossy()).await {
+                    Ok(_) => DoctorCheckResult {
+                        name: "database",
+                        status: DoctorStatus::Pass,
+                        message: format!(
+                            "registry connectivity verified in read-only mode at {}",
+                            config.db_path.display()
+                        ),
+                    },
+                    Err(error) => DoctorCheckResult {
+                        name: "database",
+                        status: DoctorStatus::Fail,
+                        message: format!(
+                            "failed to open registry read-only at {}: {error}",
+                            config.db_path.display()
+                        ),
+                    },
+                };
 
             DoctorReport {
                 checks: vec![
@@ -220,7 +221,9 @@ mod tests {
 
         assert_eq!(report.overall_status(), DoctorStatus::Fail);
         assert_eq!(report.checks[0].status, DoctorStatus::Fail);
-        assert!(report.checks[0].message.contains("failed to load effective configuration"));
+        assert!(report.checks[0]
+            .message
+            .contains("failed to load effective configuration"));
     }
 
     #[tokio::test]
@@ -238,15 +241,14 @@ mod tests {
         assert_eq!(report.checks[2].status, DoctorStatus::Pass);
         assert_eq!(report.checks[3].name, "database");
         assert_eq!(report.checks[3].status, DoctorStatus::Fail);
-        assert!(report.checks[3].message.contains("failed to open registry read-only"));
+        assert!(report.checks[3]
+            .message
+            .contains("failed to open registry read-only"));
     }
 
     #[tokio::test]
     async fn doctor_report_fails_when_inbound_auth_is_enabled_without_token() {
-        let env = HashMap::from([(
-            "ROOK_INBOUND_AUTH_ENABLED".to_string(),
-            "true".to_string(),
-        )]);
+        let env = HashMap::from([("ROOK_INBOUND_AUTH_ENABLED".to_string(), "true".to_string())]);
 
         let report = run_with_config_path(None, &env).await;
 
@@ -254,7 +256,9 @@ mod tests {
         assert_eq!(report.checks.len(), 1);
         assert_eq!(report.checks[0].name, "config");
         assert_eq!(report.checks[0].status, DoctorStatus::Fail);
-        assert!(report.checks[0].message.contains("inbound auth token is required"));
+        assert!(report.checks[0]
+            .message
+            .contains("inbound auth token is required"));
     }
 
     #[tokio::test]
@@ -277,7 +281,9 @@ mod tests {
             .find(|check| check.name == "assets")
             .expect("assets check should be present");
         assert_eq!(assets_check.status, DoctorStatus::Pass);
-        assert!(assets_check.message.contains("embedded dashboard assets are available"));
+        assert!(assets_check
+            .message
+            .contains("embedded dashboard assets are available"));
 
         let inbound_auth_check = report
             .checks
@@ -285,7 +291,9 @@ mod tests {
             .find(|check| check.name == "inbound_auth")
             .expect("inbound auth check should be present");
         assert_eq!(inbound_auth_check.status, DoctorStatus::Pass);
-        assert!(inbound_auth_check.message.contains("token configuration is present"));
+        assert!(inbound_auth_check
+            .message
+            .contains("token configuration is present"));
         assert!(!inbound_auth_check.message.contains("super-secret-token"));
     }
 
@@ -348,12 +356,18 @@ mod tests {
         };
 
         let rendered = render_report(&report);
-        let config_index = rendered.find("- config:").expect("config line should exist");
-        let assets_index = rendered.find("- assets:").expect("assets line should exist");
+        let config_index = rendered
+            .find("- config:")
+            .expect("config line should exist");
+        let assets_index = rendered
+            .find("- assets:")
+            .expect("assets line should exist");
         let auth_index = rendered
             .find("- inbound_auth:")
             .expect("inbound auth line should exist");
-        let db_index = rendered.find("- database:").expect("database line should exist");
+        let db_index = rendered
+            .find("- database:")
+            .expect("database line should exist");
 
         assert!(rendered.contains("rook doctor: fail"));
         assert!(rendered.contains("summary: total=4, pass=3, warn=0, fail=1"));

--- a/clients/rook/src/idempotency/middleware.rs
+++ b/clients/rook/src/idempotency/middleware.rs
@@ -17,8 +17,8 @@ use crate::gateway::types::{
 };
 use crate::idempotency::canonical::{canonicalize_json_bytes, hash_canonical_bytes};
 use crate::idempotency::is_valid_idempotency_key;
-use crate::observability::Observability;
 use crate::idempotency::types::{ChatIdempotencyScope, ReserveResult, StoredGatewayResponse};
+use crate::observability::Observability;
 use crate::services::idempotency::SharedIdempotencyService;
 use axum::Json;
 

--- a/clients/rook/src/main.rs
+++ b/clients/rook/src/main.rs
@@ -750,7 +750,10 @@ mod tests {
         )
         .await;
 
-        assert!(result.is_err());
+        let error_text = result.expect_err("invalid config should fail").to_string();
+        assert!(error_text.contains("ROOK_PORT"));
+        assert!(error_text.contains("not-a-port"));
+        assert!(error_text.contains("parse") || error_text.contains("port"));
     }
 
     #[tokio::test]
@@ -846,7 +849,10 @@ mod tests {
         )
         .await;
 
-        assert!(result.is_err());
+        let error_text = result.expect_err("invalid config should fail").to_string();
+        assert!(error_text.contains("ROOK_PORT"));
+        assert!(error_text.contains("not-a-port"));
+        assert!(error_text.contains("parse") || error_text.contains("port"));
     }
 
     #[test]

--- a/clients/rook/src/main.rs
+++ b/clients/rook/src/main.rs
@@ -4,7 +4,11 @@
 
 use anyhow::Result;
 use clap::{ArgAction, Parser, Subcommand};
-use rook::config::{discover_default_config_path, RookConfig, RookConfigExportView};
+use rook::config::{
+    discover_default_config_path, load_effective_config, CliRookConfigOverlay, LoadRookConfigInput,
+    PartialChatCompletionsIdempotencyConfig, PartialIdempotencyConfig, PartialInboundAuthConfig,
+    PartialRateLimitConfig, PartialSurfaceRateLimitPolicy, RookConfig, RookConfigExportView,
+};
 use rook::doctor;
 use rook::registry::RookRegistry;
 use rook::server::ServerConfig;
@@ -106,16 +110,24 @@ async fn main() -> Result<()> {
 }
 
 async fn run_cli(cli: Cli) -> Result<()> {
-    run_cli_with_tui_runner_and_output(cli, |registry, dashboard_url| async move {
-        rook::tui::run_standalone(registry, dashboard_url).await
-    }, |line| {
-        println!("{line}");
-        Ok(())
-    })
+    run_cli_with_tui_runner_and_output(
+        cli,
+        |registry, dashboard_url| async move {
+            rook::tui::run_standalone(registry, dashboard_url).await
+        },
+        |line| {
+            println!("{line}");
+            Ok(())
+        },
+    )
     .await
 }
 
-async fn run_cli_with_tui_runner_and_output<F, Fut, O>(cli: Cli, tui_runner: F, output: O) -> Result<()>
+async fn run_cli_with_tui_runner_and_output<F, Fut, O>(
+    cli: Cli,
+    tui_runner: F,
+    output: O,
+) -> Result<()>
 where
     F: Fn(RookRegistry, String) -> Fut,
     Fut: std::future::Future<Output = Result<(), rook::domain::RookError>>,
@@ -152,7 +164,7 @@ where
             chat_rate_limit_window_seconds,
             chat_idempotency_replay_window_seconds,
         } => {
-            let config_path = discover_default_config_path(&env);
+            let config_path = discover_default_config_path(env);
             let config = build_serve_config(
                 ServeOverrides {
                     host,
@@ -170,7 +182,7 @@ where
                     chat_idempotency_replay_window_seconds,
                 },
                 config_path.as_deref(),
-                &env,
+                env,
             )?;
             rook::server::run(config).await?;
         }
@@ -183,7 +195,7 @@ where
             .await?;
         }
         Commands::Doctor => {
-            let config_path = discover_default_config_path(&env);
+            let config_path = discover_default_config_path(env);
             let report = doctor::run_with_config_path(config_path.as_deref(), env).await;
             output(doctor::render_report(&report))?;
             doctor::ensure_success(&report)?;
@@ -191,8 +203,12 @@ where
         Commands::Config {
             action: ConfigCommands::Export,
         } => {
-            let config_path = discover_default_config_path(&env);
-            let config = build_export_config_from_path(config_path.as_deref(), env)?;
+            let config_path = discover_default_config_path(env);
+            let config = build_export_config_from_path(
+                config_path.as_deref(),
+                env,
+                CliRookConfigOverlay::default(),
+            )?;
             output(render_config_export(&config)?)?;
         }
     }
@@ -203,8 +219,13 @@ where
 fn build_export_config_from_path(
     file_path: Option<&std::path::Path>,
     env: &std::collections::HashMap<String, String>,
+    cli: CliRookConfigOverlay,
 ) -> Result<RookConfig> {
-    Ok(RookConfig::from_sources_with_path(file_path, env)?)
+    Ok(load_effective_config(LoadRookConfigInput {
+        file_path,
+        env,
+        cli: Some(cli),
+    })?)
 }
 
 fn build_serve_config(
@@ -212,57 +233,26 @@ fn build_serve_config(
     file_path: Option<&std::path::Path>,
     env: &std::collections::HashMap<String, String>,
 ) -> Result<ServerConfig> {
-    let mut config = RookConfig::from_sources_with_path_unvalidated(file_path, env)?;
+    let config = load_effective_config(LoadRookConfigInput {
+        file_path,
+        env,
+        cli: Some(input.into_cli_overlay()),
+    })?;
 
-    if let Some(host) = input.host {
-        config.host = host;
-    }
-    if let Some(port) = input.port {
-        config.port = port;
-    }
-    if input.enable_tui {
-        config.enable_tui = true;
-    }
-    if let Some(db_path) = input.db_path {
-        config.db_path = db_path.into();
-    }
-    if input.inbound_auth_enabled {
-        config.inbound_auth.enabled = true;
-    }
-    if let Some(inbound_auth_token) = input.inbound_auth_token {
-        config.inbound_auth.bearer_token = Some(inbound_auth_token);
-    }
-    if let Some(max_requests) = input.api_rate_limit_max_requests {
-        config.rate_limits.api.max_requests = max_requests;
-    }
-    if let Some(window_seconds) = input.api_rate_limit_window_seconds {
-        config.rate_limits.api.window_seconds = window_seconds;
-    }
-    if let Some(max_requests) = input.models_rate_limit_max_requests {
-        config.rate_limits.v1_models.max_requests = max_requests;
-    }
-    if let Some(window_seconds) = input.models_rate_limit_window_seconds {
-        config.rate_limits.v1_models.window_seconds = window_seconds;
-    }
-    if let Some(max_requests) = input.chat_rate_limit_max_requests {
-        config.rate_limits.v1_chat_completions.max_requests = max_requests;
-    }
-    if let Some(window_seconds) = input.chat_rate_limit_window_seconds {
-        config.rate_limits.v1_chat_completions.window_seconds = window_seconds;
-    }
-    if let Some(replay_window_seconds) = input.chat_idempotency_replay_window_seconds {
-        config.idempotency.chat_completions.replay_window_seconds = replay_window_seconds;
-    }
-
-    config.validate()?;
     Ok(config.to_server_config())
 }
 
 fn render_config_export(config: &RookConfig) -> Result<String> {
-    Ok(serde_json::to_string_pretty(&RookConfigExportView::from_config(config))?)
+    Ok(serde_json::to_string_pretty(
+        &RookConfigExportView::from_config(config),
+    )?)
 }
 
-async fn launch_tui_with_runner<F, Fut>(db_path: &str, dashboard_url: String, tui_runner: F) -> Result<()>
+async fn launch_tui_with_runner<F, Fut>(
+    db_path: &str,
+    dashboard_url: String,
+    tui_runner: F,
+) -> Result<()>
 where
     F: Fn(RookRegistry, String) -> Fut,
     Fut: std::future::Future<Output = Result<(), rook::domain::RookError>>,
@@ -272,6 +262,7 @@ where
     Ok(())
 }
 
+#[derive(Clone)]
 struct ServeOverrides {
     host: Option<String>,
     port: Option<u16>,
@@ -286,6 +277,72 @@ struct ServeOverrides {
     chat_rate_limit_max_requests: Option<u32>,
     chat_rate_limit_window_seconds: Option<u64>,
     chat_idempotency_replay_window_seconds: Option<u64>,
+}
+
+impl ServeOverrides {
+    fn into_cli_overlay(self) -> CliRookConfigOverlay {
+        CliRookConfigOverlay {
+            host: self.host,
+            port: self.port,
+            enable_tui: self.enable_tui.then_some(true),
+            db_path: self.db_path.map(Into::into),
+            inbound_auth: option_if(
+                self.inbound_auth_enabled || self.inbound_auth_token.is_some(),
+                PartialInboundAuthConfig {
+                    enabled: self.inbound_auth_enabled.then_some(true),
+                    bearer_token: self.inbound_auth_token,
+                },
+            ),
+            transport: None,
+            rate_limits: option_if(
+                self.api_rate_limit_max_requests.is_some()
+                    || self.api_rate_limit_window_seconds.is_some()
+                    || self.models_rate_limit_max_requests.is_some()
+                    || self.models_rate_limit_window_seconds.is_some()
+                    || self.chat_rate_limit_max_requests.is_some()
+                    || self.chat_rate_limit_window_seconds.is_some(),
+                PartialRateLimitConfig {
+                    api: option_if(
+                        self.api_rate_limit_max_requests.is_some()
+                            || self.api_rate_limit_window_seconds.is_some(),
+                        PartialSurfaceRateLimitPolicy {
+                            max_requests: self.api_rate_limit_max_requests,
+                            window_seconds: self.api_rate_limit_window_seconds,
+                        },
+                    ),
+                    v1_models: option_if(
+                        self.models_rate_limit_max_requests.is_some()
+                            || self.models_rate_limit_window_seconds.is_some(),
+                        PartialSurfaceRateLimitPolicy {
+                            max_requests: self.models_rate_limit_max_requests,
+                            window_seconds: self.models_rate_limit_window_seconds,
+                        },
+                    ),
+                    v1_chat_completions: option_if(
+                        self.chat_rate_limit_max_requests.is_some()
+                            || self.chat_rate_limit_window_seconds.is_some(),
+                        PartialSurfaceRateLimitPolicy {
+                            max_requests: self.chat_rate_limit_max_requests,
+                            window_seconds: self.chat_rate_limit_window_seconds,
+                        },
+                    ),
+                },
+            ),
+            idempotency: option_if(
+                self.chat_idempotency_replay_window_seconds.is_some(),
+                PartialIdempotencyConfig {
+                    chat_completions: Some(PartialChatCompletionsIdempotencyConfig {
+                        enabled: None,
+                        replay_window_seconds: self.chat_idempotency_replay_window_seconds,
+                    }),
+                },
+            ),
+        }
+    }
+}
+
+fn option_if<T>(condition: bool, value: T) -> Option<T> {
+    condition.then_some(value)
 }
 
 #[cfg(test)]
@@ -332,8 +389,12 @@ mod tests {
             ("ROOK_DB_PATH".to_string(), "/env/rook.db".to_string()),
         ]);
 
-        let config = build_export_config_from_path(Some(config_path.as_path()), &env)
-            .expect("effective config should assemble from path");
+        let config = build_export_config_from_path(
+            Some(config_path.as_path()),
+            &env,
+            CliRookConfigOverlay::default(),
+        )
+        .expect("effective config should assemble from path");
 
         assert_eq!(config.host, "0.0.0.0");
         assert_eq!(config.port, 7575);
@@ -431,6 +492,86 @@ mod tests {
     }
 
     #[test]
+    fn serve_and_config_export_share_effective_config_resolution() {
+        let temp_dir = tempfile::tempdir().expect("temp dir should exist");
+        let config_path = temp_dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+            host = "1.1.1.1"
+            port = 6464
+            db_path = "/file/rook.db"
+
+            [inbound_auth]
+            enabled = true
+            bearer_token = "file-token"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let env = std::collections::HashMap::from([
+            ("HOME".to_string(), temp_dir.path().display().to_string()),
+            ("ROOK_PORT".to_string(), "7474".to_string()),
+            ("ROOK_DB_PATH".to_string(), "/env/rook.db".to_string()),
+            (
+                "ROOK_INBOUND_AUTH_TOKEN".to_string(),
+                "env-token".to_string(),
+            ),
+        ]);
+        let rook_dir = temp_dir.path().join(".config").join("rook");
+        std::fs::create_dir_all(&rook_dir).expect("rook config dir should exist");
+        std::fs::copy(&config_path, rook_dir.join("config.toml"))
+            .expect("default config path should be populated");
+
+        let serve_overrides = ServeOverrides {
+            host: Some("3.3.3.3".to_string()),
+            port: Some(8484),
+            enable_tui: true,
+            db_path: Some("/cli/rook.db".to_string()),
+            inbound_auth_enabled: true,
+            inbound_auth_token: Some("cli-token".to_string()),
+            api_rate_limit_max_requests: None,
+            api_rate_limit_window_seconds: None,
+            models_rate_limit_max_requests: None,
+            models_rate_limit_window_seconds: None,
+            chat_rate_limit_max_requests: None,
+            chat_rate_limit_window_seconds: None,
+            chat_idempotency_replay_window_seconds: None,
+        };
+
+        let serve = build_serve_config(serve_overrides.clone(), Some(config_path.as_path()), &env)
+            .expect("serve config should resolve");
+
+        let export = build_export_config_from_path(
+            Some(config_path.as_path()),
+            &env,
+            serve_overrides.into_cli_overlay(),
+        )
+        .expect("export config should resolve");
+        let rendered = render_config_export(&export).expect("export should render");
+
+        assert_eq!(serve.host, export.host);
+        assert_eq!(serve.port, export.port);
+        assert_eq!(serve.db_path.as_deref(), Some("/cli/rook.db"));
+        assert_eq!(export.db_path, std::path::PathBuf::from("/cli/rook.db"));
+        assert_eq!(
+            serve.inbound_auth.bearer_token.as_deref(),
+            Some("cli-token")
+        );
+        assert_eq!(
+            export.inbound_auth.bearer_token.as_deref(),
+            Some("cli-token")
+        );
+
+        assert!(rendered.contains("\"host\": \"3.3.3.3\""));
+        assert!(rendered.contains("\"port\": 8484"));
+        assert!(rendered.contains("\"db_path\": \"/cli/rook.db\""));
+        assert!(rendered.contains("\"bearer_token\": \"[redacted]\""));
+        assert!(!rendered.contains("env-token"));
+        assert!(!rendered.contains("cli-token"));
+    }
+
+    #[test]
     fn build_serve_config_uses_cli_over_shared_config_inputs() {
         let env = std::collections::HashMap::from([("ROOK_PORT".to_string(), "7171".to_string())]);
 
@@ -459,11 +600,17 @@ mod tests {
         assert_eq!(config.port, 8181);
         assert!(config.enable_tui);
         assert_eq!(config.db_path.as_deref(), Some("/cli/rook.db"));
-        assert_eq!(config.inbound_auth.bearer_token.as_deref(), Some("cli-token"));
+        assert_eq!(
+            config.inbound_auth.bearer_token.as_deref(),
+            Some("cli-token")
+        );
         assert_eq!(config.rate_limits.api.max_requests, 88);
         assert_eq!(config.rate_limits.v1_models.max_requests, 99);
         assert_eq!(config.rate_limits.v1_chat_completions.max_requests, 77);
-        assert_eq!(config.idempotency.chat_completions.replay_window_seconds, 7200);
+        assert_eq!(
+            config.idempotency.chat_completions.replay_window_seconds,
+            7200
+        );
     }
 
     #[test]
@@ -590,10 +737,8 @@ mod tests {
 
     #[tokio::test]
     async fn doctor_command_returns_error_on_invalid_effective_config() {
-        let env = std::collections::HashMap::from([(
-            "ROOK_PORT".to_string(),
-            "not-a-port".to_string(),
-        )]);
+        let env =
+            std::collections::HashMap::from([("ROOK_PORT".to_string(), "not-a-port".to_string())]);
 
         let result = run_cli_with_tui_runner_output_and_env(
             Cli {
@@ -686,10 +831,8 @@ mod tests {
 
     #[tokio::test]
     async fn config_export_command_returns_error_on_invalid_effective_config() {
-        let env = std::collections::HashMap::from([(
-            "ROOK_PORT".to_string(),
-            "not-a-port".to_string(),
-        )]);
+        let env =
+            std::collections::HashMap::from([("ROOK_PORT".to_string(), "not-a-port".to_string())]);
 
         let result = run_cli_with_tui_runner_output_and_env(
             Cli {
@@ -706,6 +849,36 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[test]
+    fn build_serve_config_returns_error_on_invalid_effective_config() {
+        let env = std::collections::HashMap::from([(
+            "ROOK_INBOUND_AUTH_ENABLED".to_string(),
+            "true".to_string(),
+        )]);
+
+        let result = build_serve_config(
+            ServeOverrides {
+                host: None,
+                port: None,
+                enable_tui: false,
+                db_path: None,
+                inbound_auth_enabled: false,
+                inbound_auth_token: None,
+                api_rate_limit_max_requests: None,
+                api_rate_limit_window_seconds: None,
+                models_rate_limit_max_requests: None,
+                models_rate_limit_window_seconds: None,
+                chat_rate_limit_max_requests: None,
+                chat_rate_limit_window_seconds: None,
+                chat_idempotency_replay_window_seconds: None,
+            },
+            None,
+            &env,
+        );
+
+        assert!(result.is_err());
+    }
+
     #[tokio::test]
     async fn tui_command_launches_real_runner_with_effective_db_path() {
         let captured = Arc::new(Mutex::new(None::<String>));
@@ -718,10 +891,8 @@ mod tests {
             move |_registry, dashboard_url| {
                 let captured_for_runner = captured_for_runner.clone();
                 async move {
-                    *captured_for_runner.lock().unwrap() = Some(format!(
-                        "{}|{}",
-                        DEFAULT_ROOK_DB_PATH, dashboard_url
-                    ));
+                    *captured_for_runner.lock().unwrap() =
+                        Some(format!("{}|{}", DEFAULT_ROOK_DB_PATH, dashboard_url));
                     Ok(())
                 }
             },

--- a/clients/rook/src/observability.rs
+++ b/clients/rook/src/observability.rs
@@ -186,11 +186,7 @@ pub struct UpstreamOutcomesHandle {
 }
 
 impl UpstreamOutcomesHandle {
-    pub fn inc(
-        &self,
-        vendor: impl Into<Cow<'static, str>>,
-        outcome: impl Into<Cow<'static, str>>,
-    ) {
+    pub fn inc(&self, vendor: impl Into<Cow<'static, str>>, outcome: impl Into<Cow<'static, str>>) {
         self.family
             .get_or_create(&UpstreamOutcomeLabels::new(vendor, outcome))
             .inc();
@@ -205,7 +201,11 @@ pub struct HttpRequestLabels {
 }
 
 impl HttpRequestLabels {
-    fn new(surface: impl Into<Cow<'static, str>>, endpoint: impl Into<Cow<'static, str>>, status_class: impl Into<Cow<'static, str>>) -> Self {
+    fn new(
+        surface: impl Into<Cow<'static, str>>,
+        endpoint: impl Into<Cow<'static, str>>,
+        status_class: impl Into<Cow<'static, str>>,
+    ) -> Self {
         Self {
             surface: surface.into(),
             endpoint: endpoint.into(),
@@ -295,28 +295,34 @@ mod tests {
     fn metric_handles_record_samples_into_registry_output() {
         let metrics = Observability::bootstrap();
 
-        metrics.http_requests_total().inc("admin_api", "/api/health", "2xx");
+        metrics
+            .http_requests_total()
+            .inc("admin_api", "/api/health", "2xx");
         metrics
             .rate_limit_rejections_total()
             .inc("admin_api", "/api/health");
         metrics
             .idempotency_outcomes_total()
             .inc("gateway_chat_completions", "replay");
-        metrics
-            .upstream_outcomes_total()
-            .inc("open_ai", "success");
-        metrics
-            .http_request_duration_seconds()
-            .observe("gateway_models", "/v1/models", "2xx", 0.125);
+        metrics.upstream_outcomes_total().inc("open_ai", "success");
+        metrics.http_request_duration_seconds().observe(
+            "gateway_models",
+            "/v1/models",
+            "2xx",
+            0.125,
+        );
 
         let rendered = metrics
             .render_prometheus()
             .expect("metrics should render in prometheus text format");
 
         assert!(rendered.contains("rook_http_requests_total{surface=\"admin_api\",endpoint=\"/api/health\",status_class=\"2xx\"} 1"));
-        assert!(rendered.contains("rook_rate_limit_rejections_total{surface=\"admin_api\",endpoint=\"/api/health\"} 1"));
+        assert!(rendered.contains(
+            "rook_rate_limit_rejections_total{surface=\"admin_api\",endpoint=\"/api/health\"} 1"
+        ));
         assert!(rendered.contains("rook_idempotency_outcomes_total{surface=\"gateway_chat_completions\",outcome=\"replay\"} 1"));
-        assert!(rendered.contains("rook_upstream_outcomes_total{vendor=\"open_ai\",outcome=\"success\"} 1"));
+        assert!(rendered
+            .contains("rook_upstream_outcomes_total{vendor=\"open_ai\",outcome=\"success\"} 1"));
         assert!(rendered.contains("rook_http_request_duration_seconds_sum{surface=\"gateway_models\",endpoint=\"/v1/models\",status_class=\"2xx\"} 0.125"));
         assert!(rendered.contains("rook_http_request_duration_seconds_count{surface=\"gateway_models\",endpoint=\"/v1/models\",status_class=\"2xx\"} 1"));
     }

--- a/clients/rook/src/server/mod.rs
+++ b/clients/rook/src/server/mod.rs
@@ -667,7 +667,11 @@ mod tests {
         let missing_account_path = format!("/api/accounts/{missing_account_id}");
         let missing_response = app
             .clone()
-            .oneshot(Request::get(&missing_account_path).body(Body::empty()).unwrap())
+            .oneshot(
+                Request::get(&missing_account_path)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(missing_response.status(), StatusCode::NOT_FOUND);
@@ -701,7 +705,9 @@ mod tests {
         let (metrics_status, metrics_body) = request_text(app, "/api/metrics").await;
         assert_eq!(metrics_status, StatusCode::OK);
         let text = String::from_utf8(metrics_body).unwrap();
-        assert!(text.contains("rook_rate_limit_rejections_total{surface=\"admin_api\",endpoint=\"/api/accounts\"} 1"));
+        assert!(text.contains(
+            "rook_rate_limit_rejections_total{surface=\"admin_api\",endpoint=\"/api/accounts\"} 1"
+        ));
     }
 
     #[tokio::test]
@@ -1379,12 +1385,14 @@ mod tests {
         let ok_upstream = Router::new().route("/v1/chat/completions", post(ok_handler));
         let ok_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let ok_addr: SocketAddr = ok_listener.local_addr().unwrap();
-        let _ok_server = tokio::spawn(async move { axum::serve(ok_listener, ok_upstream).await.unwrap() });
+        let _ok_server =
+            tokio::spawn(async move { axum::serve(ok_listener, ok_upstream).await.unwrap() });
 
         let error_upstream = Router::new().route("/v1/chat/completions", post(error_handler));
         let error_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let error_addr: SocketAddr = error_listener.local_addr().unwrap();
-        let _error_server = tokio::spawn(async move { axum::serve(error_listener, error_upstream).await.unwrap() });
+        let _error_server =
+            tokio::spawn(async move { axum::serve(error_listener, error_upstream).await.unwrap() });
 
         let registry = RookRegistry::open_in_memory().await.unwrap();
         seed_route(
@@ -1461,9 +1469,14 @@ mod tests {
         let (metrics_status, metrics_body) = request_text(app, "/api/metrics").await;
         assert_eq!(metrics_status, StatusCode::OK);
         let text = String::from_utf8(metrics_body).unwrap();
-        assert!(text.contains("rook_upstream_outcomes_total{vendor=\"open_ai\",outcome=\"success\"} 1"));
-        assert!(text.contains("rook_upstream_outcomes_total{vendor=\"open_ai\",outcome=\"http_error\"} 1"));
-        assert!(text.contains("rook_upstream_outcomes_total{vendor=\"unrouted\",outcome=\"route_rejected\"} 1"));
+        assert!(
+            text.contains("rook_upstream_outcomes_total{vendor=\"open_ai\",outcome=\"success\"} 1")
+        );
+        assert!(text
+            .contains("rook_upstream_outcomes_total{vendor=\"open_ai\",outcome=\"http_error\"} 1"));
+        assert!(text.contains(
+            "rook_upstream_outcomes_total{vendor=\"unrouted\",outcome=\"route_rejected\"} 1"
+        ));
     }
 
     #[tokio::test]
@@ -1581,7 +1594,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(replay.status(), StatusCode::OK);
-        assert_eq!(replay.headers().get("idempotency-replayed").unwrap(), "true");
+        assert_eq!(
+            replay.headers().get("idempotency-replayed").unwrap(),
+            "true"
+        );
 
         let (metrics_status, metrics_body) = request_text(app, "/api/metrics").await;
         assert_eq!(metrics_status, StatusCode::OK);

--- a/clients/rook/src/services/audit.rs
+++ b/clients/rook/src/services/audit.rs
@@ -4,7 +4,10 @@ use crate::domain::RookError;
 use std::future::Future;
 
 pub trait AuditService: Clone + Send + Sync + 'static {
-    fn append(&self, event: StoredAdminAuditEvent) -> impl Future<Output = Result<(), RookError>> + Send;
+    fn append(
+        &self,
+        event: StoredAdminAuditEvent,
+    ) -> impl Future<Output = Result<(), RookError>> + Send;
     fn list_recent(
         &self,
         query: AdminAuditListQuery,
@@ -23,7 +26,10 @@ impl SqliteAuditService {
 }
 
 impl AuditService for SqliteAuditService {
-    fn append(&self, event: StoredAdminAuditEvent) -> impl Future<Output = Result<(), RookError>> + Send {
+    fn append(
+        &self,
+        event: StoredAdminAuditEvent,
+    ) -> impl Future<Output = Result<(), RookError>> + Send {
         let db = self.db.clone();
         async move { db.insert_admin_audit_event(&event).await }
     }

--- a/clients/rook/src/transport/forwarded.rs
+++ b/clients/rook/src/transport/forwarded.rs
@@ -35,7 +35,8 @@ pub fn resolve_forwarded_context(
         };
     }
 
-    let (trusted_any, malformed_any) = apply_allowed_forwarded_headers(headers, config, &mut context);
+    let (trusted_any, malformed_any) =
+        apply_allowed_forwarded_headers(headers, config, &mut context);
     context.trust = resolve_forwarded_trust(trusted_any, malformed_any, forwarded_present);
 
     ForwardedResolution {
@@ -125,6 +126,7 @@ fn apply_allowed_forwarded_headers(
     (trusted_any, malformed_any)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn apply_forwarded_value<T>(
     headers: &HeaderMap,
     enabled: bool,

--- a/clients/rook/src/transport/middleware.rs
+++ b/clients/rook/src/transport/middleware.rs
@@ -121,10 +121,12 @@ pub async fn apply_transport_baseline(
         .observability
         .http_requests_total()
         .inc(surface, route.clone(), status_class);
-    state
-        .observability
-        .http_request_duration_seconds()
-        .observe(surface, route.clone(), status_class, elapsed.as_secs_f64());
+    state.observability.http_request_duration_seconds().observe(
+        surface,
+        route.clone(),
+        status_class,
+        elapsed.as_secs_f64(),
+    );
 
     set_response_request_id_header(
         response.headers_mut(),

--- a/clients/rook/src/transport/rate_limit.rs
+++ b/clients/rook/src/transport/rate_limit.rs
@@ -132,8 +132,7 @@ pub async fn apply_rate_limit(
                 .inc(metrics_surface(state.surface), endpoint.clone());
             match state.surface {
                 RateLimitedSurface::AdminApi => admin_rate_limited_response(retry_after_seconds),
-                RateLimitedSurface::GatewayModels
-                | RateLimitedSurface::GatewayChatCompletions => {
+                RateLimitedSurface::GatewayModels | RateLimitedSurface::GatewayChatCompletions => {
                     gateway_rate_limited_response(retry_after_seconds)
                 }
             }

--- a/clients/rook/src/tui/app.rs
+++ b/clients/rook/src/tui/app.rs
@@ -220,7 +220,11 @@ pub enum ViewData {
     Routes(RoutesViewModel),
 }
 
-fn into_load_state<T>(model: T, is_empty: impl FnOnce(&T) -> bool, empty_message: &str) -> LoadState<T> {
+fn into_load_state<T>(
+    model: T,
+    is_empty: impl FnOnce(&T) -> bool,
+    empty_message: &str,
+) -> LoadState<T> {
     if is_empty(&model) {
         LoadState::Empty {
             message: empty_message.to_string(),

--- a/clients/rook/src/tui/mod.rs
+++ b/clients/rook/src/tui/mod.rs
@@ -19,7 +19,10 @@ use crate::registry::RookRegistry;
 use std::sync::Arc;
 use tokio::sync::Notify;
 
-pub async fn run_standalone(registry: RookRegistry, dashboard_url: String) -> Result<(), RookError> {
+pub async fn run_standalone(
+    registry: RookRegistry,
+    dashboard_url: String,
+) -> Result<(), RookError> {
     runtime::run_standalone(registry, dashboard_url).await
 }
 

--- a/clients/rook/src/tui/query.rs
+++ b/clients/rook/src/tui/query.rs
@@ -2,7 +2,9 @@ use crate::admin::handlers::{build_health_summary_view, list_health_account_view
 use crate::admin::types::{AccountView, HealthAccountView, HealthSummaryView, PoolView, RouteView};
 use crate::domain::RookError;
 use crate::registry::RookRegistry;
-use crate::services::{account::AccountService as _, pool::PoolService as _, route::RouteService as _};
+use crate::services::{
+    account::AccountService as _, pool::PoolService as _, route::RouteService as _,
+};
 use crate::tui::view_models::{
     build_health_view, build_pools_view, build_providers_view, build_status_view, HealthViewModel,
     PoolsViewModel, ProvidersViewModel, RouteRow, RoutesViewModel, StatusViewModel,
@@ -51,8 +53,16 @@ impl TuiQueryService {
             .collect())
     }
 
-    pub async fn load_route(&self, route_id: crate::domain::RouteId) -> Result<Option<RouteView>, RookError> {
-        Ok(self.registry.routes().get(route_id).await.map(RouteView::from))
+    pub async fn load_route(
+        &self,
+        route_id: crate::domain::RouteId,
+    ) -> Result<Option<RouteView>, RookError> {
+        Ok(self
+            .registry
+            .routes()
+            .get(route_id)
+            .await
+            .map(RouteView::from))
     }
 
     pub async fn load_health_rows(&self) -> Result<Vec<HealthAccountView>, RookError> {
@@ -122,14 +132,12 @@ impl TuiQueryService {
                     .get(&route.target_pool_id)
                     .cloned()
                     .unwrap_or_else(|| route.target_pool_id.to_string()),
-                fallback_route_label: route
-                    .fallback_route_id
-                    .map(|fallback_id| {
-                        route_labels
-                            .get(&fallback_id)
-                            .cloned()
-                            .unwrap_or_else(|| fallback_id.to_string())
-                    }),
+                fallback_route_label: route.fallback_route_id.map(|fallback_id| {
+                    route_labels
+                        .get(&fallback_id)
+                        .cloned()
+                        .unwrap_or_else(|| fallback_id.to_string())
+                }),
                 route,
             })
             .collect();
@@ -275,13 +283,20 @@ mod tests {
         let query = TuiQueryService::new(registry);
         let routes = query.load_routes_view().await.unwrap();
         let primary_detail = query.load_route(primary_route_id).await.unwrap().unwrap();
-        let no_fallback_detail = query.load_route(no_fallback_route_id).await.unwrap().unwrap();
+        let no_fallback_detail = query
+            .load_route(no_fallback_route_id)
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(routes.rows.len(), 3);
         assert_eq!(primary_detail.logical_model, "gpt-4o");
         assert_eq!(primary_detail.target_pool_id, primary_pool_id);
         assert_eq!(primary_detail.fallback_route_id, Some(fallback_route_id));
-        assert_eq!(primary_detail.capability_constraints, vec!["chat".to_string()]);
+        assert_eq!(
+            primary_detail.capability_constraints,
+            vec!["chat".to_string()]
+        );
 
         let no_fallback_row = routes
             .rows

--- a/clients/rook/src/tui/render.rs
+++ b/clients/rook/src/tui/render.rs
@@ -231,7 +231,11 @@ fn render_routes(frame: &mut ratatui::Frame, area: Rect, state: &LoadState<Route
             .iter()
             .enumerate()
             .map(|(index, row)| {
-                let prefix = if index == model.selected_index { ">" } else { " " };
+                let prefix = if index == model.selected_index {
+                    ">"
+                } else {
+                    " "
+                };
                 ListItem::new(format!(
                     "{prefix} {} → {}",
                     row.route.logical_model, row.target_pool_label

--- a/clients/rook/src/tui/runtime.rs
+++ b/clients/rook/src/tui/runtime.rs
@@ -45,7 +45,10 @@ impl Drop for TerminalSession {
     }
 }
 
-pub async fn run_standalone(registry: RookRegistry, dashboard_url: String) -> Result<(), RookError> {
+pub async fn run_standalone(
+    registry: RookRegistry,
+    dashboard_url: String,
+) -> Result<(), RookError> {
     run_app(registry, dashboard_url, None).await
 }
 
@@ -79,7 +82,8 @@ async fn run_app(
             break;
         }
 
-        let maybe_event = poll_terminal_event(Duration::from_millis(100)).map_err(RookError::Config)?;
+        let maybe_event =
+            poll_terminal_event(Duration::from_millis(100)).map_err(RookError::Config)?;
         if let Some(event) = maybe_event {
             handle_runtime_event(&mut app, event, &query, &tx, &mut last_refresh);
         }

--- a/clients/rook/src/tui/view_models.rs
+++ b/clients/rook/src/tui/view_models.rs
@@ -231,9 +231,7 @@ pub fn build_health_view(
     HealthViewModel { summary, rows }
 }
 
-pub fn build_routes_view(
-    mut rows: Vec<RouteRow>,
-) -> RoutesViewModel {
+pub fn build_routes_view(mut rows: Vec<RouteRow>) -> RoutesViewModel {
     rows.sort_by(|left, right| left.route.logical_model.cmp(&right.route.logical_model));
     RoutesViewModel {
         rows,
@@ -244,7 +242,9 @@ pub fn build_routes_view(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::admin::types::{AccountView, HealthAccountView, HealthSummaryView, PoolView, RouteView};
+    use crate::admin::types::{
+        AccountView, HealthAccountView, HealthSummaryView, PoolView, RouteView,
+    };
     use crate::domain::{AccountId, PoolId, ProviderVendor, RouteId, SelectionStrategy};
 
     fn account(name: &str, vendor: ProviderVendor, enabled: bool) -> AccountView {
@@ -391,7 +391,10 @@ mod tests {
 
         assert_eq!(routes.rows[0].route.logical_model, "a-model");
         assert_eq!(routes.rows[0].target_pool_label, "pool-a");
-        assert_eq!(routes.rows[0].fallback_route_label.as_deref(), Some("fallback-a"));
+        assert_eq!(
+            routes.rows[0].fallback_route_label.as_deref(),
+            Some("fallback-a")
+        );
         assert_eq!(routes.rows[0].route.fallback_route_id, Some(fallback_id));
         assert_eq!(routes.rows[1].fallback_route_label, None);
         assert_eq!(routes.selected_index, 0);

--- a/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/design.md
+++ b/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/design.md
@@ -1,0 +1,360 @@
+# Design: Add config export and environment-based configuration overrides #678
+
+## Technical Approach
+
+This change formalizes Rook's operator-facing configuration path around a single effective-config assembly pipeline in `clients/rook/src/config/`. The implementation keeps `gateway` as the source-of-truth domain for bind posture and secret-handling requirements, and treats the existing `127.0.0.1:4141` default plus inbound-auth fail-closed behavior as contracts that the new loader must preserve.
+
+The core approach is:
+
+1. keep `RookConfig` as the resolved runtime configuration model
+2. introduce explicit partial overlay types for file, environment, and CLI inputs
+3. assemble effective configuration through one layered pipeline: defaults → file → env → CLI
+4. validate only after the final effective config is assembled
+5. expose a dedicated redacted export view instead of serializing raw config structs
+6. convert the validated `RookConfig` into the existing `ServerConfig` for runtime startup
+
+This keeps `main.rs` thin, avoids duplicating precedence logic across commands, and ensures `rook serve` and `rook config export` report the same effective values under the same inputs.
+
+## Architecture Decisions
+
+### Decision: Keep `RookConfig` as the canonical resolved model
+
+**Choice**: Treat `clients/rook/src/config/mod.rs::RookConfig` as the single canonical effective configuration type, and continue using `ServerConfig` only as the server runtime wiring type.
+
+**Alternatives considered**:
+- Expand `ServerConfig` to absorb file/env/export concerns.
+- Keep separate ad hoc config assembly in `main.rs` for each command.
+
+**Rationale**:
+- The repository already separates operator config concerns from HTTP runtime concerns.
+- `server/mod.rs` already consumes `ServerConfig`; changing that boundary is unnecessary for this scoped change.
+- A distinct `RookConfig` supports export, validation, and precedence testing without coupling those concerns to server startup internals.
+
+### Decision: Represent overlays as partial typed structures, not immediate mutation from every source
+
+**Choice**: Introduce or formalize partial overlay structs for each input layer, with nested partials mirroring the shape of `RookConfig`, then merge them into defaults in precedence order.
+
+**Alternatives considered**:
+- Parse TOML straight into `RookConfig` and mutate it field-by-field for env and CLI.
+- Store env and CLI overrides as untyped string maps until the end.
+
+**Rationale**:
+- The file loader already uses `PartialRookConfig` and nested partial structs; extending that pattern is consistent with current code.
+- Matching partial shapes across file/env/CLI makes precedence behavior explicit and testable.
+- Typed partials allow parse failures to be attributed to exact operator inputs before runtime conversion.
+
+### Decision: Centralize assembly in one config loader API
+
+**Choice**: Add a single assembly entrypoint in `clients/rook/src/config/` that accepts optional file path, environment map, and CLI override struct, returns a resolved `RookConfig`, and performs validation after all overlays are applied.
+
+**Alternatives considered**:
+- Keep `from_sources_with_path_unvalidated` for startup and a different path for export.
+- Validate after each layer.
+
+**Rationale**:
+- The change requires deterministic precedence across `serve` and `config export`.
+- Final-state validation is less error-prone than per-layer validation because partial overlays may be intentionally incomplete.
+- A single assembly API keeps command code in `main.rs` focused on parsing and dispatch.
+
+### Decision: Parse `ROOK_*` overrides into typed partial config rather than mutating live config directly
+
+**Choice**: Move environment interpretation toward an env-overlay builder that maps supported `ROOK_*` names into a partial typed overlay, then merges it like any other layer.
+
+**Alternatives considered**:
+- Keep the existing `apply_env_overrides(&mut self, env)` mutation style as the long-term interface.
+
+**Rationale**:
+- The current mutation path works but hides the overlay boundary and makes CLI/env behavior less symmetric.
+- Converting env into a typed overlay simplifies precedence reasoning, error reporting, and future documentation generation.
+- This also makes it easier to test env parsing in isolation from file loading and validation.
+
+### Decision: Redacted export must be a dedicated view model
+
+**Choice**: Continue using a dedicated export struct family such as `RookConfigExportView`, but shape it as an explicitly operator-safe rendering layer derived from validated effective config.
+
+**Alternatives considered**:
+- Derive `Serialize` on `RookConfig` and rely on field-level redaction hacks.
+- Print debug output with custom `Debug` impls.
+
+**Rationale**:
+- The gateway spec requires operator-visible secret protection.
+- Existing code already uses dedicated export structs and redaction helpers; this is the safest and least disruptive pattern.
+- A dedicated export view prevents future secret-bearing fields from being leaked through accidental generic serialization.
+
+### Decision: CLI flags remain the highest-precedence additive overlay
+
+**Choice**: Keep CLI flags as the final overlay layer, represented as a partial `ServeOverrides`-like structure that only sets fields explicitly supplied by the operator.
+
+**Alternatives considered**:
+- Give CLI flags defaults at clap parse time and always populate a full config.
+- Let CLI bypass config loading for some fields.
+
+**Rationale**:
+- Explicit CLI precedence is required by the proposal.
+- Boolean flags such as `--tui` and `--inbound-auth-enabled` already behave as additive-only overrides; representing them as partials preserves that intent.
+- Avoiding clap defaults prevents accidental masking of file or environment settings.
+
+## Data Flow
+
+### Effective configuration assembly
+
+```text
+Operator
+  |
+  | rook serve / rook config export
+  v
+main.rs
+  |
+  | parse CLI -> partial CLI overrides
+  v
+config::load_effective_config(...)
+  |
+  +--> Defaults: RookConfig::default()
+  |
+  +--> File overlay: parse TOML into PartialRookConfig
+  |
+  +--> Env overlay: parse ROOK_* into PartialRookConfig-like overlay
+  |
+  +--> CLI overlay: apply explicit command flags only
+  |
+  +--> validate final RookConfig
+  |
+  +--> on serve: to_server_config()
+  |
+  +--> on export: RookConfigExportView::from_config()
+```
+
+### Validation and export flow
+
+```text
+config file/env/CLI inputs
+        |
+        v
+partial overlays
+        |
+        v
+merged RookConfig
+        |
+        +--> validate host/db/auth/transport/rate-limit/idempotency
+        |        |
+        |        +--> invalid => operator-facing RookError::Config
+        |
+        +--> valid =>
+                 |-- serve: ServerConfig
+                 '-- export: redacted JSON view
+```
+
+### Environment parsing shape
+
+The environment parser maps flat `ROOK_*` variables into the nested config model. Representative mappings stay aligned to the current config schema:
+
+- `ROOK_HOST` → `host`
+- `ROOK_PORT` → `port`
+- `ROOK_ENABLE_TUI` → `enable_tui`
+- `ROOK_DB_PATH` → `db_path`
+- `ROOK_INBOUND_AUTH_ENABLED` → `inbound_auth.enabled`
+- `ROOK_INBOUND_AUTH_TOKEN` → `inbound_auth.bearer_token`
+- `ROOK_TRANSPORT_REQUEST_ID_*` → `transport.request_id.*`
+- `ROOK_TRANSPORT_TRUSTED_PROXY_*` → `transport.trusted_proxy.*`
+- `ROOK_API_RATE_LIMIT_*` / `ROOK_V1_MODELS_RATE_LIMIT_*` / `ROOK_V1_CHAT_RATE_LIMIT_*` → `rate_limits.*`
+- `ROOK_CHAT_IDEMPOTENCY_*` → `idempotency.chat_completions.*`
+
+Numeric, boolean, comma-delimited list, and string parsing remain field-specific and fail closed with variable-specific messages.
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `openspec/changes/add-config-export-and-environment-based-configuration-overrides-678/design.md` | Create | Technical design for this OpenSpec change. |
+| `clients/rook/src/config/mod.rs` | Modify | Centralize effective-config assembly, add overlay merge helpers, formalize env parsing, keep validation entrypoint, and refine export view/redaction helpers. |
+| `clients/rook/src/main.rs` | Modify | Replace direct config mutation in command handlers with calls into the shared config assembly API; keep CLI parsing and output behavior only. |
+| `clients/rook/src/server/mod.rs` | Possible narrow touch | Consume unchanged `ServerConfig`; only adjust if conversion or tests need minor updates. No new server behavior is introduced by design. |
+| `clients/rook/src/lib.rs` | Possible narrow touch | Only if new config submodules or re-exports are introduced under `config/`. |
+| `clients/rook/README.md` or equivalent operator docs | Modify | Document precedence, default config path, supported `ROOK_*` names, export safety, and validation behavior. |
+| `clients/rook/src/config/mod.rs` tests | Modify | Add unit coverage for merge order, env parsing, validation failures, and redaction semantics. |
+| `clients/rook/src/main.rs` tests | Modify | Verify CLI integration uses shared precedence and export paths rather than bespoke mutation logic. |
+
+## Interfaces / Contracts
+
+### Effective config assembly API
+
+The implementation should converge on a single entrypoint in `clients/rook/src/config/` with a shape along these lines:
+
+```rust
+pub struct CliRookConfigOverlay {
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub enable_tui: Option<bool>,
+    pub db_path: Option<PathBuf>,
+    pub inbound_auth: Option<PartialInboundAuthConfig>,
+    pub rate_limits: Option<PartialRateLimitConfig>,
+    pub idempotency: Option<PartialIdempotencyConfig>,
+}
+
+pub struct LoadRookConfigInput<'a> {
+    pub file_path: Option<&'a Path>,
+    pub env: &'a HashMap<String, String>,
+    pub cli: Option<CliRookConfigOverlay>,
+}
+
+pub fn load_effective_config(input: LoadRookConfigInput<'_>) -> Result<RookConfig, RookError>;
+```
+
+The exact names may differ, but the contract should be:
+
+- accept all input layers explicitly
+- parse file and env into partial overlays
+- merge in precedence order
+- validate only once on the final resolved config
+- return `RookError::Config` with operator-readable messages on failure
+
+### Partial overlay merge contract
+
+Each overlay type should follow the same semantic rule:
+
+```rust
+trait ApplyOverlay<T> {
+    fn apply_to(self, target: &mut T);
+}
+```
+
+This does not need to be a literal public trait, but the internal contract should remain:
+
+- `None` means "no override at this layer"
+- `Some(value)` means "replace the current resolved value"
+- nested `Some(partial)` means recursively apply only the explicitly set nested fields
+
+That rule is what makes defaults < file < env < CLI deterministic.
+
+### Export contract
+
+`rook config export` should continue to emit a dedicated redacted JSON representation. The export contract for secrets in this change is:
+
+- inbound auth token is never emitted raw
+- when inbound auth is enabled and a token is configured, export shows redacted or presence-only state
+- when inbound auth is enabled but token is blank/missing, export still fails validation rather than printing an invalid success view
+- non-secret scalar fields such as host, port, db path, rate limits, and request-id headers are emitted as effective values
+
+Representative view shape:
+
+```rust
+#[derive(Serialize)]
+pub struct RookConfigExportView {
+    pub host: String,
+    pub port: u16,
+    pub enable_tui: bool,
+    pub db_path: String,
+    pub inbound_auth: InboundAuthExportView,
+    pub transport: TransportExportView,
+    pub rate_limits: RateLimitExportView,
+    pub idempotency: IdempotencyExportView,
+}
+```
+
+### Validation contract
+
+Validation remains anchored in config and must cover the final effective `RookConfig` for both startup and export:
+
+- `host` must not be blank
+- `db_path` must not be blank
+- inbound auth enabled requires a non-blank token
+- request-id headers must be syntactically valid header names
+- trusted proxy enabled requires at least one valid CIDR
+- rate-limit windows and request counts must be greater than zero
+- idempotency replay window must be greater than zero
+
+This preserves existing validation behavior while ensuring invalid file/env/CLI combinations fail before startup or export output.
+
+## Module Impacts
+
+### `clients/rook/src/config/`
+
+This is the main implementation surface.
+
+Planned changes:
+
+- keep `RookConfig` as the effective model
+- retain or refine `PartialRookConfig` and nested partial structs as the merge vocabulary
+- add overlay application helpers to remove repeated field-by-field mutation logic
+- introduce an env-to-partial parser instead of burying env semantics in direct mutation
+- expose one public assembly function for command integration
+- keep `to_server_config()` as the conversion seam into existing runtime wiring
+- preserve and strengthen `RookConfigExportView` as the only export serializer
+
+This module becomes the single source of truth for:
+
+- config discovery
+- file parsing
+- environment parsing
+- precedence
+- validation
+- redacted export rendering
+
+### `clients/rook/src/main.rs`
+
+`main.rs` should stop manually assembling final configs field-by-field after calling an unvalidated loader.
+
+Planned changes:
+
+- keep clap command definitions largely intact for this change
+- translate `serve` flags into a partial CLI overlay
+- call the shared config assembly API for both `Serve` and `Config::Export`
+- convert the resulting `RookConfig` into `ServerConfig` only for `serve`
+- keep JSON formatting for export in the CLI layer, but keep redaction policy in `config/`
+
+This keeps `main.rs` responsible for:
+
+- parsing
+- command dispatch
+- stdout rendering
+- process exit behavior
+
+and removes responsibility for config precedence or validation internals.
+
+### Existing runtime conversion
+
+The change should preserve the current runtime boundary:
+
+```text
+RookConfig --to_server_config()--> ServerConfig --server::run(...)--> HTTP runtime
+```
+
+No new runtime config type is needed beyond possibly cleaner conversion helpers. That keeps the change bounded and avoids incidental churn in `server/mod.rs`.
+
+### Docs and tests
+
+Docs should explain:
+
+- default config path discovery (`XDG_CONFIG_HOME` / `HOME`)
+- exact precedence order
+- supported `ROOK_*` overrides
+- that export is safe for operator inspection because secrets are redacted
+- that invalid effective config fails before startup or export succeeds
+
+Tests should be concentrated in config and CLI integration layers, not server behavior unrelated to config.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|--------------|----------|
+| Unit | Default path discovery | Test `XDG_CONFIG_HOME` and `HOME` resolution cases. |
+| Unit | TOML partial parsing | Parse partial config files with nested sections and unknown-field rejection. |
+| Unit | Overlay merge precedence | Verify defaults < file < env < CLI for shared fields like host, port, db path, inbound auth, and rate limits. |
+| Unit | Env parsing | Verify booleans, numerics, CIDR lists, and variable-specific failures for invalid `ROOK_*` inputs. |
+| Unit | Validation | Verify invalid final combinations fail closed with actionable `RookError::Config` messages. |
+| Unit | Export redaction | Verify raw secrets never appear in `RookConfigExportView` JSON output. |
+| Integration-ish (`main.rs` tests) | `serve` CLI integration | Parse CLI input, assemble effective config with env/file inputs, and confirm CLI has final precedence. |
+| Integration-ish (`main.rs` tests) | `config export` integration | Confirm export uses the same assembly pipeline as serve and prints redacted effective config. |
+| Regression | Gateway bind posture contract | Preserve default `127.0.0.1:4141` and explicit non-loopback override behavior consistent with `openspec/specs/gateway/spec.md`. |
+
+## Migration / Rollout
+
+No migration required.
+
+This change is an in-place refactor and hardening of Rook's configuration path. Existing config files continue to be read from the same discovered location, existing defaults remain in place, and runtime startup still receives a `ServerConfig`. The rollout concern is behavioral consistency: the shared assembly path must match current safe defaults while making precedence and validation explicit.
+
+## Open Questions
+
+- [ ] Should `rook config export` continue returning JSON only, or should the implementation leave room for a future TOML/YAML format flag without changing the internal export view model?
+- [ ] Should the environment parser accept any additional aliases for current variables, or should this change strictly preserve the already-implemented `ROOK_*` names to avoid undocumented compatibility surface?
+- [ ] Should additive-only CLI flags such as `--tui` and `--inbound-auth-enabled` remain one-way overrides in the shared overlay model, or should the model be generalized now to support explicit disable flags later? For this change, the design assumes current one-way behavior is preserved.

--- a/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/proposal.md
+++ b/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/proposal.md
@@ -1,0 +1,64 @@
+# Proposal: Add config export and environment-based configuration overrides #678
+
+## Intent
+
+Rook needs a first-class, inspectable configuration model instead of relying primarily on CLI flags and partial scaffolding. This change establishes a stable operator-facing configuration surface that behaves predictably across local development, containers, and automation while preserving the existing gateway safety posture and secret redaction requirements.
+
+## Scope
+
+### In Scope
+- Introduce a first-class `RookConfig` model for Rook runtime configuration.
+- Implement layered configuration loading with explicit precedence across defaults, config file inputs, `ROOK_*` environment overrides, and CLI flags.
+- Add `rook config export` to print the effective configuration with secret values redacted or reduced to presence-only state.
+- Validate effective configuration at startup and config export time so invalid configuration fails closed with clear operator-facing errors.
+- Document and test precedence, environment override behavior, and redaction semantics.
+- Align the proposal with the `gateway` spec domain as the source of truth for bind posture and operator-visible secret handling.
+
+### Out of Scope
+- Redesigning provider credential storage, encryption, or secret management backends.
+- Expanding gateway/admin API behavior beyond configuration loading, validation, and export surfaces.
+- Introducing a new remote configuration service, hot reload system, or live config mutation workflow.
+- Reworking unrelated CLI commands or changing established gateway semantics outside the configuration path.
+
+## Approach
+
+Define a single `RookConfig` model under `clients/rook/src/config/` and route startup through one layered config loader that derives the effective configuration from defaults, file state, `ROOK_*` environment variables, and explicit CLI flags. The loader will validate the final resolved configuration before server startup or export, emit deterministic precedence behavior, and reuse the `gateway` domain requirements for loopback-first bind defaults, inbound-auth fail-closed behavior, and operator-visible secret redaction.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `clients/rook/src/config/` | Modified | Add the first-class `RookConfig` model, layered loaders, environment override parsing, validation, and redaction/export helpers. |
+| `clients/rook/src/main.rs` | Modified | Route CLI startup and `rook config export` through the shared effective-config loading and validation flow. |
+| `clients/rook/src/...` CLI wiring | Modified | Connect CLI flags to the final precedence layer without bypassing centralized config validation. |
+| `clients/rook/tests/` and/or config-focused test modules | Modified | Add coverage for precedence ordering, `ROOK_*` overrides, invalid config failures, and redacted export output. |
+| Operator docs for Rook configuration | Modified | Document supported config inputs, precedence rules, environment variable naming, and safe export expectations. |
+| `openspec/specs/gateway/spec.md` and related gateway artifacts | Referenced | Treat gateway requirements as the source of truth for bind posture, inbound auth config expectations, and operator-visible secret protection. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Precedence behavior becomes ambiguous across file, env, and CLI inputs | Medium | Centralize resolution in one loader and add explicit precedence tests and operator documentation. |
+| Config export accidentally exposes secrets | Medium | Use redaction/presence-only rendering aligned to gateway secret-handling requirements and verify with tests. |
+| Stricter validation breaks existing startup paths unexpectedly | Medium | Keep validation scoped to clearly invalid states, preserve existing safe defaults, and provide clear actionable error messages. |
+| Bind or inbound-auth behavior drifts from gateway source-of-truth | Low | Treat `openspec/specs/gateway/spec.md` as authoritative for bind defaults and secret-related config behavior. |
+
+## Rollback Plan
+
+Revert the new centralized config loader and `rook config export` command wiring, restoring the prior CLI-driven startup path while preserving any unaffected documentation changes only if they still describe shipped behavior. If rollout reveals regressions, disable the new export path and revert precedence enforcement in `clients/rook/src/config/` and `clients/rook/src/main.rs` together so startup semantics return to the previous implementation as one unit.
+
+## Dependencies
+
+- Existing gateway spec requirements for loopback-first bind posture, inbound auth configuration, and operator-visible secret protection.
+- Current Rook CLI/config scaffolding in `clients/rook/src/config/` and `clients/rook/src/main.rs`.
+- Test coverage updates for config loading, validation, and export behavior.
+
+## Success Criteria
+
+- [ ] `rook config export` outputs the effective configuration without leaking secrets.
+- [ ] A first-class `RookConfig` model defines the resolved runtime configuration for Rook.
+- [ ] `ROOK_*` environment overrides are implemented, documented, and covered by tests.
+- [ ] Invalid configuration fails closed with clear operator-facing validation messages.
+- [ ] Config precedence across defaults, file, environment, and CLI is explicit and verified by tests.
+- [ ] The change preserves gateway source-of-truth requirements for bind posture and secret redaction.

--- a/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/specs/gateway/spec.md
+++ b/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/specs/gateway/spec.md
@@ -1,0 +1,168 @@
+# Delta for gateway
+
+## ADDED Requirements
+
+### Requirement: Shared Effective Rook Configuration Assembly
+
+The system MUST define a first-class `RookConfig` model as the effective runtime configuration for
+Rook within the gateway domain.
+
+The system MUST assemble the effective configuration through one shared resolution path that is used
+by both `serve` and `rook config export`.
+
+That shared resolution path MUST apply configuration sources in this precedence order:
+
+1. built-in defaults
+2. configuration file values
+3. `ROOK_*` environment overrides
+4. CLI flag overrides
+
+The shared resolution path MUST validate the final effective configuration before it is used for
+server startup or config export.
+
+The system MUST NOT allow `serve` and `rook config export` to diverge in effective-value
+resolution, precedence behavior, or validation outcome.
+
+#### Scenario: serve and config export resolve the same effective configuration
+
+- GIVEN the same built-in defaults, config file inputs, `ROOK_*` environment values, and CLI flag
+  values
+- WHEN Rook resolves configuration for `serve`
+- AND Rook resolves configuration for `rook config export`
+- THEN both commands MUST produce the same effective configuration values
+- AND both commands MUST apply the same precedence order
+- AND both commands MUST apply the same validation rules
+
+#### Scenario: CLI overrides all lower-precedence sources
+
+- GIVEN a built-in default bind port
+- AND a config file sets a different bind port
+- AND a `ROOK_*` environment override sets a third bind port
+- AND a CLI flag sets a fourth bind port
+- WHEN Rook resolves the effective configuration
+- THEN the effective bind port MUST be the CLI-provided value
+- AND the result MUST reflect the precedence order defaults < file < environment < CLI
+
+#### Scenario: environment overrides file values when CLI does not override them
+
+- GIVEN a config file sets a database path
+- AND a `ROOK_*` environment override sets a different database path
+- AND no CLI flag overrides the database path
+- WHEN Rook resolves the effective configuration
+- THEN the effective database path MUST be the environment-provided value
+
+### Requirement: `ROOK_*` Environment Override Contract
+
+The system MUST support operator-facing configuration overrides through documented `ROOK_*`
+environment variables.
+
+Each supported `ROOK_*` environment variable MUST map deterministically onto the corresponding
+`RookConfig` field or sub-field it overrides.
+
+Environment override behavior MUST be documented for operators, including the variable naming
+scheme and its position in the precedence order.
+
+Verification for this change MUST include automated coverage that demonstrates supported
+`ROOK_*` overrides affect the effective configuration as documented.
+
+#### Scenario: documented environment override is applied to effective configuration
+
+- GIVEN a supported `ROOK_*` environment variable is documented for a specific configuration field
+- AND the config file provides a different value for that field
+- WHEN Rook resolves the effective configuration
+- THEN the effective configuration MUST use the environment-provided value for that field
+
+#### Scenario: unsupported environment variable does not create ambiguous configuration
+
+- GIVEN an environment variable outside the documented supported `ROOK_*` override contract
+- WHEN Rook resolves the effective configuration
+- THEN the system MUST NOT treat that variable as a valid override for an unrelated config field
+- AND operator-facing documentation MUST remain the source of truth for supported overrides
+
+### Requirement: Redacted Effective Config Export
+
+The system MUST provide `rook config export` as an operator-visible command that outputs the
+validated effective configuration.
+
+`rook config export` MUST render the effective configuration derived from the same shared assembly
+path used by `serve`.
+
+Config export MUST protect secret-bearing values using redacted or presence-only semantics.
+
+Config export MUST NOT expose raw inbound bearer tokens, provider API keys, authorization header
+values, cookies, or equivalent secret-bearing material.
+
+When config export needs to communicate secret state, it MUST report only configured, enabled,
+present, absent, or an equivalent redacted state rather than the raw secret value.
+
+#### Scenario: config export shows effective non-secret values and redacts secrets
+
+- GIVEN effective configuration contains non-secret runtime settings and one or more configured
+  secret-bearing values
+- WHEN an operator runs `rook config export`
+- THEN the output MUST include the effective non-secret values
+- AND the output MUST represent secret-bearing fields only with redacted or presence-only state
+- AND the output MUST NOT reveal the raw secret values
+
+#### Scenario: config export preserves gateway bind posture reporting without leaking secrets
+
+- GIVEN the effective configuration resolves the gateway bind host and port
+- AND inbound auth or provider credentials are also configured
+- WHEN an operator runs `rook config export`
+- THEN the output MUST report the effective bind target consistently with the gateway domain
+- AND the output MUST continue to redact secret-bearing fields
+
+### Requirement: Invalid Configuration Fails Closed With Operator-Facing Messages
+
+The system MUST fail closed when the effective configuration is invalid after applying defaults,
+file inputs, environment overrides, and CLI overrides.
+
+Validation failure MUST prevent server startup and MUST prevent successful config export.
+
+Validation failure output MUST be operator-facing and clear enough to identify the invalid
+configuration area and the reason the configuration cannot be used.
+
+The system MUST NOT continue with partially applied or partially validated configuration.
+
+#### Scenario: invalid effective configuration blocks startup
+
+- GIVEN effective configuration inputs resolve to an invalid state required for gateway startup
+- WHEN Rook loads configuration for `serve`
+- THEN configuration validation MUST fail before the server starts
+- AND the command MUST return a non-success result
+- AND the operator-facing error MUST identify the invalid configuration area
+
+#### Scenario: invalid effective configuration blocks config export
+
+- GIVEN effective configuration inputs resolve to an invalid state
+- WHEN an operator runs `rook config export`
+- THEN configuration validation MUST fail before export output is produced as a successful result
+- AND the command MUST return a non-success result
+- AND the operator-facing error MUST clearly explain why the configuration is invalid
+
+### Requirement: Explicit Precedence Verification and Documentation
+
+The system MUST make configuration precedence explicit in operator-facing documentation for this
+change.
+
+The documented precedence order MUST be defaults < file < environment < CLI.
+
+Verification for this change MUST include automated tests that assert precedence behavior across at
+least defaults, file inputs, `ROOK_*` environment overrides, and CLI flags.
+
+Verification for this change MUST include coverage that confirms config export redaction behavior
+and invalid-configuration fail-closed behavior.
+
+#### Scenario: precedence documentation matches implemented behavior
+
+- GIVEN operator-facing documentation for Rook configuration inputs
+- WHEN the documentation describes configuration precedence
+- THEN it MUST state the order defaults < file < environment < CLI
+- AND that documented order MUST match the behavior verified by automated tests
+
+#### Scenario: automated verification catches precedence regressions
+
+- GIVEN automated tests for layered configuration resolution
+- WHEN a lower-precedence source would incorrectly override a higher-precedence source
+- THEN the relevant precedence verification MUST fail
+- AND the failure MUST identify that implemented precedence drifted from the documented contract

--- a/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/state.yaml
+++ b/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/state.yaml
@@ -1,0 +1,11 @@
+change: add-config-export-and-environment-based-configuration-overrides-678
+current_phase: verify
+completed:
+  - propose
+  - spec
+  - design
+  - tasks
+  - apply
+  - verify
+next: archive
+updated: 2026-04-27T16:36:53Z

--- a/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/tasks.md
+++ b/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Add config export and environment-based configuration overrides #678
+
+## Phase 1: Foundation and shared config assembly
+
+- [x] 1.1 In `clients/rook/src/config/mod.rs`, formalize `RookConfig` as the canonical effective model and align `PartialRookConfig`/nested partials so file, env, and CLI overlays share the same shape.
+- [x] 1.2 RED: add config-module tests in `clients/rook/src/config/mod.rs` covering defaults < file < env < CLI precedence for host, port, db path, inbound auth, and one nested rate-limit field.
+- [x] 1.3 In `clients/rook/src/config/mod.rs`, implement a single `load_effective_config(...)` entrypoint that reads defaults, parses file overlay, applies env overlay, applies CLI overlay, and validates only the final resolved config.
+- [x] 1.4 REFACTOR: remove or narrow old ad hoc config-loading/mutation paths in `clients/rook/src/config/mod.rs` so `serve` and export cannot bypass shared assembly.
+
+## Phase 2: Environment overrides and validation
+
+- [x] 2.1 RED: add unit tests in `clients/rook/src/config/mod.rs` for supported `ROOK_*` mappings, including booleans, numerics, CIDR lists, and unsupported variables being ignored.
+- [x] 2.2 In `clients/rook/src/config/mod.rs`, implement an env-to-partial parser for documented overrides such as `ROOK_HOST`, `ROOK_PORT`, `ROOK_ENABLE_TUI`, `ROOK_DB_PATH`, inbound auth, transport, rate-limit, and idempotency fields.
+- [x] 2.3 In `clients/rook/src/config/mod.rs`, make env parse failures return variable-specific `RookError::Config` messages and keep overlay semantics deterministic (`None` = no override, `Some` = replace).
+- [x] 2.4 RED/GREEN: add and implement final-config validation tests in `clients/rook/src/config/mod.rs` for blank host/db path, enabled inbound auth without token, invalid header names, missing trusted proxy CIDRs, and zero-valued limits/windows.
+
+## Phase 3: CLI integration and safe config export
+
+- [x] 3.1 RED: add `clients/rook/src/main.rs` tests proving `serve` and `rook config export` resolve the same effective values from identical file/env/CLI inputs.
+- [x] 3.2 In `clients/rook/src/main.rs`, translate command flags into a typed CLI overlay and route both `Serve` and `Config::Export` through `config::load_effective_config(...)` before runtime conversion or printing.
+- [x] 3.3 RED: add export tests in `clients/rook/src/config/mod.rs` and/or `clients/rook/src/main.rs` asserting raw tokens, API keys, auth headers, and cookies never appear in export output.
+- [x] 3.4 In `clients/rook/src/config/mod.rs`, finalize `RookConfigExportView` redaction/presence-only rendering for secret-bearing fields while preserving effective non-secret values such as bind target and db path.
+
+## Phase 4: Documentation and automated verification
+
+- [x] 4.1 Update `clients/rook/README.md` or the operator-facing Rook config doc to document default config discovery, supported `ROOK_*` names, precedence order, validation failures, and redacted export behavior.
+- [x] 4.2 Add or update automated tests under `clients/rook/src/config/mod.rs` and `clients/rook/src/main.rs` to cover gateway default bind posture (`127.0.0.1:4141`), explicit non-loopback overrides, invalid-config fail-closed behavior, and documented precedence regression cases.

--- a/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/verify-report.md
+++ b/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/verify-report.md
@@ -1,0 +1,102 @@
+## Verification Report
+
+**Change**: add-config-export-and-environment-based-configuration-overrides-678
+**Version**: N/A
+
+---
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 14 |
+| Tasks complete | 14 |
+| Tasks incomplete | 0 |
+
+All tasks in `openspec/changes/add-config-export-and-environment-based-configuration-overrides-678/tasks.md` are marked complete.
+
+---
+
+### Build & Tests Execution
+
+**Build / static verification**: ✅ Passed
+
+Commands executed in `clients/rook` (scoped to the owning workspace per `openspec/config.yaml`):
+
+- `cargo fmt --all -- --check` → ✅ Passed
+- `cargo clippy --all-targets -- -D warnings` → ✅ Passed
+- `cargo test` → ✅ Passed
+
+Observed command evidence:
+- `cargo clippy --all-targets -- -D warnings` finished successfully in the workspace after the follow-up fixes.
+- `cargo test` completed successfully after recompiling `rook v3.6.2`.
+- No coverage threshold is configured in `openspec/config.yaml`.
+
+**Coverage**: ➖ Not configured
+
+`openspec/config.yaml` does not define `rules.verify.coverage_threshold`.
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test / Evidence | Result |
+|-------------|----------|-----------------|--------|
+| Shared Effective Rook Configuration Assembly | serve and config export resolve the same effective configuration | `clients/rook/src/main.rs > serve_and_config_export_share_effective_config_resolution` | ✅ COMPLIANT |
+| Shared Effective Rook Configuration Assembly | CLI overrides all lower-precedence sources | `clients/rook/src/config/mod.rs > load_effective_config_applies_defaults_then_file_then_env_then_cli`; `clients/rook/src/main.rs > build_serve_config_uses_cli_over_shared_config_inputs` | ✅ COMPLIANT |
+| Shared Effective Rook Configuration Assembly | environment overrides file values when CLI does not override them | `clients/rook/src/main.rs > build_export_config_from_path_uses_file_then_env_precedence`; `clients/rook/src/main.rs > build_serve_config_preserves_file_and_env_when_cli_omits_flags` | ✅ COMPLIANT |
+| `ROOK_*` Environment Override Contract | documented environment override is applied to effective configuration | `clients/rook/src/config/mod.rs > parse_env_overlay_maps_supported_rook_variables_and_ignores_unknown_ones`; `clients/rook/src/main.rs > build_export_config_from_path_uses_file_then_env_precedence` | ✅ COMPLIANT |
+| `ROOK_*` Environment Override Contract | unsupported environment variable does not create ambiguous configuration | `clients/rook/src/config/mod.rs > parse_env_overlay_maps_supported_rook_variables_and_ignores_unknown_ones` | ✅ COMPLIANT |
+| Redacted Effective Config Export | config export shows effective non-secret values and redacts secrets | `clients/rook/src/main.rs > render_config_export_outputs_redacted_json`; `clients/rook/src/config/mod.rs > rook_config_export_view_redacts_inbound_auth_token`; `clients/rook/src/config/mod.rs > rook_config_export_view_never_serializes_secret_like_literals` | ✅ COMPLIANT |
+| Redacted Effective Config Export | config export preserves gateway bind posture reporting without leaking secrets | `clients/rook/src/main.rs > serve_and_config_export_share_effective_config_resolution`; `clients/rook/src/main.rs > render_config_export_outputs_redacted_json`; `clients/rook/src/main.rs > serve_cli_defaults_to_loopback_first_bind_posture` | ✅ COMPLIANT |
+| Invalid Configuration Fails Closed With Operator-Facing Messages | invalid effective configuration blocks startup | `clients/rook/src/main.rs > build_serve_config_rejects_invalid_effective_configuration`; `clients/rook/src/config/mod.rs > rook_config_validate_reuses_subconfig_validation` | ✅ COMPLIANT |
+| Invalid Configuration Fails Closed With Operator-Facing Messages | invalid effective configuration blocks config export | `clients/rook/src/main.rs > config_export_command_returns_error_on_invalid_effective_config` | ✅ COMPLIANT |
+| Explicit Precedence Verification and Documentation | precedence documentation matches implemented behavior | `clients/rook/README.md`; `clients/rook/src/config/mod.rs > load_effective_config_applies_defaults_then_file_then_env_then_cli` | ✅ COMPLIANT |
+| Explicit Precedence Verification and Documentation | automated verification catches precedence regressions | `clients/rook/src/config/mod.rs > load_effective_config_applies_defaults_then_file_then_env_then_cli`; `clients/rook/src/main.rs > build_serve_config_from_path_uses_file_env_then_cli_precedence`; `clients/rook/src/main.rs > serve_and_config_export_share_effective_config_resolution` | ✅ COMPLIANT |
+
+**Compliance summary**: 11/11 checked scenarios compliant.
+
+---
+
+### Correctness (Static — Structural Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Shared Effective Rook Configuration Assembly | ✅ Implemented | `load_effective_config(...)` centralizes defaults → file → env → CLI and is used by both `serve` and `rook config export`. Export now accepts a CLI overlay parameter and the parity test asserts equal effective results. |
+| `ROOK_*` Environment Override Contract | ✅ Implemented | `parse_env_overlay(...)` deterministically maps documented `ROOK_*` names into typed partial overlays and ignores unsupported variables. README documents supported names and precedence. |
+| Redacted Effective Config Export | ✅ Implemented | `RookConfigExportView::from_config(...)` emits non-secret fields and redacts inbound auth token state while preserving operator-visible effective settings such as bind host/port and db path. |
+| Invalid Configuration Fails Closed With Operator-Facing Messages | ✅ Implemented | `load_effective_config(...)` validates final resolved config, and both `build_serve_config(...)` and `build_export_config_from_path(...)` rely on that shared validated result. |
+| Explicit Precedence Verification and Documentation | ✅ Implemented | README documents defaults < file < env < CLI and automated tests cover precedence behavior for shared config loading. |
+
+---
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Keep `RookConfig` as the canonical resolved model | ✅ Yes | `RookConfig` remains the resolved config model and converts to `ServerConfig` only at the runtime startup boundary. |
+| Represent overlays as partial typed structures | ✅ Yes | File/env/CLI all use partial typed overlays (`PartialRookConfig`, nested partials, `CliRookConfigOverlay`). |
+| Centralize assembly in one config loader API | ✅ Yes | `load_effective_config(...)` is the shared assembly entrypoint used by both serve and export. |
+| Parse `ROOK_*` into typed partial config | ✅ Yes | `parse_env_overlay(...)` builds typed nested overlays and returns variable-specific parse errors. |
+| Redacted export must be a dedicated view model | ✅ Yes | `RookConfigExportView` and nested export views remain the export boundary. |
+| CLI flags remain highest-precedence additive overlay | ✅ Yes | Serve uses CLI as final overlay, and export now exercises the same CLI overlay contract in the shared-resolution test path. |
+| Remove/narrow bypass paths | ⚠️ Partial | `RookConfig::from_sources_with_path_unvalidated(...)` still exists publicly. It is not used by serve/export, so the core behavior is compliant, but the bypass helper remains available. |
+| File changes match design table | ✅ Yes | The key files (`clients/rook/src/config/mod.rs`, `clients/rook/src/main.rs`, `clients/rook/README.md`) were updated consistently with the design. |
+
+---
+
+### Issues Found
+
+**CRITICAL**
+- None.
+
+**WARNING**
+- `RookConfig::from_sources_with_path_unvalidated(...)` remains public in `clients/rook/src/config/mod.rs`. This does not break the verified behavior because serve/export do not use it, but it leaves a future bypass path that is broader than the design intent to narrow ad hoc loaders.
+
+**SUGGESTION**
+- Consider removing or restricting `from_sources_with_path_unvalidated(...)` if it is no longer needed outside tests or transitional compatibility code.
+- Consider removing stale top-of-file `FIXME` comments in `clients/rook/src/config/mod.rs` if they still describe already-implemented work.
+
+---
+
+### Verdict
+PASS
+
+The change now satisfies the checked proposal/spec/design/tasks artifacts for the `gateway` domain slice, and the scoped verification commands (`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`) all pass in `clients/rook`.

--- a/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/verify-report.md
+++ b/openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/verify-report.md
@@ -1,4 +1,4 @@
-## Verification Report
+# Verification Report
 
 **Change**: add-config-export-and-environment-based-configuration-overrides-678
 **Version**: N/A
@@ -6,13 +6,14 @@
 ---
 
 ### Completeness
+
 | Metric | Value |
 |--------|-------|
 | Tasks total | 14 |
 | Tasks complete | 14 |
 | Tasks incomplete | 0 |
 
-All tasks in `openspec/changes/add-config-export-and-environment-based-configuration-overrides-678/tasks.md` are marked complete.
+All tasks in `openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/tasks.md` are marked complete.
 
 ---
 

--- a/openspec/specs/gateway/spec.md
+++ b/openspec/specs/gateway/spec.md
@@ -2951,6 +2951,181 @@ Suggested error codes include:
 
 ---
 
+### Requirement: Shared Effective Rook Configuration Assembly
+
+The system MUST define a first-class `RookConfig` model as the effective runtime configuration for
+Rook within the gateway domain.
+
+The system MUST assemble the effective configuration through one shared resolution path that is used
+by both `serve` and `rook config export`.
+
+That shared resolution path MUST apply configuration sources in this precedence order:
+
+1. built-in defaults
+2. configuration file values
+3. `ROOK_*` environment overrides
+4. CLI flag overrides
+
+The shared resolution path MUST validate the final effective configuration before it is used for
+server startup or config export.
+
+The system MUST NOT allow `serve` and `rook config export` to diverge in effective-value
+resolution, precedence behavior, or validation outcome.
+
+#### Scenario: serve and config export resolve the same effective configuration
+
+- GIVEN the same built-in defaults, config file inputs, `ROOK_*` environment values, and CLI flag
+  values
+- WHEN Rook resolves configuration for `serve`
+- AND Rook resolves configuration for `rook config export`
+- THEN both commands MUST produce the same effective configuration values
+- AND both commands MUST apply the same precedence order
+- AND both commands MUST apply the same validation rules
+
+#### Scenario: CLI overrides all lower-precedence sources
+
+- GIVEN a built-in default bind port
+- AND a config file sets a different bind port
+- AND a `ROOK_*` environment override sets a third bind port
+- AND a CLI flag sets a fourth bind port
+- WHEN Rook resolves the effective configuration
+- THEN the effective bind port MUST be the CLI-provided value
+- AND the result MUST reflect the precedence order defaults < file < environment < CLI
+
+#### Scenario: environment overrides file values when CLI does not override them
+
+- GIVEN a config file sets a database path
+- AND a `ROOK_*` environment override sets a different database path
+- AND no CLI flag overrides the database path
+- WHEN Rook resolves the effective configuration
+- THEN the effective database path MUST be the environment-provided value
+
+---
+
+### Requirement: `ROOK_*` Environment Override Contract
+
+The system MUST support operator-facing configuration overrides through documented `ROOK_*`
+environment variables.
+
+Each supported `ROOK_*` environment variable MUST map deterministically onto the corresponding
+`RookConfig` field or sub-field it overrides.
+
+Environment override behavior MUST be documented for operators, including the variable naming
+scheme and its position in the precedence order.
+
+Verification for this change MUST include automated coverage that demonstrates supported
+`ROOK_*` overrides affect the effective configuration as documented.
+
+#### Scenario: documented environment override is applied to effective configuration
+
+- GIVEN a supported `ROOK_*` environment variable is documented for a specific configuration field
+- AND the config file provides a different value for that field
+- WHEN Rook resolves the effective configuration
+- THEN the effective configuration MUST use the environment-provided value for that field
+
+#### Scenario: unsupported environment variable does not create ambiguous configuration
+
+- GIVEN an environment variable outside the documented supported `ROOK_*` override contract
+- WHEN Rook resolves the effective configuration
+- THEN the system MUST NOT treat that variable as a valid override for an unrelated config field
+- AND operator-facing documentation MUST remain the source of truth for supported overrides
+
+---
+
+### Requirement: Redacted Effective Config Export
+
+The system MUST provide `rook config export` as an operator-visible command that outputs the
+validated effective configuration.
+
+`rook config export` MUST render the effective configuration derived from the same shared assembly
+path used by `serve`.
+
+Config export MUST protect secret-bearing values using redacted or presence-only semantics.
+
+Config export MUST NOT expose raw inbound bearer tokens, provider API keys, authorization header
+values, cookies, or equivalent secret-bearing material.
+
+When config export needs to communicate secret state, it MUST report only configured, enabled,
+present, absent, or an equivalent redacted state rather than the raw secret value.
+
+#### Scenario: config export shows effective non-secret values and redacts secrets
+
+- GIVEN effective configuration contains non-secret runtime settings and one or more configured
+  secret-bearing values
+- WHEN an operator runs `rook config export`
+- THEN the output MUST include the effective non-secret values
+- AND the output MUST represent secret-bearing fields only with redacted or presence-only state
+- AND the output MUST NOT reveal the raw secret values
+
+#### Scenario: config export preserves gateway bind posture reporting without leaking secrets
+
+- GIVEN the effective configuration resolves the gateway bind host and port
+- AND inbound auth or provider credentials are also configured
+- WHEN an operator runs `rook config export`
+- THEN the output MUST report the effective bind target consistently with the gateway domain
+- AND the output MUST continue to redact secret-bearing fields
+
+---
+
+### Requirement: Invalid Configuration Fails Closed With Operator-Facing Messages
+
+The system MUST fail closed when the effective configuration is invalid after applying defaults,
+file inputs, environment overrides, and CLI overrides.
+
+Validation failure MUST prevent server startup and MUST prevent successful config export.
+
+Validation failure output MUST be operator-facing and clear enough to identify the invalid
+configuration area and the reason the configuration cannot be used.
+
+The system MUST NOT continue with partially applied or partially validated configuration.
+
+#### Scenario: invalid effective configuration blocks startup
+
+- GIVEN effective configuration inputs resolve to an invalid state required for gateway startup
+- WHEN Rook loads configuration for `serve`
+- THEN configuration validation MUST fail before the server starts
+- AND the command MUST return a non-success result
+- AND the operator-facing error MUST identify the invalid configuration area
+
+#### Scenario: invalid effective configuration blocks config export
+
+- GIVEN effective configuration inputs resolve to an invalid state
+- WHEN an operator runs `rook config export`
+- THEN configuration validation MUST fail before export output is produced as a successful result
+- AND the command MUST return a non-success result
+- AND the operator-facing error MUST clearly explain why the configuration is invalid
+
+---
+
+### Requirement: Explicit Precedence Verification and Documentation
+
+The system MUST make configuration precedence explicit in operator-facing documentation for this
+change.
+
+The documented precedence order MUST be defaults < file < environment < CLI.
+
+Verification for this change MUST include automated tests that assert precedence behavior across at
+least defaults, file inputs, `ROOK_*` environment overrides, and CLI flags.
+
+Verification for this change MUST include coverage that confirms config export redaction behavior
+and invalid-configuration fail-closed behavior.
+
+#### Scenario: precedence documentation matches implemented behavior
+
+- GIVEN operator-facing documentation for Rook configuration inputs
+- WHEN the documentation describes configuration precedence
+- THEN it MUST state the order defaults < file < environment < CLI
+- AND that documented order MUST match the behavior verified by automated tests
+
+#### Scenario: automated verification catches precedence regressions
+
+- GIVEN automated tests for layered configuration resolution
+- WHEN a lower-precedence source would incorrectly override a higher-precedence source
+- THEN the relevant precedence verification MUST fail
+- AND the failure MUST identify that implemented precedence drifted from the documented contract
+
+---
+
 ## Non-functional Requirements
 
 ### NFR-1: Response Time


### PR DESCRIPTION
## Related Issues

Closes #678

---

## Summary

This PR introduces a first-class Rook configuration pipeline with explicit precedence across defaults, config file values, `ROOK_*` environment overrides, and CLI overrides.

It also implements `rook config export`, validates effective configuration before use, redacts secret-bearing fields from operator-visible output, and aligns the shared config path used by `serve`, `doctor`, and export-related flows. The accompanying OpenSpec gateway source-of-truth has been synced and the completed change artifacts have been archived.

---

## Tested Information

Verified in `clients/rook` with:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

Additional verification covered:

- precedence resolution across defaults, file, env, and CLI
- redacted config export output
- fail-closed behavior for invalid effective config
- parity between `serve` and `config export` resolution under the same inputs

---

## Documentation Impact

- Docs updated in:
  - `clients/rook/README.md`
  - `openspec/specs/gateway/spec.md`
  - `openspec/changes/archive/2026-04-27-add-config-export-and-environment-based-configuration-overrides-678/`
- No docs update required because:
- I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/CONTRIBUTING.md).
- [x] I have included tests or provided justification for why tests are not needed.
- [x] I have updated documentation or verified no documentation changes were needed.
- [x] I have verified formatting, linting, and tests relevant to this change.
