### PR TITLE
test(runtime): tolerate transient Dream lock contention

### DIFF
--- a/clients/agent-runtime/src/memory/dream.rs
+++ b/clients/agent-runtime/src/memory/dream.rs
@@ -634,6 +634,20 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn run_if_triggered_after_transient_busy(workspace_dir: &Path) -> MemoryConsolidationReport {
+        let mut last_report = None;
+        for _ in 0..10 {
+            if let Some(report) = run_if_triggered(workspace_dir).unwrap() {
+                if report.lock_state != DreamLockState::Busy {
+                    return report;
+                }
+                last_report = Some(report);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        last_report.expect("Dream run should produce a report")
+    }
+
     #[test]
     fn rejects_active_session_without_recorded_completion() {
         let tmp = TempDir::new().unwrap();
@@ -652,8 +666,9 @@ mod tests {
         let eligibility = dream_eligibility(tmp.path(), "sess-123").unwrap();
         assert_eq!(eligibility, DreamEligibility::Eligible);
 
-        let report = run_if_triggered(tmp.path()).unwrap().unwrap();
+        let report = run_if_triggered_after_transient_busy(tmp.path());
         assert_eq!(report.trigger_reason, DreamTriggerReason::TimeElapsed);
+        assert_eq!(report.lock_state, DreamLockState::Acquired);
         assert_eq!(report.sessions_processed, 1);
         assert_eq!(
             report.session_reports[0].artifact_refs,

--- a/clients/agent-runtime/src/memory/dream.rs
+++ b/clients/agent-runtime/src/memory/dream.rs
@@ -787,14 +787,7 @@ mod tests {
             record_session_completion(tmp.path(), &format!("sess-{index}")).unwrap();
         }
 
-        let mut report = run_if_triggered(tmp.path()).unwrap().unwrap();
-        for _ in 0..10 {
-            if report.lock_state != DreamLockState::Busy {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(10));
-            report = run_if_triggered(tmp.path()).unwrap().unwrap_or(report);
-        }
+        let report = run_if_triggered_after_transient_busy(tmp.path());
         assert_eq!(report.trigger_reason, DreamTriggerReason::SessionCount);
         assert_eq!(report.lock_state, DreamLockState::Acquired);
         assert_eq!(report.status, DreamRunStatus::Completed);


### PR DESCRIPTION
## Summary

- Fixes intermittent CI failure in `memory::dream::tests::accepts_recorded_completed_session_and_creates_deterministic_artifact_ref`
- Root cause: test expected `sessions_processed = 1` but got `0` when `run_if_triggered()` returned a `Busy` lock state on first attempt
- Solution: added retry helper `run_if_triggered_after_transient_busy()` that waits for lock acquisition, matching pattern already used in `session_trigger_fires_after_five_sessions` test

## Changes

- Added `run_if_triggered_after_transient_busy()` test helper
- Updated failing test to retry on transient lock contention
- Added explicit `DreamLockState::Acquired` assertion before validating `sessions_processed`

## Testing

- Local verification: 20 consecutive runs passed
- Serial test execution: all 12 dream tests pass
- Pre-push Rust checks: passed

Fixes intermittent failure observed in https://github.com/dallay/corvus/actions/runs/25174664361/job/73803405198