### PR TITLE
fix(cerebro): improve mcp http error semantics

### DIFF
--- a/clients/cerebro/README.md
+++ b/clients/cerebro/README.md
@@ -62,6 +62,25 @@ Recommended pattern:
 
 These probe endpoints are intentionally unauthenticated. Restrict access with network policy, ingress rules, or private service topology rather than exposing them broadly on the public Internet.
 
+## MCP HTTP transport semantics
+
+`POST /mcp` preserves JSON-RPC response bodies for MCP clients and also returns HTTP status codes that reflect operational failure categories for ingress, proxy, and observability consumers.
+
+Successful JSON-RPC responses return `200 OK`. Failed JSON-RPC responses keep the JSON-RPC error payload and use these HTTP statuses:
+
+| Scenario | HTTP status |
+| --- | --- |
+| Missing or invalid bearer token | `401 Unauthorized` |
+| Authenticated caller lacks permission | `403 Forbidden` |
+| Invalid JSON-RPC request, unsupported method, or invalid params | `400 Bad Request` |
+| Requested resource is missing | `404 Not Found` |
+| Request conflicts with current state | `409 Conflict` |
+| Requested MCP tool is deferred or unimplemented | `501 Not Implemented` |
+| Storage/backend dependency failure | `503 Service Unavailable` |
+| Unexpected internal failure | `500 Internal Server Error` |
+
+Operators should alert separately on repeated authorization failures, forbidden attempts, validation spikes, backend/storage failures, and internal errors.
+
 ## Request limits
 
 Cerebro enforces a 1 MiB (1,048,576 bytes) HTTP request body limit on the router to reduce abuse and accidental oversized payloads.
@@ -88,7 +107,7 @@ Cerebro also exposes Prometheus-compatible operational metrics at `GET /metrics`
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `cerebro_requests_total` | counter | `method`, `status` | Total MCP JSON-RPC requests by canonical method (`tools.call`, `tools.list`, or `unknown`) and outcome (`ok` or `error`). |
+| `cerebro_requests_total` | counter | `method`, `status` | Total MCP JSON-RPC requests by canonical method (`tools.call`, `tools.list`, or `unknown`) and outcome (`ok`, `validation_error`, `unauthorized`, `forbidden`, `not_implemented`, `not_found`, `conflict`, `storage_error`, or `internal_error`). |
 | `cerebro_tool_latency_seconds` | histogram | `tool`, `status` | Tool execution latency by MCP tool name and outcome (`ok` or `error`). |
 | `cerebro_auth_failures_total` | counter | none | Authentication failures for MCP requests. |
 | `cerebro_readiness_failures_total` | counter | none | Readiness probe failures returned by `/readyz`. |

--- a/clients/cerebro/src/metrics.rs
+++ b/clients/cerebro/src/metrics.rs
@@ -55,11 +55,21 @@ pub fn init() {
     Lazy::force(&CEREBRO_READINESS_FAILURES_TOTAL);
     Lazy::force(&CEREBRO_STORAGE_ERRORS_TOTAL);
 
-    CEREBRO_REQUESTS_TOTAL.with_label_values(&["tools.call", "ok"]);
-    CEREBRO_REQUESTS_TOTAL.with_label_values(&["tools.call", "error"]);
-    CEREBRO_REQUESTS_TOTAL.with_label_values(&["tools.list", "ok"]);
-    CEREBRO_REQUESTS_TOTAL.with_label_values(&["tools.list", "error"]);
-    CEREBRO_REQUESTS_TOTAL.with_label_values(&["unknown", "error"]);
+    for method in ["tools.call", "tools.list", "unknown"] {
+        for status in [
+            "ok",
+            "validation_error",
+            "unauthorized",
+            "forbidden",
+            "not_implemented",
+            "not_found",
+            "conflict",
+            "storage_error",
+            "internal_error",
+        ] {
+            CEREBRO_REQUESTS_TOTAL.with_label_values(&[method, status]);
+        }
+    }
     CEREBRO_TOOL_LATENCY_SECONDS.with_label_values(&["unknown", "ok"]);
     CEREBRO_TOOL_LATENCY_SECONDS.with_label_values(&["unknown", "error"]);
     CEREBRO_STORAGE_ERRORS_TOTAL.with_label_values(&["unknown"]);

--- a/clients/cerebro/src/server.rs
+++ b/clients/cerebro/src/server.rs
@@ -55,6 +55,21 @@ pub struct JsonRpcResponse {
     pub error: Option<JsonRpcError>,
 }
 
+#[derive(Debug)]
+struct JsonRpcHttpResponse {
+    status: StatusCode,
+    body: JsonRpcResponse,
+}
+
+impl JsonRpcHttpResponse {
+    fn ok(body: JsonRpcResponse) -> Self {
+        Self {
+            status: StatusCode::OK,
+            body,
+        }
+    }
+}
+
 const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
 
 fn request_method_label(method: &str) -> &'static str {
@@ -125,36 +140,52 @@ impl CerebroService {
         request: JsonRpcRequest,
         auth_header: Option<&str>,
     ) -> JsonRpcResponse {
+        self.handle_json_rpc_http(request, auth_header).await.body
+    }
+
+    async fn handle_json_rpc_http(
+        &self,
+        request: JsonRpcRequest,
+        auth_header: Option<&str>,
+    ) -> JsonRpcHttpResponse {
         let id = request.id.clone();
         if request.jsonrpc != "2.0" {
             metrics::CEREBRO_REQUESTS_TOTAL
-                .with_label_values(&[request_method_label(&request.method), "error"])
+                .with_label_values(&[request_method_label(&request.method), "validation_error"])
                 .inc();
-            return JsonRpcResponse {
-                jsonrpc: "2.0".to_string(),
-                id,
-                result: None,
-                error: Some(JsonRpcError {
-                    code: -32600,
-                    message: "jsonrpc must be '2.0'".to_string(),
-                    data: None,
-                }),
+            log_protocol_failure(&request.method, StatusCode::BAD_REQUEST, "validation_error");
+            return JsonRpcHttpResponse {
+                status: StatusCode::BAD_REQUEST,
+                body: JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id,
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32600,
+                        message: "jsonrpc must be '2.0'".to_string(),
+                        data: None,
+                    }),
+                },
             };
         }
 
         if request.method != "tools/call" && request.method != "tools/list" {
             metrics::CEREBRO_REQUESTS_TOTAL
-                .with_label_values(&[request_method_label(&request.method), "error"])
+                .with_label_values(&[request_method_label(&request.method), "validation_error"])
                 .inc();
-            return JsonRpcResponse {
-                jsonrpc: "2.0".to_string(),
-                id,
-                result: None,
-                error: Some(JsonRpcError {
-                    code: -32601,
-                    message: "unsupported method".to_string(),
-                    data: None,
-                }),
+            log_protocol_failure(&request.method, StatusCode::BAD_REQUEST, "validation_error");
+            return JsonRpcHttpResponse {
+                status: StatusCode::BAD_REQUEST,
+                body: JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id,
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32601,
+                        message: "unsupported method".to_string(),
+                        data: None,
+                    }),
+                },
             };
         }
 
@@ -182,10 +213,21 @@ impl CerebroService {
                 Err(error) => {
                     metrics::CEREBRO_AUTH_FAILURES_TOTAL.inc();
                     metrics::CEREBRO_REQUESTS_TOTAL
-                        .with_label_values(&[request_method_label(&request.method), "error"])
+                        .with_label_values(&[
+                            request_method_label(&request.method),
+                            metric_status_for_error(&error),
+                        ])
                         .inc();
-                    tracing::warn!(error = %error, "authorization failed");
-                    return error_response(id, error);
+                    let http_status = status_for_error(&error);
+                    let error_kind = metric_status_for_error(&error);
+                    tracing::warn!(
+                        error = %error,
+                        http_status = http_status.as_u16(),
+                        error_kind,
+                        method = %request_method_label(&request.method),
+                        "authorization failed"
+                    );
+                    return http_error_response(id, error);
                 }
             };
 
@@ -203,27 +245,31 @@ impl CerebroService {
                     .with_label_values(&[request_method_label(&request.method), "ok"])
                     .inc();
                 let tools = self.tools.list_manifest();
-                return JsonRpcResponse {
+                return JsonRpcHttpResponse::ok(JsonRpcResponse {
                     jsonrpc: "2.0".to_string(),
                     id,
                     result: Some(json!({ "tools": tools })),
                     error: None,
-                };
+                });
             }
 
             let Some(params) = request.params else {
                 metrics::CEREBRO_REQUESTS_TOTAL
-                    .with_label_values(&[request_method_label(&request.method), "error"])
+                    .with_label_values(&[request_method_label(&request.method), "validation_error"])
                     .inc();
-                return JsonRpcResponse {
-                    jsonrpc: "2.0".to_string(),
-                    id,
-                    result: None,
-                    error: Some(JsonRpcError {
-                        code: -32602,
-                        message: "missing params".to_string(),
-                        data: None,
-                    }),
+                log_protocol_failure(&request.method, StatusCode::BAD_REQUEST, "validation_error");
+                return JsonRpcHttpResponse {
+                    status: StatusCode::BAD_REQUEST,
+                    body: JsonRpcResponse {
+                        jsonrpc: "2.0".to_string(),
+                        id,
+                        result: None,
+                        error: Some(JsonRpcError {
+                            code: -32602,
+                            message: "missing params".to_string(),
+                            data: None,
+                        }),
+                    },
                 };
             };
 
@@ -250,7 +296,11 @@ impl CerebroService {
             });
 
             let tool_start = Instant::now();
-            match self.tools.handle(&tool_name, params.arguments, &auth_context).await {
+            match self
+                .tools
+                .handle(&tool_name, params.arguments, &auth_context)
+                .await
+            {
                 Ok(output) => {
                     let elapsed = tool_start.elapsed();
                     let duration_ms = elapsed.as_millis() as u64;
@@ -279,18 +329,21 @@ impl CerebroService {
                         error: None,
                     });
                     tracing::info!(duration_ms, status = "ok", "tool call completed");
-                    JsonRpcResponse {
+                    JsonRpcHttpResponse::ok(JsonRpcResponse {
                         jsonrpc: "2.0".to_string(),
                         id,
                         result: Some(json!({ "output": output })),
                         error: None,
-                    }
+                    })
                 }
                 Err(error) => {
                     let elapsed = tool_start.elapsed();
                     let duration_ms = elapsed.as_millis() as u64;
                     metrics::CEREBRO_REQUESTS_TOTAL
-                        .with_label_values(&[request_method_label(&request.method), "error"])
+                        .with_label_values(&[
+                            request_method_label(&request.method),
+                            metric_status_for_error(&error),
+                        ])
                         .inc();
                     metrics::CEREBRO_TOOL_LATENCY_SECONDS
                         .with_label_values(&[tool_label.as_str(), "error"])
@@ -299,7 +352,7 @@ impl CerebroService {
                     self.event_bus.publish(ToolCallEvent {
                         kind: ToolCallEventKind::Failed,
                         request_id,
-                        tool_name,
+                        tool_name: tool_name.clone(),
                         timestamp: Utc::now().to_rfc3339(),
                         duration_ms: Some(duration_ms),
                         status: Some("error".to_string()),
@@ -307,8 +360,19 @@ impl CerebroService {
                         redacted_output: None,
                         error: Some(redacted_error),
                     });
-                    tracing::warn!(duration_ms, error = %error, status = "error", "tool call failed");
-                    error_response(id, error)
+                    let http_status = status_for_error(&error);
+                    let error_kind = metric_status_for_error(&error);
+                    tracing::warn!(
+                        duration_ms,
+                        error = %error,
+                        status = "error",
+                        http_status = http_status.as_u16(),
+                        error_kind,
+                        method = %request_method_label(&request.method),
+                        tool_name = %tool_name,
+                        "tool call failed"
+                    );
+                    http_error_response(id, error)
                 }
             }
         }
@@ -384,6 +448,40 @@ fn error_response(id: Value, error: CerebroError) -> JsonRpcResponse {
     }
 }
 
+fn status_for_error(error: &CerebroError) -> StatusCode {
+    match error {
+        CerebroError::Validation(_) => StatusCode::BAD_REQUEST,
+        CerebroError::Unauthorized => StatusCode::UNAUTHORIZED,
+        CerebroError::Forbidden(_) => StatusCode::FORBIDDEN,
+        CerebroError::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
+        CerebroError::NotFound => StatusCode::NOT_FOUND,
+        CerebroError::Conflict(_) => StatusCode::CONFLICT,
+        CerebroError::Storage(_) => StatusCode::SERVICE_UNAVAILABLE,
+        CerebroError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+fn metric_status_for_error(error: &CerebroError) -> &'static str {
+    error.code().as_str()
+}
+
+fn log_protocol_failure(method: &str, status: StatusCode, error_kind: &'static str) {
+    tracing::warn!(
+        method = %request_method_label(method),
+        http_status = status.as_u16(),
+        error_kind,
+        "mcp protocol request failed"
+    );
+}
+
+fn http_error_response(id: Value, error: CerebroError) -> JsonRpcHttpResponse {
+    let status = status_for_error(&error);
+    JsonRpcHttpResponse {
+        status,
+        body: error_response(id, error),
+    }
+}
+
 async fn handle_health() -> Json<Value> {
     Json(json!({ "status": "ok" }))
 }
@@ -436,9 +534,10 @@ async fn handle_mcp(
     State(service): State<Arc<CerebroService>>,
     headers: HeaderMap,
     Json(request): Json<JsonRpcRequest>,
-) -> Json<JsonRpcResponse> {
+) -> (StatusCode, Json<JsonRpcResponse>) {
     let auth_header = headers
         .get("authorization")
         .and_then(|value| value.to_str().ok());
-    Json(service.handle_json_rpc(request, auth_header).await)
+    let response = service.handle_json_rpc_http(request, auth_header).await;
+    (response.status, Json(response.body))
 }

--- a/clients/cerebro/tests/health_endpoints_test.rs
+++ b/clients/cerebro/tests/health_endpoints_test.rs
@@ -1,11 +1,12 @@
 use async_trait::async_trait;
 use axum::body::{to_bytes, Body};
-use axum::http::{Request, StatusCode};
+use axum::http::{header, Request, StatusCode};
 use cerebro::{
     errors::CerebroError, storage::MemoryRecord, CerebroConfig, CerebroService, InMemoryStorage,
     Storage, StorageMode,
 };
-use serde_json::Value;
+use secrecy::SecretString;
+use serde_json::{json, Value};
 use std::any::Any;
 use std::sync::Arc;
 use tower::util::ServiceExt;
@@ -52,7 +53,9 @@ impl Storage for FailingReadyStorage {
     }
 
     async fn count(&self) -> Result<usize, CerebroError> {
-        unreachable!("count is not used in readiness test")
+        Err(CerebroError::Storage(
+            "simulated storage count failure".to_string(),
+        ))
     }
 
     async fn ready(&self) -> Result<(), CerebroError> {
@@ -60,6 +63,103 @@ impl Storage for FailingReadyStorage {
             "simulated readiness failure".to_string(),
         ))
     }
+}
+
+fn authed_config() -> CerebroConfig {
+    CerebroConfig {
+        storage_mode: StorageMode::InMemory,
+        auth_token: Some(SecretString::new("secret".to_string().into())),
+        audit_token: Some(SecretString::new("audit-secret".to_string().into())),
+        ..Default::default()
+    }
+}
+
+async fn post_mcp(
+    service: Arc<CerebroService>,
+    auth_header: Option<&str>,
+    payload: Value,
+) -> (StatusCode, Value) {
+    let mut request = Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header(header::CONTENT_TYPE, "application/json");
+
+    if let Some(auth_header) = auth_header {
+        request = request.header(header::AUTHORIZATION, auth_header);
+    }
+
+    let response = service
+        .router()
+        .oneshot(
+            request
+                .body(Body::from(payload.to_string()))
+                .expect("request should build"),
+        )
+        .await
+        .expect("/mcp request should be handled");
+
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body should be readable");
+    let payload: Value = serde_json::from_slice(&body).expect("body should be valid json");
+
+    (status, payload)
+}
+
+fn tools_list_request() -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": "list",
+        "method": "tools/list"
+    })
+}
+
+fn invalid_jsonrpc_version_request() -> Value {
+    json!({
+        "jsonrpc": "1.0",
+        "id": "bad-version",
+        "method": "tools/list"
+    })
+}
+
+fn tools_call_missing_params_request() -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": "missing-params",
+        "method": "tools/call"
+    })
+}
+
+fn deferred_tool_request() -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": "deferred-tool",
+        "method": "tools/call",
+        "params": {
+            "name": "mem_context",
+            "arguments": {
+                "input": {}
+            }
+        }
+    })
+}
+
+fn forbidden_timeline_request() -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": "forbidden-timeline",
+        "method": "tools/call",
+        "params": {
+            "name": "mem_timeline",
+            "arguments": {
+                "input": {
+                    "memory_id": "memory-1",
+                    "include_deleted": true
+                }
+            }
+        }
+    })
 }
 
 #[tokio::test]
@@ -181,4 +281,252 @@ async fn metrics_returns_prometheus_format() {
     assert!(payload.contains("cerebro_auth_failures_total"));
     assert!(payload.contains("cerebro_readiness_failures_total"));
     assert!(payload.contains("cerebro_storage_errors_total"));
+}
+
+#[tokio::test]
+async fn mcp_missing_authorization_returns_401_with_json_rpc_error() {
+    let service = Arc::new(CerebroService::new(authed_config(), InMemoryStorage::new()));
+
+    let (status, payload) = post_mcp(service, None, tools_list_request()).await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(payload.get("jsonrpc").and_then(Value::as_str), Some("2.0"));
+    assert_eq!(payload.get("id"), Some(&json!("list")));
+    assert_eq!(
+        payload
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(Value::as_i64),
+        Some(-32001)
+    );
+    assert_eq!(
+        payload
+            .get("error")
+            .and_then(|error| error.get("message"))
+            .and_then(Value::as_str),
+        Some("unauthorized")
+    );
+}
+
+#[tokio::test]
+async fn mcp_invalid_authorization_returns_401_with_json_rpc_error() {
+    let service = Arc::new(CerebroService::new(authed_config(), InMemoryStorage::new()));
+
+    let (status, payload) = post_mcp(service, Some("Bearer wrong"), tools_list_request()).await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        payload
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(Value::as_i64),
+        Some(-32001)
+    );
+    assert_eq!(
+        payload
+            .get("error")
+            .and_then(|error| error.get("message"))
+            .and_then(Value::as_str),
+        Some("unauthorized")
+    );
+}
+
+#[tokio::test]
+async fn mcp_invalid_jsonrpc_version_returns_400_with_json_rpc_error() {
+    let service = Arc::new(CerebroService::new(authed_config(), InMemoryStorage::new()));
+
+    let (status, payload) = post_mcp(
+        service,
+        Some("Bearer secret"),
+        invalid_jsonrpc_version_request(),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(payload.get("id"), Some(&json!("bad-version")));
+    assert_eq!(
+        payload
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(Value::as_i64),
+        Some(-32600)
+    );
+}
+
+#[tokio::test]
+async fn mcp_missing_tools_call_params_returns_400_with_json_rpc_error() {
+    let service = Arc::new(CerebroService::new(authed_config(), InMemoryStorage::new()));
+
+    let (status, payload) = post_mcp(
+        service,
+        Some("Bearer secret"),
+        tools_call_missing_params_request(),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(payload.get("id"), Some(&json!("missing-params")));
+    assert_eq!(
+        payload
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(Value::as_i64),
+        Some(-32602)
+    );
+    assert_eq!(
+        payload
+            .get("error")
+            .and_then(|error| error.get("message"))
+            .and_then(Value::as_str),
+        Some("missing params")
+    );
+}
+
+#[tokio::test]
+async fn mcp_forbidden_tool_call_returns_403_with_json_rpc_error() {
+    let service = Arc::new(CerebroService::new(authed_config(), InMemoryStorage::new()));
+
+    let (status, payload) =
+        post_mcp(service, Some("Bearer secret"), forbidden_timeline_request()).await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(payload.get("id"), Some(&json!("forbidden-timeline")));
+    assert_eq!(
+        payload
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(Value::as_i64),
+        Some(-32003)
+    );
+    assert_eq!(
+        payload
+            .get("error")
+            .and_then(|error| error.get("message"))
+            .and_then(Value::as_str),
+        Some("forbidden: include_deleted requires audit permissions")
+    );
+}
+
+#[tokio::test]
+async fn mcp_deferred_tool_returns_501_with_json_rpc_error() {
+    let service = Arc::new(CerebroService::new(authed_config(), InMemoryStorage::new()));
+
+    let (status, payload) = post_mcp(service, Some("Bearer secret"), deferred_tool_request()).await;
+
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+    assert_eq!(payload.get("id"), Some(&json!("deferred-tool")));
+    assert_eq!(
+        payload
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(Value::as_i64),
+        Some(-32004)
+    );
+    assert_eq!(
+        payload
+            .get("error")
+            .and_then(|error| error.get("message"))
+            .and_then(Value::as_str),
+        Some("not implemented: mem_context")
+    );
+}
+
+#[tokio::test]
+async fn mcp_storage_failure_returns_503_with_json_rpc_error() {
+    let service = Arc::new(CerebroService::new(
+        authed_config(),
+        Arc::new(FailingReadyStorage),
+    ));
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": "storage-failure",
+        "method": "tools/call",
+        "params": {
+            "name": "mem_stats",
+            "arguments": {
+                "input": {}
+            }
+        }
+    });
+
+    let (status, payload) = post_mcp(service, Some("Bearer secret"), request).await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(payload.get("id"), Some(&json!("storage-failure")));
+    assert_eq!(
+        payload
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(Value::as_i64),
+        Some(-32010)
+    );
+}
+
+#[tokio::test]
+async fn mcp_successful_tools_list_returns_200_with_json_rpc_result() {
+    let service = Arc::new(CerebroService::new(authed_config(), InMemoryStorage::new()));
+
+    let (status, payload) = post_mcp(service, Some("Bearer secret"), tools_list_request()).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(payload.get("error").is_none());
+    assert!(
+        payload
+            .get("result")
+            .and_then(|result| result.get("tools"))
+            .and_then(Value::as_array)
+            .is_some(),
+        "tools/list should return a tools array"
+    );
+}
+
+#[tokio::test]
+async fn metrics_include_differentiated_mcp_failure_statuses() {
+    let service = Arc::new(CerebroService::new(authed_config(), InMemoryStorage::new()));
+
+    let _ = post_mcp(service.clone(), None, tools_list_request()).await;
+    let _ = post_mcp(
+        service.clone(),
+        Some("Bearer secret"),
+        forbidden_timeline_request(),
+    )
+    .await;
+    let _ = post_mcp(
+        service.clone(),
+        Some("Bearer secret"),
+        deferred_tool_request(),
+    )
+    .await;
+
+    let response = service
+        .router()
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body should be readable");
+    let payload = String::from_utf8(body.to_vec()).expect("body should be utf8");
+
+    assert!(
+        payload.contains("cerebro_requests_total{method=\"tools.list\",status=\"unauthorized\"}"),
+        "metrics should expose unauthorized MCP request failures"
+    );
+    assert!(
+        payload.contains("cerebro_requests_total{method=\"tools.call\",status=\"forbidden\"}"),
+        "metrics should expose forbidden MCP request failures"
+    );
+    assert!(
+        payload
+            .contains("cerebro_requests_total{method=\"tools.call\",status=\"not_implemented\"}"),
+        "metrics should expose not implemented MCP request failures"
+    );
 }


### PR DESCRIPTION
## Related Issues

Fixes #696

---

## Summary

- Return operational HTTP statuses from `POST /mcp` while preserving JSON-RPC error response bodies.
- Add differentiated low-cardinality request metric statuses and structured failure log fields for auth, validation, forbidden, unimplemented, storage, and internal failures.
- Add integration coverage for `/mcp` status semantics and document the behavior for operators.

---

## Tested Information

- `cargo fmt --manifest-path clients/cerebro/Cargo.toml`
- `cargo test --manifest-path clients/cerebro/Cargo.toml`

---

## Documentation Impact

- Docs updated in: `clients/cerebro/README.md`
- I verified the documentation matches the current behavior.

---

## Breaking Changes

`POST /mcp` now returns non-2xx HTTP statuses for JSON-RPC error responses. JSON-RPC response bodies are preserved, but clients or infrastructure that assumed all JSON-RPC errors arrive with HTTP `200 OK` may need to handle the new operational statuses.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).