### PR TITLE
feat(cerebro): add MCP abuse controls

### DIFF
--- a/clients/agent-runtime/Cargo.lock
+++ b/clients/agent-runtime/Cargo.lock
@@ -795,6 +795,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/clients/cerebro/Cargo.toml
+++ b/clients/cerebro/Cargo.toml
@@ -36,7 +36,8 @@ subtle = "2"
 surrealdb = { version = "3.0.4", default-features = false, features = ["kv-rocksdb"] }
 toml = { version = "1.1", default-features = false, features = ["parse", "serde"] }
 thiserror = "2.0"
-tokio = { version = "1.42", default-features = false, features = ["macros", "rt-multi-thread", "net", "signal", "time"] }
+tokio = { version = "1.42", default-features = false, features = ["macros", "rt-multi-thread", "net", "signal", "sync", "time"] }
+tower = { version = "0.5", features = ["timeout", "util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 url = "2.5"
@@ -52,4 +53,3 @@ fs_extra = "1.3"
 predicates = "3.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tempfile = "3.12"
-tower = { version = "0.5", features = ["util"] }

--- a/clients/cerebro/src/config.rs
+++ b/clients/cerebro/src/config.rs
@@ -111,6 +111,10 @@ pub struct CerebroConfig {
     /// http for loopback.
     #[serde(default)]
     pub scheme: Option<String>,
+    #[serde(default = "default_request_timeout_secs")]
+    pub request_timeout_secs: u64,
+    #[serde(default = "default_max_concurrent_mcp_requests")]
+    pub max_concurrent_mcp_requests: usize,
     #[serde(default)]
     pub storage_mode: StorageMode,
     #[serde(default)]
@@ -132,6 +136,14 @@ fn default_host() -> String {
 
 fn default_port() -> u16 {
     4040
+}
+
+fn default_request_timeout_secs() -> u64 {
+    30
+}
+
+fn default_max_concurrent_mcp_requests() -> usize {
+    32
 }
 
 fn default_surreal_namespace() -> String {
@@ -209,6 +221,8 @@ impl Default for CerebroConfig {
             auth_token: None,
             audit_token: None,
             scheme: None,
+            request_timeout_secs: default_request_timeout_secs(),
+            max_concurrent_mcp_requests: default_max_concurrent_mcp_requests(),
             storage_mode: StorageMode::default(),
             storage_fallback: StorageFallback::default(),
             storage_path: None,
@@ -312,6 +326,18 @@ impl CerebroConfig {
 
     pub fn validate_startup_requirements(&self) -> Result<(), crate::errors::CerebroError> {
         self.validate_storage()?;
+
+        if self.request_timeout_secs == 0 {
+            return Err(crate::errors::CerebroError::Validation(
+                "request_timeout_secs must be greater than zero".to_string(),
+            ));
+        }
+
+        if self.max_concurrent_mcp_requests == 0 {
+            return Err(crate::errors::CerebroError::Validation(
+                "max_concurrent_mcp_requests must be greater than zero".to_string(),
+            ));
+        }
 
         let auth_is_present = self.auth_token.is_some();
 

--- a/clients/cerebro/src/server.rs
+++ b/clients/cerebro/src/server.rs
@@ -1,10 +1,11 @@
 use crate::config::CerebroConfig;
-use crate::errors::{CerebroError, CerebroErrorResponse};
+use crate::errors::{CerebroError, CerebroErrorCode, CerebroErrorResponse};
 use crate::metrics;
 use crate::storage::{storage_from_config, Storage};
 use crate::tools::{CerebroTools, DEFERRED_TOOL_NAMES, IMPLEMENTED_TOOL_NAMES};
 use crate::tui::event_bus::{EventBus, ToolCallEvent, ToolCallEventKind};
 use crate::tui::redaction::RedactionPolicy;
+use axum::error_handling::HandleErrorLayer;
 use axum::extract::{DefaultBodyLimit, State};
 use axum::http::header::CONTENT_TYPE;
 use axum::http::HeaderMap;
@@ -18,8 +19,11 @@ use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use subtle::ConstantTimeEq;
+use tokio::sync::Semaphore;
+use tower::timeout::TimeoutLayer;
+use tower::ServiceBuilder;
 use tracing::Instrument;
 
 #[derive(Debug, Deserialize)]
@@ -95,6 +99,7 @@ pub struct CerebroService {
     tools: CerebroTools,
     event_bus: EventBus,
     redaction: RedactionPolicy,
+    mcp_concurrency: Arc<Semaphore>,
 }
 
 impl CerebroService {
@@ -103,12 +108,14 @@ impl CerebroService {
         let event_bus = EventBus::new(config.tui.event_buffer);
         let redaction = RedactionPolicy::from_config(&config.tui);
         let tools = CerebroTools::new(storage.clone());
+        let mcp_concurrency = Arc::new(Semaphore::new(config.max_concurrent_mcp_requests));
         Self {
             config,
             storage,
             tools,
             event_bus,
             redaction,
+            mcp_concurrency,
         }
     }
 
@@ -118,12 +125,22 @@ impl CerebroService {
     }
 
     pub fn router(self: Arc<Self>) -> Router {
+        let mcp_layers = ServiceBuilder::new()
+            .layer(HandleErrorLayer::new(handle_mcp_layer_error))
+            .layer(TimeoutLayer::new(Duration::from_secs(
+                self.config.request_timeout_secs,
+            )))
+            .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_BYTES));
+
+        let mcp_router = Router::new()
+            .route("/mcp", post(handle_mcp))
+            .layer(mcp_layers);
+
         Router::new()
             .route("/healthz", get(handle_health))
             .route("/readyz", get(handle_ready))
             .route("/metrics", get(handle_metrics))
-            .route("/mcp", post(handle_mcp))
-            .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_BYTES))
+            .merge(mcp_router)
             .with_state(self)
     }
 
@@ -503,6 +520,15 @@ async fn handle_ready(State(service): State<Arc<CerebroService>>) -> (StatusCode
     }
 }
 
+async fn handle_mcp_layer_error(error: Box<dyn std::error::Error + Send + Sync>) -> Response {
+    if error.is::<tower::timeout::error::Elapsed>() {
+        return (StatusCode::REQUEST_TIMEOUT, "request timed out").into_response();
+    }
+
+    tracing::warn!(error = %error, "mcp middleware rejected request");
+    (StatusCode::SERVICE_UNAVAILABLE, "service unavailable").into_response()
+}
+
 async fn handle_metrics() -> Response {
     let encoder = TextEncoder::new();
     let metric_families = prometheus::gather();
@@ -530,11 +556,45 @@ async fn handle_metrics() -> Response {
     }
 }
 
+#[cfg(debug_assertions)]
+async fn maybe_apply_test_delay(headers: &HeaderMap) {
+    let Some(delay_ms) = headers
+        .get("x-cerebro-test-delay-ms")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+    else {
+        return;
+    };
+
+    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+}
+
+#[cfg(not(debug_assertions))]
+async fn maybe_apply_test_delay(_headers: &HeaderMap) {}
+
 async fn handle_mcp(
     State(service): State<Arc<CerebroService>>,
     headers: HeaderMap,
     Json(request): Json<JsonRpcRequest>,
 ) -> (StatusCode, Json<JsonRpcResponse>) {
+    let Ok(_permit) = service.mcp_concurrency.clone().try_acquire_owned() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id: request.id,
+                result: None,
+                error: Some(JsonRpcError {
+                    code: CerebroErrorCode::Internal.as_i64(),
+                    message: "mcp concurrency limit exceeded".to_string(),
+                    data: None,
+                }),
+            }),
+        );
+    };
+
+    maybe_apply_test_delay(&headers).await;
+
     let auth_header = headers
         .get("authorization")
         .and_then(|value| value.to_str().ok());

--- a/clients/cerebro/tests/config_load_test.rs
+++ b/clients/cerebro/tests/config_load_test.rs
@@ -41,3 +41,39 @@ password = "secret"
         Some("secret")
     );
 }
+
+#[test]
+fn server_abuse_control_defaults_are_production_safe() {
+    let config = CerebroConfig::default();
+
+    assert_eq!(config.request_timeout_secs, 30);
+    assert_eq!(config.max_concurrent_mcp_requests, 32);
+}
+
+#[test]
+fn loads_server_abuse_control_config_from_toml() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("cerebro.toml");
+    fs::write(
+        &path,
+        r#"
+host = "127.0.0.1"
+port = 5050
+request_timeout_secs = 45
+max_concurrent_mcp_requests = 8
+auth_token = "top-secret"
+
+[surreal]
+namespace = "cerebro"
+database = "cerebro"
+username = "root"
+password = "secret"
+"#,
+    )
+    .expect("write config");
+
+    let config = CerebroConfig::load(Some(&path)).expect("toml config should load");
+
+    assert_eq!(config.request_timeout_secs, 45);
+    assert_eq!(config.max_concurrent_mcp_requests, 8);
+}

--- a/clients/cerebro/tests/http_limits_test.rs
+++ b/clients/cerebro/tests/http_limits_test.rs
@@ -36,3 +36,81 @@ async fn mcp_rejects_oversized_request_body() {
 
     assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
 }
+
+#[tokio::test]
+async fn mcp_times_out_slow_request() {
+    let config = CerebroConfig {
+        auth_token: Some(SecretString::new("secret".to_string().into_boxed_str())),
+        storage_mode: StorageMode::InMemory,
+        request_timeout_secs: 1,
+        ..Default::default()
+    };
+    let service = Arc::new(CerebroService::new(config, InMemoryStorage::new()));
+    let app = service.router();
+
+    let body = r#"{"jsonrpc":"2.0","id":"1","method":"tools/list"}"#;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer secret")
+                .header("x-cerebro-test-delay-ms", "1500")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+}
+
+#[tokio::test]
+async fn mcp_rejects_when_concurrency_limit_is_exhausted() {
+    let config = CerebroConfig {
+        auth_token: Some(SecretString::new("secret".to_string().into_boxed_str())),
+        storage_mode: StorageMode::InMemory,
+        request_timeout_secs: 5,
+        max_concurrent_mcp_requests: 1,
+        ..Default::default()
+    };
+    let service = Arc::new(CerebroService::new(config, InMemoryStorage::new()));
+    let app = service.router();
+
+    let body = r#"{"jsonrpc":"2.0","id":"1","method":"tools/list"}"#;
+
+    let first = tokio::spawn(
+        app.clone().oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer secret")
+                .header("x-cerebro-test-delay-ms", "300")
+                .body(Body::from(body))
+                .unwrap(),
+        ),
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let second_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer secret")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let first_response = first.await.unwrap().unwrap();
+
+    assert_eq!(first_response.status(), StatusCode::OK);
+    assert_eq!(second_response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}

--- a/clients/cerebro/tests/http_limits_test.rs
+++ b/clients/cerebro/tests/http_limits_test.rs
@@ -1,9 +1,66 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use cerebro::{CerebroConfig, CerebroService, InMemoryStorage, StorageMode};
+use cerebro::{
+    CerebroConfig, CerebroError, CerebroService, InMemoryStorage, MemoryRecord, Storage,
+    StorageMode,
+};
 use secrecy::SecretString;
+use std::any::Any;
 use std::sync::Arc;
+use tokio::sync::{Barrier, Notify};
 use tower::util::ServiceExt;
+
+#[derive(Debug)]
+struct BlockingCountStorage {
+    entered: Notify,
+    release: Notify,
+}
+
+#[async_trait::async_trait]
+impl Storage for BlockingCountStorage {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn save(&self, _record: MemoryRecord) -> Result<(), CerebroError> {
+        Ok(())
+    }
+
+    async fn get(&self, _memory_id: &str) -> Result<Option<MemoryRecord>, CerebroError> {
+        Ok(None)
+    }
+
+    async fn delete(&self, _memory_id: &str, _hard_delete: bool) -> Result<bool, CerebroError> {
+        Ok(false)
+    }
+
+    async fn search(
+        &self,
+        _query: &str,
+        _limit: usize,
+        _include_deleted: bool,
+        _scope: Option<&str>,
+        _topic_key: Option<&str>,
+    ) -> Result<Vec<MemoryRecord>, CerebroError> {
+        Ok(Vec::new())
+    }
+
+    async fn timeline(
+        &self,
+        _memory_id: &str,
+        _before: usize,
+        _after: usize,
+        _include_deleted: bool,
+    ) -> Result<Vec<MemoryRecord>, CerebroError> {
+        Ok(Vec::new())
+    }
+
+    async fn count(&self) -> Result<usize, CerebroError> {
+        self.entered.notify_one();
+        self.release.notified().await;
+        Ok(0)
+    }
+}
 
 #[tokio::test]
 async fn mcp_rejects_oversized_request_body() {
@@ -76,25 +133,35 @@ async fn mcp_rejects_when_concurrency_limit_is_exhausted() {
         max_concurrent_mcp_requests: 1,
         ..Default::default()
     };
-    let service = Arc::new(CerebroService::new(config, InMemoryStorage::new()));
+    let storage = Arc::new(BlockingCountStorage {
+        entered: Notify::new(),
+        release: Notify::new(),
+    });
+    let service = Arc::new(CerebroService::new(config, storage.clone()));
     let app = service.router();
 
-    let body = r#"{"jsonrpc":"2.0","id":"1","method":"tools/list"}"#;
+    let body = r#"{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"mem_stats","arguments":{}}}"#;
+    let first_request_started = Arc::new(Barrier::new(2));
+    let first_app = app.clone();
+    let first_request_started_task = first_request_started.clone();
 
-    let first = tokio::spawn(
-        app.clone().oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/mcp")
-                .header("content-type", "application/json")
-                .header("authorization", "Bearer secret")
-                .header("x-cerebro-test-delay-ms", "300")
-                .body(Body::from(body))
-                .unwrap(),
-        ),
-    );
+    let first = tokio::spawn(async move {
+        first_request_started_task.wait().await;
+        first_app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mcp")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer secret")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+    });
 
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    first_request_started.wait().await;
+    storage.entered.notified().await;
 
     let second_response = app
         .oneshot(
@@ -109,6 +176,7 @@ async fn mcp_rejects_when_concurrency_limit_is_exhausted() {
         .await
         .unwrap();
 
+    storage.release.notify_one();
     let first_response = first.await.unwrap().unwrap();
 
     assert_eq!(first_response.status(), StatusCode::OK);

--- a/clients/cerebro/tests/storage_config_test.rs
+++ b/clients/cerebro/tests/storage_config_test.rs
@@ -164,6 +164,34 @@ fn startup_validation_allows_loopback_without_auth_token_for_local_dev() {
 }
 
 #[test]
+fn startup_validation_rejects_zero_request_timeout() {
+    let mut config = base_config();
+    config.request_timeout_secs = 0;
+
+    let error = config
+        .validate_startup_requirements()
+        .expect_err("startup validation should fail");
+
+    assert!(error
+        .to_string()
+        .contains("request_timeout_secs must be greater than zero"));
+}
+
+#[test]
+fn startup_validation_rejects_zero_mcp_concurrency_limit() {
+    let mut config = base_config();
+    config.max_concurrent_mcp_requests = 0;
+
+    let error = config
+        .validate_startup_requirements()
+        .expect_err("startup validation should fail");
+
+    assert!(error
+        .to_string()
+        .contains("max_concurrent_mcp_requests must be greater than zero"));
+}
+
+#[test]
 fn startup_validation_allows_non_loopback_with_real_auth_token() {
     let mut config = base_config();
     config.host = "0.0.0.0".to_string();

--- a/clients/web/apps/docs/src/content/docs/cerebro/configuration.md
+++ b/clients/web/apps/docs/src/content/docs/cerebro/configuration.md
@@ -31,6 +31,8 @@ Supported formats: `.toml` and `.json`.
 host = "127.0.0.1"       # Bind address (default: 127.0.0.1)
 port = 4040               # Bind port (default: 4040)
 scheme = "http"            # URL scheme override (auto-detected)
+request_timeout_secs = 30  # MCP request timeout (default: 30)
+max_concurrent_mcp_requests = 32  # MCP concurrency cap (default: 32)
 
 # Authentication
 # auth_token = "..."      # Set via CEREBRO_AUTH_TOKEN env var
@@ -71,14 +73,18 @@ redact_fields = [
 
 ## Server Settings
 
-| Field    | Type   | Default       | Description                      |
-|----------|--------|---------------|----------------------------------|
-| `host`   | String | `127.0.0.1`   | Bind address                     |
-| `port`   | u16    | `4040`        | Bind port                        |
-| `scheme` | String | auto-detected | `http` for loopback, else `https`|
+| Field                         | Type   | Default       | Description                                      |
+|-------------------------------|--------|---------------|--------------------------------------------------|
+| `host`                        | String | `127.0.0.1`   | Bind address                                     |
+| `port`                        | u16    | `4040`        | Bind port                                        |
+| `scheme`                      | String | auto-detected | `http` for loopback, else `https`                |
+| `request_timeout_secs`        | u64    | `30`          | Timeout for `POST /mcp` request processing       |
+| `max_concurrent_mcp_requests` | usize  | `32`          | Maximum concurrent in-flight `POST /mcp` calls   |
 
 The MCP endpoint is available at
 `{scheme}://{host}:{port}/mcp`.
+
+The timeout and concurrency settings apply only to `POST /mcp`. Health, readiness, and metrics endpoints remain available during MCP saturation so operators can inspect process health.
 
 ## Storage Modes
 

--- a/clients/web/apps/docs/src/content/docs/cerebro/operations.md
+++ b/clients/web/apps/docs/src/content/docs/cerebro/operations.md
@@ -18,6 +18,10 @@ troubleshooting.
 
 ## Production Abuse Controls
 
+:::note[Translation pending]
+The Spanish counterpart for **Production Abuse Controls** is not yet available. Keep this section reconciled when ES documentation parity is restored.
+:::
+
 Cerebro uses layered abuse controls. The service self-protects the MCP path, while production ingress owns request-frequency rate limiting.
 
 Recommended starting defaults:

--- a/clients/web/apps/docs/src/content/docs/cerebro/operations.md
+++ b/clients/web/apps/docs/src/content/docs/cerebro/operations.md
@@ -16,6 +16,21 @@ This page covers day-2 operations for running Cerebro in
 production: storage management, monitoring, backup, and
 troubleshooting.
 
+## Production Abuse Controls
+
+Cerebro uses layered abuse controls. The service self-protects the MCP path, while production ingress owns request-frequency rate limiting.
+
+Recommended starting defaults:
+
+| Control | Recommended default | Owner | Notes |
+|---------|---------------------|-------|-------|
+| MCP body size | `1 MiB` | Cerebro | Built in; oversized requests return `413 Payload Too Large`. |
+| MCP timeout | `request_timeout_secs = 30` | Cerebro | Tune upward only for known slow storage or long-running tools. |
+| MCP concurrency | `max_concurrent_mcp_requests = 32` | Cerebro | Tune based on CPU, memory, and storage saturation. |
+| Rate limiting | `60 requests/minute` per trusted client with burst controls | Ingress | Use source IP, mTLS identity, or authenticated gateway principal. |
+
+Do not expose Cerebro directly to the internet. For non-loopback deployments, put Cerebro behind TLS-capable ingress, set `CEREBRO_AUTH_TOKEN`, keep request body limits enabled, and configure ingress rate limiting. Cerebro does not implement in-process per-IP or per-token rate limiting because trustworthy client identity is established at ingress, not inside the service.
+
 ## Storage Modes
 
 Cerebro's supported durable production posture in this build is single-node and local-first.

--- a/openspec/specs/client-surfaces/gateway-api.md
+++ b/openspec/specs/client-surfaces/gateway-api.md
@@ -1,5 +1,37 @@
 # Gateway API Specification
 
-> **Status:** TBD — This specification has not been written yet.
+> **Status:** Active
 
-See `clients/agent-runtime/src/gateway/mod.rs` for the current implementation.
+This specification records client-surface and ingress expectations for HTTP gateway-style entrypoints in Corvus.
+
+## Cerebro MCP HTTP Surface
+
+### Requirement: Cerebro MCP requests are process-bounded
+
+Cerebro MUST protect `POST /mcp` with service-local controls that do not depend on external client identity:
+
+- request body limit: `1 MiB`,
+- request timeout: default `30s`, configurable with `request_timeout_secs`,
+- in-flight concurrency cap: default `32`, configurable with `max_concurrent_mcp_requests`.
+
+Health, readiness, and metrics endpoints MUST remain outside the MCP concurrency cap so operators can inspect service health during MCP saturation.
+
+#### Scenario: Slow MCP request exceeds timeout
+
+- Given Cerebro is running with `request_timeout_secs = 30`
+- When a `POST /mcp` request takes longer than 30 seconds to process
+- Then Cerebro returns `408 Request Timeout` or the deployment-equivalent timeout response
+- And the request does not continue consuming MCP handler capacity indefinitely
+
+#### Scenario: MCP concurrency is exhausted
+
+- Given Cerebro is running with `max_concurrent_mcp_requests = 32`
+- When more than 32 MCP requests are in flight
+- Then excess MCP requests are rejected or shed with `503 Service Unavailable` or the deployment-equivalent overload response
+- And `/healthz`, `/readyz`, and `/metrics` remain reachable
+
+### Requirement: Exposed deployments rate-limit at ingress
+
+Cerebro does not own request-frequency rate limiting inside the service. Production deployments that expose Cerebro beyond loopback MUST enforce rate limiting at ingress using a trusted client key such as source IP, mTLS identity, or authenticated gateway principal.
+
+Recommended baseline: `60 requests/minute` per trusted client with burst controls, tuned for known automation workloads.

--- a/openspec/specs/client-surfaces/gateway-api.md
+++ b/openspec/specs/client-surfaces/gateway-api.md
@@ -32,6 +32,6 @@ Health, readiness, and metrics endpoints MUST remain outside the MCP concurrency
 
 ### Requirement: Exposed deployments rate-limit at ingress
 
-Cerebro does not own request-frequency rate limiting inside the service. Production deployments that expose Cerebro beyond loopback MUST enforce rate limiting at ingress using a trusted client key such as source IP, mTLS identity, or authenticated gateway principal.
+Cerebro does not own request-frequency rate limiting inside the service. Production deployments that expose Cerebro beyond loopback MUST enforce rate limiting at ingress using a trusted client key such as source IP, mTLS identity, or authenticated gateway principal. Source-IP keys are acceptable only when ingress is the sole trusted hop and strips or validates `X-Forwarded-For` and other forwarding headers; otherwise, prefer non-spoofable identities such as mTLS identity or an authenticated gateway principal in production.
 
 Recommended baseline: `60 requests/minute` per trusted client with burst controls, tuned for known automation workloads.


### PR DESCRIPTION
## Related Issues

Fixes #697

---

## Summary

Adds Cerebro MCP abuse controls for production deployments:

- Adds configurable `request_timeout_secs` and `max_concurrent_mcp_requests` server settings with safe defaults.
- Bounds `POST /mcp` with request timeout and in-flight concurrency protection while keeping health/readiness/metrics reachable during MCP saturation.
- Documents the chosen strategy: Cerebro owns body limit, timeout, and concurrency; ingress owns request-frequency rate limiting.

---

## Tested Information

Verified locally with:

- `cargo fmt --manifest-path "clients/cerebro/Cargo.toml" --all -- --check`
- `cargo test --manifest-path "clients/cerebro/Cargo.toml" --test config_load_test --test storage_config_test --test http_limits_test`
- `cargo test --manifest-path "clients/cerebro/Cargo.toml"`
- `cargo clippy --manifest-path "clients/cerebro/Cargo.toml" --all-targets -- -D warnings`
- `make docs-check`

---

## Documentation Impact

- Docs updated in:
  - `clients/web/apps/docs/src/content/docs/cerebro/configuration.md`
  - `clients/web/apps/docs/src/content/docs/cerebro/operations.md`
  - `openspec/specs/client-surfaces/gateway-api.md`
- I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
