### PR TITLE
fix(tooling): add local sonar review workflow

### DIFF
--- a/.github/workflows/_build-cerebro-binaries.yml
+++ b/.github/workflows/_build-cerebro-binaries.yml
@@ -68,6 +68,14 @@ jobs:
           toolchain: ${{ steps.rust-channel.outputs.channel }}
           targets: ${{ matrix.target }}
 
+      - name: 🧹 Free Linux runner disk space
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
+          docker system prune -af || true
+          sudo apt-get clean
+          df -h
+
       - name: 🛠 Install native build dependencies
         if: runner.os == 'Linux'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,15 @@ link-check-local: ## Check repository local links with Lychee (offline)
 
 lint-all: lint-kotlin lint-rust lint-android ## Run all linters
 
+sonar: check-tools ## Run local SonarQube analysis (coverage + scan)
+	@echo "🔍 $(BOLD)Running local SonarQube analysis...$(SGR0)"
+	@bash ./scripts/sonar.sh --validate-only
+	@$(GRADLEW) test jvmTest :agent-core-kmp:koverXmlReport :composeApp:koverXmlReport
+	@pnpm --dir clients/web install --frozen-lockfile
+	@pnpm --dir clients/web/apps/dashboard test:coverage
+	@$(MAKE) rust-coverage
+	@bash ./scripts/sonar.sh
+
 # --- TESTING ---
 
 test: ## Run all tests
@@ -314,7 +323,7 @@ rust-coverage: ## Run Rust coverage for agent-runtime
 		exit 1; \
 	}
 	@mkdir -p coverage
-	@cd clients/agent-runtime && cargo llvm-cov --lcov --output-path ../../coverage/agent-runtime-coverage.lcov
+	@cd clients/agent-runtime && cargo llvm-cov --lcov --output-path ../../coverage/agent-runtime-coverage.lcov -- --test-threads=1
 
 test-all: test rust-test web-test-all ## Run all tests (Gradle + Rust + Web)
 
@@ -420,7 +429,7 @@ sync-version: ## Sync VERSION with git tag
         web-install docs-dev docs-build docs-check docs-format \
         dashboard-dev dashboard-build dashboard-check dashboard-test \
         marketing-dev marketing-build marketing-check web-build-all web-clean-all web-test-all web-check-all \
-        format check-format check lint-kotlin lint-rust lint-android lint-all \
+        format check-format check lint-kotlin lint-rust lint-android lint-all sonar \
         test test-app test-core test-verbose test-coverage rust-coverage test-all check-all docs-code \
         deps deps-app deps-analysis deps-update \
         dev-up dev-up-dashboard dev-down dev-shell dev-agent dev-logs dev-status dev-build dev-clean clean-web clean-pnpm \

--- a/Makefile
+++ b/Makefile
@@ -432,7 +432,7 @@ sync-version: ## Sync VERSION with git tag
         dashboard-dev dashboard-build dashboard-check dashboard-test \
         marketing-dev marketing-build marketing-check web-build-all web-clean-all web-test-all web-check-all \
         format check-format check lint-kotlin lint-rust lint-android lint-all sonar \
-        test test-app test-core test-verbose test-coverage rust-coverage test-all check-all docs-code \
+        test test-app test-core test-verbose test-coverage rust-coverage rust-coverage-validate test-all check-all docs-code \
         deps deps-app deps-analysis deps-update \
         dev-up dev-up-dashboard dev-down dev-shell dev-agent dev-logs dev-status dev-build dev-clean clean-web clean-pnpm \
         runtime-up runtime-up-dashboard runtime-down runtime-logs runtime-status \

--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ link-check-local: ## Check repository local links with Lychee (offline)
 
 lint-all: lint-kotlin lint-rust lint-android ## Run all linters
 
-sonar: check-tools ## Run local SonarQube analysis (coverage + scan)
+sonar: check-tools rust-coverage-validate ## Run local SonarQube analysis (coverage + scan)
 	@echo "🔍 $(BOLD)Running local SonarQube analysis...$(SGR0)"
 	@bash ./scripts/sonar.sh --validate-only
 	@$(GRADLEW) test jvmTest :agent-core-kmp:koverXmlReport :composeApp:koverXmlReport
@@ -313,7 +313,7 @@ test-coverage: rust-coverage ## Run coverage reports
 	@echo "📊 Kotlin report: modules/agent-core-kmp/build/reports/kover/html/index.html"
 	@echo "📊 Rust report: coverage/agent-runtime-coverage.lcov"
 
-rust-coverage: ## Run Rust coverage for agent-runtime
+rust-coverage-validate: ## Validate Rust coverage prerequisites for agent-runtime
 	@command -v cargo-llvm-cov >/dev/null 2>&1 || { \
 		echo "cargo-llvm-cov is required. Install with: cargo install cargo-llvm-cov" >&2; \
 		exit 1; \
@@ -322,6 +322,8 @@ rust-coverage: ## Run Rust coverage for agent-runtime
 		echo "llvm-tools-preview (or llvm-tools) is required. Install with: rustup component add llvm-tools-preview" >&2; \
 		exit 1; \
 	}
+
+rust-coverage: rust-coverage-validate ## Run Rust coverage for agent-runtime
 	@mkdir -p coverage
 	@cd clients/agent-runtime && cargo llvm-cov --lcov --output-path ../../coverage/agent-runtime-coverage.lcov -- --test-threads=1
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ make sonar
 ```
 
 Local prerequisites:
+
 - `SONAR_TOKEN` exported in your shell
 - `sonar-scanner` available on `PATH`
 - the standard repo toolchain required by `make check-tools`

--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dallay_corvus&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dallay_corvus)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=dallay_corvus&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=dallay_corvus)
 
+### Local monthly review
+
+Run the recurring Sonar review workflow locally with:
+
+```bash
+make sonar
+```
+
+Local prerequisites:
+- `SONAR_TOKEN` exported in your shell
+- `sonar-scanner` available on `PATH`
+- the standard repo toolchain required by `make check-tools`
+
+`make sonar` generates the same main coverage inputs used by CI before invoking the local scanner. The authoritative quality gate still lives in SonarCloud, but this command makes the monthly review reproducible from a developer workstation.
+
 ## 🛠️ Tech Stack
 
 ![Kotlin](https://img.shields.io/badge/kotlin-%237F52FF.svg?style=for-the-badge&logo=kotlin&logoColor=white)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Local prerequisites:
 
 `make sonar` generates the same main coverage inputs used by CI before invoking the local scanner. As part of that flow it runs the `rust-coverage` target, so missing `cargo-llvm-cov` or `llvm-tools-preview` will cause `make sonar` to exit during preflight. The authoritative quality gate still lives in SonarCloud, but this command makes the monthly review reproducible from a developer workstation.
 
+> Note: la traducción al español de esta sección sigue pendiente para mantener la paridad del README.
+
 ## 🛠️ Tech Stack
 
 ![Kotlin](https://img.shields.io/badge/kotlin-%237F52FF.svg?style=for-the-badge&logo=kotlin&logoColor=white)

--- a/README.md
+++ b/README.md
@@ -60,8 +60,11 @@ Local prerequisites:
 - `SONAR_TOKEN` exported in your shell
 - `sonar-scanner` available on `PATH`
 - the standard repo toolchain required by `make check-tools`
+- the Rust coverage tooling required by `rust-coverage`:
+  - `cargo install cargo-llvm-cov`
+  - `rustup component add llvm-tools-preview`
 
-`make sonar` generates the same main coverage inputs used by CI before invoking the local scanner. The authoritative quality gate still lives in SonarCloud, but this command makes the monthly review reproducible from a developer workstation.
+`make sonar` generates the same main coverage inputs used by CI before invoking the local scanner. As part of that flow it runs the `rust-coverage` target, so missing `cargo-llvm-cov` or `llvm-tools-preview` will cause `make sonar` to exit during preflight. The authoritative quality gate still lives in SonarCloud, but this command makes the monthly review reproducible from a developer workstation.
 
 ## 🛠️ Tech Stack
 

--- a/clients/agent-runtime/src/memory/dream.rs
+++ b/clients/agent-runtime/src/memory/dream.rs
@@ -772,13 +772,14 @@ mod tests {
             record_session_completion(tmp.path(), &format!("sess-{index}")).unwrap();
         }
 
-        let report = match run_if_triggered(tmp.path()).unwrap().unwrap() {
-            report if report.lock_state == DreamLockState::Acquired => report,
-            report if report.lock_state == DreamLockState::Busy => {
-                run_if_triggered(tmp.path()).unwrap().unwrap_or(report)
+        let mut report = run_if_triggered(tmp.path()).unwrap().unwrap();
+        for _ in 0..10 {
+            if report.lock_state != DreamLockState::Busy {
+                break;
             }
-            report => report,
-        };
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            report = run_if_triggered(tmp.path()).unwrap().unwrap_or(report);
+        }
         assert_eq!(report.trigger_reason, DreamTriggerReason::SessionCount);
         assert_eq!(report.lock_state, DreamLockState::Acquired);
         assert_eq!(report.status, DreamRunStatus::Completed);

--- a/clients/agent-runtime/src/memory/dream.rs
+++ b/clients/agent-runtime/src/memory/dream.rs
@@ -772,7 +772,13 @@ mod tests {
             record_session_completion(tmp.path(), &format!("sess-{index}")).unwrap();
         }
 
-        let report = run_if_triggered(tmp.path()).unwrap().unwrap();
+        let report = match run_if_triggered(tmp.path()).unwrap().unwrap() {
+            report if report.lock_state == DreamLockState::Acquired => report,
+            report if report.lock_state == DreamLockState::Busy => {
+                run_if_triggered(tmp.path()).unwrap().unwrap_or(report)
+            }
+            report => report,
+        };
         assert_eq!(report.trigger_reason, DreamTriggerReason::SessionCount);
         assert_eq!(report.lock_state, DreamLockState::Acquired);
         assert_eq!(report.status, DreamRunStatus::Completed);

--- a/clients/web/apps/dashboard/scripts/run-coverage.mjs
+++ b/clients/web/apps/dashboard/scripts/run-coverage.mjs
@@ -39,6 +39,9 @@ const vitestArgs = [
   "--environment",
   "happy-dom",
   "--coverage",
+  "--coverage.reporter=lcov",
+  "--coverage.reporter=html",
+  "--coverage.reporter=text",
   ...specFiles,
 ];
 

--- a/clients/web/apps/dashboard/src/utils/runCoverage.spec.ts
+++ b/clients/web/apps/dashboard/src/utils/runCoverage.spec.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const exitCallbacks: Array<(code: number | null, signal: NodeJS.Signals | null) => void> = [];
+const spawnMock = vi.fn(() => ({
+  on: vi.fn(
+    (event: string, callback: (code: number | null, signal: NodeJS.Signals | null) => void) => {
+      if (event === "exit") {
+        exitCallbacks.push(callback);
+      }
+    }
+  ),
+}));
+const readdirMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  default: {
+    spawn: spawnMock,
+  },
+  spawn: spawnMock,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readdir: readdirMock,
+  },
+  readdir: readdirMock,
+}));
+
+describe("dashboard run-coverage script", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    exitCallbacks.length = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("spawns vitest with deterministic lcov coverage arguments", async () => {
+    readdirMock.mockImplementation(async (dirUrl: URL) => {
+      const href = String(dirUrl);
+      if (href.includes("/src") && !href.includes("/nested")) {
+        return [
+          { name: "zeta.spec.ts", isDirectory: () => false, isFile: () => true },
+          { name: "alpha.spec.ts", isDirectory: () => false, isFile: () => true },
+          { name: "nested", isDirectory: () => true, isFile: () => false },
+        ];
+      }
+
+      if (href.includes("/nested")) {
+        return [
+          { name: "beta.spec.ts", isDirectory: () => false, isFile: () => true },
+          { name: "notes.txt", isDirectory: () => false, isFile: () => true },
+        ];
+      }
+
+      return [];
+    });
+
+    await import("../../scripts/run-coverage.mjs?sorted-specs");
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [command, args, options] = spawnMock.mock.calls[0];
+    expect(command).toBe("pnpm");
+    expect(args.slice(0, 9)).toEqual([
+      "exec",
+      "vitest",
+      "--run",
+      "--environment",
+      "happy-dom",
+      "--coverage",
+      "--coverage.reporter=lcov",
+      "--coverage.reporter=html",
+      "--coverage.reporter=text",
+    ]);
+    expect(args.slice(9)).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/alpha\.spec\.ts$/),
+        expect.stringMatching(/nested\/beta\.spec\.ts$/),
+        expect.stringMatching(/zeta\.spec\.ts$/),
+      ])
+    );
+    expect(args.slice(9)).toHaveLength(3);
+    expect(String(options.cwd)).toContain("dashboard");
+    expect(options.stdio).toBe("inherit");
+  });
+
+  it("exits with code 1 when no spec files are found", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: string | number | null
+    ) => {
+      throw new Error(`process.exit:${code ?? "undefined"}`);
+    }) as never);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    readdirMock.mockResolvedValue([]);
+
+    await expect(import("../../scripts/run-coverage.mjs?no-specs")).rejects.toThrow(
+      "process.exit:1"
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith("No dashboard unit spec files were found under src/.");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("maps child exit outcomes back to the parent process", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation((() => true) as never);
+    readdirMock.mockResolvedValue([
+      { name: "alpha.spec.ts", isDirectory: () => false, isFile: () => true },
+    ]);
+
+    await import("../../scripts/run-coverage.mjs?exit-forwarding");
+
+    expect(exitCallbacks).toHaveLength(1);
+    exitCallbacks[0](null, "SIGTERM");
+    exitCallbacks[0](0, null);
+    exitCallbacks[0](null, null);
+
+    expect(killSpy).toHaveBeenCalledWith(process.pid, "SIGTERM");
+    expect(exitSpy).toHaveBeenNthCalledWith(1, 0);
+    expect(exitSpy).toHaveBeenNthCalledWith(2, 1);
+  });
+});

--- a/clients/web/apps/dashboard/src/utils/runCoverage.spec.ts
+++ b/clients/web/apps/dashboard/src/utils/runCoverage.spec.ts
@@ -74,14 +74,11 @@ describe("dashboard run-coverage script", () => {
       "--coverage.reporter=html",
       "--coverage.reporter=text",
     ]);
-    expect(args.slice(9)).toEqual(
-      expect.arrayContaining([
-        expect.stringMatching(/alpha\.spec\.ts$/),
-        expect.stringMatching(/nested[\\/]beta\.spec\.ts$/),
-        expect.stringMatching(/zeta\.spec\.ts$/),
-      ])
-    );
-    expect(args.slice(9)).toHaveLength(3);
+    expect(args.slice(9)).toEqual([
+      expect.stringMatching(/alpha\.spec\.ts$/),
+      expect.stringMatching(/nested[\\/]beta\.spec\.ts$/),
+      expect.stringMatching(/zeta\.spec\.ts$/),
+    ]);
     expect(String(options.cwd)).toContain("dashboard");
     expect(options.stdio).toBe("inherit");
   });

--- a/clients/web/apps/dashboard/src/utils/runCoverage.spec.ts
+++ b/clients/web/apps/dashboard/src/utils/runCoverage.spec.ts
@@ -62,7 +62,7 @@ describe("dashboard run-coverage script", () => {
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const [command, args, options] = spawnMock.mock.calls[0];
-    expect(command).toBe("pnpm");
+    expect(String(command)).toMatch(/pnpm(\.cmd)?$/);
     expect(args.slice(0, 9)).toEqual([
       "exec",
       "vitest",
@@ -77,7 +77,7 @@ describe("dashboard run-coverage script", () => {
     expect(args.slice(9)).toEqual(
       expect.arrayContaining([
         expect.stringMatching(/alpha\.spec\.ts$/),
-        expect.stringMatching(/nested\/beta\.spec\.ts$/),
+        expect.stringMatching(/nested[\\/]beta\.spec\.ts$/),
         expect.stringMatching(/zeta\.spec\.ts$/),
       ])
     );

--- a/openspec/changes/2026-04-28-monthly-sonar-review-433/design.md
+++ b/openspec/changes/2026-04-28-monthly-sonar-review-433/design.md
@@ -1,0 +1,225 @@
+# Design: Monthly Sonar review workflow and targeted quality remediation #433
+
+## Technical Approach
+
+This change closes the immediate operational gap in the recurring monthly SonarQube review issue by adding a local `make sonar` workflow that mirrors the existing GitHub SonarQube analysis job closely enough for repeatable developer use, then applying a narrow set of locally verifiable quality improvements that strengthen the current failed quality-gate posture without widening into an open-ended repository cleanup.
+
+The implementation stays intentionally scoped:
+
+1. add a `sonar` make target as the documented local entry point for monthly Sonar review;
+2. move scanner invocation and environment validation into a dedicated script so the Makefile remains readable and CI-aligned arguments stay centralized;
+3. reuse the existing coverage-generation paths already encoded in `.github/workflows/sonarqube-analysis.yml` for Kotlin, dashboard web coverage, and Rust coverage;
+4. fail fast with operator-facing messages when required scanner credentials or tools are missing;
+5. fix only small, high-signal quality issues that are locally reproducible or strongly implied by existing checks and the current Sonar status;
+6. document the monthly Sonar workflow where contributors already look for standard development commands.
+
+This design deliberately avoids changing Sonar policy, inventing a second source of truth for analysis arguments, or broadening the scope into unrelated repository-wide smell cleanup. Where touched behavior intersects Rook operator-facing documentation or existing bind-posture wording, the existing `gateway` spec domain remains the source of truth rather than introducing a new domain for operational wording.
+
+## Architecture Decisions
+
+### Decision: Add `make sonar` as the canonical local monthly entry point
+
+**Choice**: Introduce a top-level `sonar` Make target that developers can run locally during the recurring monthly review process.
+
+**Alternatives considered**:
+- Keep Sonar execution GitHub-only and document the workflow manually.
+- Ask contributors to run the scanner with ad hoc shell commands.
+
+**Rationale**:
+- The GitHub issue explicitly calls out `make sonar` as the monthly analysis command.
+- The repository already standardizes cross-platform workflows through `Makefile` targets.
+- A single local entry point improves repeatability and makes monthly maintenance less dependent on workflow-file archaeology.
+
+### Decision: Use a dedicated script for scanner invocation instead of embedding all flags in the Makefile
+
+**Choice**: Add a script such as `scripts/sonar.sh` to validate environment requirements, compute or confirm the project key, and invoke the Sonar scanner with CI-aligned arguments.
+
+**Alternatives considered**:
+- Put the entire scanner command and all `-Dsonar.*` flags directly into `Makefile`.
+- Duplicate the GitHub Actions command block in multiple places.
+
+**Rationale**:
+- The current Sonar command is long and operationally dense.
+- A script is easier to test, easier to keep aligned with CI, and produces clearer fail-fast messages.
+- Centralizing scanner args reduces drift between local execution and `.github/workflows/sonarqube-analysis.yml`.
+
+### Decision: Reuse the existing CI coverage-generation contract
+
+**Choice**: Make the local Sonar workflow generate the same core coverage artifacts the CI analysis job expects: Kotlin Kover XML, dashboard LCOV, and Rust LCOV.
+
+**Alternatives considered**:
+- Run the scanner without local coverage generation.
+- Invent a second lighter-weight local coverage contract.
+
+**Rationale**:
+- The CI workflow already defines the practical analysis inputs that SonarCloud consumes today.
+- Reusing that contract improves parity and makes local failures more actionable.
+- Monthly review should validate the same main evidence sources that feed the hosted analysis.
+
+### Decision: Fail closed when required Sonar credentials or scanner tooling are missing
+
+**Choice**: `make sonar` must return a non-success result with explicit operator-facing guidance if `SONAR_TOKEN`, scanner tooling, or other required prerequisites are unavailable.
+
+**Alternatives considered**:
+- Silently skip the scan when credentials are absent.
+- Allow a partial success that only builds coverage and pretends analysis ran.
+
+**Rationale**:
+- The issue acceptance criteria require that SonarQube analysis completes successfully.
+- Silent skipping would make monthly review unreliable and would hide missing provisioning.
+- Clear failure output makes local setup and CI parity problems immediately visible.
+
+### Decision: Keep remediation narrow and locally verifiable
+
+**Choice**: After the workflow is in place, fix only a bounded set of code-quality issues that can be validated with existing local checks, coverage generation, or directly impacted files.
+
+**Alternatives considered**:
+- Attempt a broad repo-wide code smell cleanup.
+- Limit the change strictly to tooling without any quality remediation.
+
+**Rationale**:
+- The current public Sonar badges show the quality gate is failing even though bugs and vulnerabilities are zero, so operational tooling alone is insufficient.
+- At the same time, the recurring monthly issue is maintenance work, not a mandate for large-scale refactoring.
+- A small, evidence-driven remediation set best matches the issue intent and keeps reviewable scope.
+
+## Data Flow
+
+### Local Sonar workflow
+
+```text
+Developer
+  |
+  | make sonar
+  v
+Makefile target
+  |
+  +--> prerequisite checks / existing toolchain assumptions
+  |
+  +--> Kotlin coverage generation
+  |      - ./gradlew test jvmTest :agent-core-kmp:koverXmlReport :composeApp:koverXmlReport
+  |
+  +--> Dashboard web coverage generation
+  |      - pnpm/vitest lcov in clients/web/apps/dashboard
+  |
+  +--> Rust coverage generation
+  |      - cargo llvm-cov -> coverage/agent-runtime-coverage.lcov
+  |
+  +--> scripts/sonar.sh
+         - validate SONAR_TOKEN / scanner tooling
+         - align scanner args to CI workflow
+         - invoke sonar-scanner / equivalent local scanner entrypoint
+```
+
+### Failure path
+
+```text
+make sonar
+   |
+   +--> missing SONAR_TOKEN
+   |       -> clear operator-facing error
+   |       -> non-zero exit
+   |
+   +--> missing scanner binary or unsupported prerequisite
+   |       -> clear operator-facing error
+   |       -> non-zero exit
+   |
+   +--> coverage generation failure
+           -> upstream task output preserved
+           -> scan not attempted or command exits non-zero
+```
+
+### Monthly review remediation path
+
+```text
+Current Sonar status / local checks
+        |
+        +--> operational gap: no local make target
+        |         -> add make+script workflow
+        |
+        +--> local quality signal
+                  -> run relevant checks/tests/coverage commands
+                  -> identify bounded actionable issues
+                  -> apply narrow fixes
+                  -> re-run touched verification paths
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `openspec/changes/2026-04-28-monthly-sonar-review-433/design.md` | Create | Technical design for the monthly Sonar review workflow and narrow remediation slice. |
+| `Makefile` | Modify | Add `sonar` target and any small supporting help/phony updates needed for the new local entry point. |
+| `scripts/sonar.sh` | Create | Centralize Sonar scanner env validation and CI-aligned scanner invocation. |
+| `.github/workflows/sonarqube-analysis.yml` | Possible narrow touch | Only if needed to reduce argument drift or share a documented contract with the new local script; avoid broad workflow redesign. |
+| `README.md` or another contributor-facing workflow doc | Modify | Document the local monthly Sonar review command and prerequisites. |
+| Quality-affected source/test files | Modify narrowly | Apply bounded fixes for locally verifiable maintainability or coverage-adjacent issues discovered during implementation. |
+
+## Interfaces / Contracts
+
+### `make sonar`
+
+The new top-level contract is:
+
+- `make sonar` is the canonical local entry point for the recurring monthly Sonar review workflow.
+- It must attempt the same main coverage inputs used by the CI Sonar analysis job.
+- It must fail closed when required credentials or scanner prerequisites are absent.
+- It must not silently report success when the scan did not actually run.
+
+### Scanner script contract
+
+The script contract should be conceptually similar to:
+
+```bash
+scripts/sonar.sh
+```
+
+Behavior requirements:
+
+1. require `SONAR_TOKEN`;
+2. require local scanner availability or emit a clear installation message;
+3. compute or validate the project key consistently with CI (`dallay_corvus` / repo-derived key);
+4. invoke the scanner with arguments aligned to `.github/workflows/sonarqube-analysis.yml`;
+5. return non-zero on any validation or scan failure.
+
+The exact implementation language may remain shell-first to match existing repo conventions.
+
+### Documentation contract
+
+Contributor-facing docs must explain:
+
+- that monthly Sonar review now starts with `make sonar`;
+- which prerequisites are required locally;
+- that local review complements, but does not replace, the hosted SonarCloud quality-gate result;
+- where to look if the scan fails during coverage generation versus scanner setup.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Local workflow | `make sonar` wiring | Run the target or its component commands far enough to verify target wiring, prerequisite behavior, and script invocation semantics. |
+| Script validation | Missing credential/tool behavior | Confirm absent `SONAR_TOKEN` or scanner tooling yields clear non-zero failures. |
+| Coverage generation | CI-aligned artifact paths | Verify expected coverage outputs are generated or that failures surface clearly from the existing commands. |
+| Quality remediation | Touched-file regressions | Run the relevant existing checks/tests for files or modules modified during remediation. |
+| Documentation | Discoverability and correctness | Review docs to ensure the monthly workflow and prerequisites match the implemented commands. |
+
+## Migration / Rollout
+
+No data migration is required.
+
+Rollout is low risk if the change preserves these constraints:
+
+- local Sonar execution is additive and does not replace the existing GitHub workflow;
+- the new script reuses the current CI scanner contract rather than inventing incompatible flags;
+- quality remediation remains scoped to small, locally verified improvements;
+- documentation clearly distinguishes local execution from the authoritative hosted quality-gate result.
+
+If full local scanner parity proves blocked by missing local tooling in some environments, the acceptable fallback is:
+
+1. keep `make sonar` as the canonical entry point;
+2. fail closed with explicit setup guidance rather than silently degrading;
+3. ensure coverage generation and scan prerequisites remain visible to contributors.
+
+## Open Questions
+
+- [ ] Confirm whether the repository already expects `sonar-scanner` directly on `PATH` locally, or whether the script should support a second invocation path that still preserves CI-aligned behavior.
+- [ ] Confirm which specific locally reproducible quality issues provide the best narrow remediation set once verification commands are run.

--- a/openspec/changes/2026-04-28-monthly-sonar-review-433/tasks.md
+++ b/openspec/changes/2026-04-28-monthly-sonar-review-433/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Monthly Sonar review workflow and targeted quality remediation #433
+
+## Phase 1: Local Sonar workflow foundation
+
+- [ ] 1.1 Modify `Makefile` to add a documented `sonar` target and include it in the phony/help workflow alongside existing quality commands.
+- [ ] 1.2 Create `scripts/sonar.sh` to validate `SONAR_TOKEN`, check local scanner availability, derive the Sonar project key, and invoke CI-aligned scanner arguments.
+- [ ] 1.3 Keep `.github/workflows/sonarqube-analysis.yml` and `scripts/sonar.sh` aligned by extracting or normalizing any duplicated scanner assumptions only if needed to reduce drift.
+
+## Phase 2: Coverage and command wiring
+
+- [ ] 2.1 RED: Verify the local `sonar` workflow reproduces the expected Kotlin, dashboard, and Rust coverage artifact paths from `.github/workflows/sonarqube-analysis.yml`; capture failing gaps first.
+- [ ] 2.2 GREEN: Wire `Makefile` so `make sonar` runs the required Kotlin coverage command, dashboard Vitest LCOV generation, Rust LCOV generation, and then `scripts/sonar.sh` in dependency order.
+- [ ] 2.3 GREEN: Ensure the command fails closed with clear operator-facing messages when coverage generation, credentials, or scanner prerequisites are missing.
+
+## Phase 3: Targeted quality remediation
+
+- [ ] 3.1 RED: Run the most relevant local verification commands for touched areas to identify a narrow set of actionable quality issues contributing to the monthly Sonar maintenance slice.
+- [ ] 3.2 GREEN: Apply bounded fixes only in directly affected files, prioritizing maintainability or coverage-adjacent issues that are locally reproducible and do not widen scope.
+- [ ] 3.3 REFACTOR: Clean up any helper logic or command text added for the new workflow so operational guidance stays concise and consistent with existing repo conventions.
+
+## Phase 4: Documentation and verification
+
+- [ ] 4.1 Modify `README.md` or the nearest contributor-facing workflow doc to explain `make sonar`, local prerequisites, and how local execution relates to hosted SonarCloud results.
+- [ ] 4.2 VERIFY: Re-run the scoped verification path for all touched files, including `make sonar` prerequisite behavior and the relevant existing tests/checks for any remediation changes.
+- [ ] 4.3 VERIFY: Confirm the implementation still matches `openspec/changes/2026-04-28-monthly-sonar-review-433/design.md` and remains limited to monthly Sonar workflow parity plus narrow quality maintenance.

--- a/scripts/sonar.sh
+++ b/scripts/sonar.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SONAR_ORGANIZATION="${SONAR_ORGANIZATION:-dallay}"
-REPO_SLUG="$(git -C "$ROOT_DIR" config --get remote.origin.url 2>/dev/null | sed -E 's#^.*[:/]([^/]+)/([^/.]+)(\.git)?$#\1_\2#')"
-SONAR_PROJECT_KEY="${SONAR_PROJECT_KEY:-${REPO_SLUG:-dallay_corvus}}"
+SONAR_PROJECT_KEY="${SONAR_PROJECT_KEY:-dallay_corvus}"
 SONAR_PROJECT_KEY="${SONAR_PROJECT_KEY//-/_}"
 SONAR_PROJECT_NAME="${SONAR_PROJECT_NAME:-$(basename "$ROOT_DIR")}"
 VALIDATE_ONLY="${1:-}"

--- a/scripts/sonar.sh
+++ b/scripts/sonar.sh
@@ -56,4 +56,4 @@ sonar-scanner \
   -Dsonar.rust.lcov.reportPaths="$RUST_LCOV_REPORT" \
   -Dsonar.javascript.lcov.reportPaths="$WEB_LCOV_REPORT" \
   -Dsonar.python.version=3.12 \
-  -Dsonar.typescript.node="$ROOT_DIR/clients/web/node_modules"
+  -Dsonar.nodejs.executable="$(command -v node)"

--- a/scripts/sonar.sh
+++ b/scripts/sonar.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SONAR_ORGANIZATION="${SONAR_ORGANIZATION:-dallay}"
+REPO_SLUG="$(git -C "$ROOT_DIR" config --get remote.origin.url 2>/dev/null | sed -E 's#^.*[:/]([^/]+)/([^/.]+)(\.git)?$#\1_\2#')"
+SONAR_PROJECT_KEY="${SONAR_PROJECT_KEY:-${REPO_SLUG:-dallay_corvus}}"
+SONAR_PROJECT_KEY="${SONAR_PROJECT_KEY//-/_}"
+SONAR_PROJECT_NAME="${SONAR_PROJECT_NAME:-$(basename "$ROOT_DIR")}"
+VALIDATE_ONLY="${1:-}"
+
+if [[ -z "${SONAR_TOKEN:-}" ]]; then
+  echo "SONAR_TOKEN is not configured. Local SonarQube analysis requires this environment variable." >&2
+  echo "Export SONAR_TOKEN and retry 'make sonar'." >&2
+  exit 1
+fi
+
+if ! command -v sonar-scanner >/dev/null 2>&1; then
+  echo "sonar-scanner is required for local SonarQube analysis." >&2
+  echo "Install sonar-scanner and ensure it is available on PATH, then retry 'make sonar'." >&2
+  exit 1
+fi
+
+if [[ "$VALIDATE_ONLY" == "--validate-only" ]]; then
+  exit 0
+fi
+
+KOVER_CORE_REPORT="$ROOT_DIR/modules/agent-core-kmp/build/reports/kover/report.xml"
+KOVER_APP_REPORT="$ROOT_DIR/clients/composeApp/build/reports/kover/report.xml"
+RUST_LCOV_REPORT="$ROOT_DIR/coverage/agent-runtime-coverage.lcov"
+WEB_LCOV_REPORT="$ROOT_DIR/clients/web/apps/dashboard/coverage/lcov.info"
+
+for report in "$KOVER_CORE_REPORT" "$KOVER_APP_REPORT" "$RUST_LCOV_REPORT" "$WEB_LCOV_REPORT"; do
+  if [[ ! -f "$report" ]]; then
+    echo "Expected coverage artifact is missing: $report" >&2
+    echo "Run 'make sonar' from a clean state so coverage generation completes before scanning." >&2
+    exit 1
+  fi
+done
+
+cd "$ROOT_DIR"
+
+sonar-scanner \
+  -Dsonar.organization="$SONAR_ORGANIZATION" \
+  -Dsonar.projectKey="$SONAR_PROJECT_KEY" \
+  -Dsonar.projectName="$SONAR_PROJECT_NAME" \
+  -Dsonar.sources=. \
+  -Dsonar.tests=. \
+  -Dsonar.test.inclusions='**/*.spec.ts,**/*.test.ts,**/*.test.tsx,**/*_test.rs,**/tests/**,**/src/test/**,**/src/commonTest/**,**/src/jvmTest/**,**/src/androidUnitTest/**,**/src/iosTest/**' \
+  -Dsonar.exclusions='**/.git/**,**/.gradle/**,**/build/**,**/dist/**,**/coverage/**,**/node_modules/**,**/.next/**,**/.turbo/**,**/target/**,**/vendor/**,**/generated/**,**/clients/agent-runtime/target/**' \
+  -Dsonar.coverage.exclusions='**/*.spec.ts,**/*.test.ts,**/*.test.tsx,scripts/**,clients/web/apps/dashboard/src/App.vue,clients/web/packages/shared/index.ts,clients/agent-runtime/npm/corvus-cli/scripts/postinstall.mjs,clients/agent-runtime/npm/corvus-cli/lib/install.js,gradle/build-logic/src/main/kotlin/**,clients/composeApp/src/**,clients/iosApp/**,clients/web/apps/*/src/main.ts,clients/web/apps/*/src/i18n.ts,clients/web/apps/docs/src/content.config.ts,clients/web/apps/docs/astro.config.mjs,clients/web/apps/marketing/astro.config.mjs,clients/web/apps/dashboard/tsconfig.node.json,clients/web/packages/locales/src/index.ts,clients/agent-runtime/firmware/**,clients/agent-runtime/examples/**' \
+  -Dsonar.cpd.exclusions='**/content/docs/**/*.md,**/content/docs/**/*.mdx' \
+  -Dsonar.issue.ignore.multicriteria=e1 \
+  -Dsonar.issue.ignore.multicriteria.e1.ruleKey=kotlin:S100 \
+  -Dsonar.issue.ignore.multicriteria.e1.resourceKey='**/*Test.kt' \
+  -Dsonar.coverage.jacoco.xmlReportPaths="$KOVER_CORE_REPORT,$KOVER_APP_REPORT" \
+  -Dsonar.rust.lcov.reportPaths="$RUST_LCOV_REPORT" \
+  -Dsonar.javascript.lcov.reportPaths="$WEB_LCOV_REPORT" \
+  -Dsonar.python.version=3.12 \
+  -Dsonar.typescript.node="$ROOT_DIR/clients/web/node_modules"


### PR DESCRIPTION
## Related Issues

Fixes #433

---

## Summary

- add a local `make sonar` workflow that validates prerequisites, generates Kotlin/Rust/dashboard coverage artifacts, and launches SonarScanner with the repository's SonarCloud configuration
- align dashboard coverage output with the `lcov.info` artifact Sonar expects and harden the dream-memory session-count test/coverage path for more stable local verification
- document the local monthly Sonar review flow and capture the implementation/design notes in OpenSpec

---

## Tested Information

- `make sonar` (validated end-to-end through prerequisite checks, coverage generation, and SonarScanner analysis startup)
- `bash ./scripts/sonar.sh --validate-only`
- `bash ./scripts/sonar.sh`
- `pnpm --dir clients/web/apps/dashboard test:coverage`
- `cargo test session_trigger_fires_after_five_sessions --manifest-path clients/agent-runtime/Cargo.toml -- --nocapture`
- `cargo llvm-cov --lcov --output-path ../../coverage/agent-runtime-coverage.lcov -- --test-threads=1` from `clients/agent-runtime`

---

## Documentation Impact

- Docs updated in:
  - `README.md`
  - `openspec/changes/2026-04-28-monthly-sonar-review-433/design.md`
  - `openspec/changes/2026-04-28-monthly-sonar-review-433/tasks.md`
- No docs update required because:
- [x] I verified the documentation matches the current behavior.

---

## Breaking Changes

- None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/CONTRIBUTING.md).
- [x] My PR title follows Conventional Commits.
- [x] I have performed a self-review of my changes.
- [x] I have tested the changes locally.
- [x] I have updated documentation where needed.
- [x] I confirm this PR does not introduce breaking changes.
