### PR TITLE
fix(ci): guard release component outputs

### DIFF
--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -95,12 +95,33 @@ jobs:
 
           with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
               for key, value in flags.items():
-                  output.write(f"{key}={'true' if value else 'false'}\\n")
+                  output.write(f"{key}={'true' if value else 'false'}\n")
 
           with pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as summary:
               summary.write("### Resolved affected components\n\n")
               summary.write(f"- Raw payload: `{payload['raw_payload']}`\n")
               summary.write(f"- Resolved affected components: `{', '.join(payload['affected_components'])}`\n")
+
+      - name: 🔎 Validate component flag outputs
+        shell: python
+        env:
+          COMPONENT_FLAG_OUTPUTS: |
+            has_corvus_runtime=${{ steps.component-flags.outputs.has_corvus_runtime }}
+            has_rook=${{ steps.component-flags.outputs.has_rook }}
+            has_cerebro=${{ steps.component-flags.outputs.has_cerebro }}
+            has_gradle_kmp=${{ steps.component-flags.outputs.has_gradle_kmp }}
+        run: |
+          import os
+
+          raw_outputs = os.environ["COMPONENT_FLAG_OUTPUTS"].splitlines()
+          for raw_output in raw_outputs:
+              key, separator, value = raw_output.partition("=")
+              if not separator:
+                  raise SystemExit(f"Invalid component flag output entry: {raw_output!r}")
+              if value not in {"true", "false"}:
+                  raise SystemExit(
+                      f"Invalid component flag output {key}: expected 'true' or 'false', got {value!r}",
+                  )
 
       - name: 🦀 Resolve Rust channel
         if: ${{ inputs.release }}

--- a/scripts/release-contract.test.mjs
+++ b/scripts/release-contract.test.mjs
@@ -995,6 +995,27 @@ test("release workflows encode release-please-owned stable and beta governance",
     ],
     "publish workflow",
   );
+  assert.doesNotMatch(
+    publishWorkflow,
+    /output\.write\(f"\{key\}=\{'true' if value else 'false'\}\\\\n"\)/,
+    "component flag outputs must use real newlines, not literal \\n text",
+  );
+
+  assertIncludesAll(
+    publishWorkflow,
+    [
+      /Validate component flag outputs/,
+      /COMPONENT_FLAG_OUTPUTS:/,
+      /has_corvus_runtime=\$\{\{ steps\.component-flags\.outputs\.has_corvus_runtime \}\}/,
+      /has_rook=\$\{\{ steps\.component-flags\.outputs\.has_rook \}\}/,
+      /has_cerebro=\$\{\{ steps\.component-flags\.outputs\.has_cerebro \}\}/,
+      /has_gradle_kmp=\$\{\{ steps\.component-flags\.outputs\.has_gradle_kmp \}\}/,
+      /value not in \{"true", "false"\}/,
+      /Invalid component flag output/,
+    ],
+    "publish workflow component flag output guardrail",
+  );
+
   assert.doesNotMatch(publishWorkflow, /known_components = \{/);
   assert.doesNotMatch(publishWorkflow, /const stableStringCollator/);
   assert.doesNotMatch(publishWorkflow, /Invalid \$\{channel\} release tag/);


### PR DESCRIPTION
## Related Issues

No issue linked.

---

## Summary

Fixes release workflow component flag output serialization so component-scoped downstream jobs receive clean boolean outputs. Adds a fail-fast guardrail that validates `has_corvus_runtime`, `has_rook`, `has_cerebro`, and `has_gradle_kmp` before Docker, binary, npm, or release asset jobs evaluate `needs.publish.outputs.*` gates.

This prevents a supported `cerebro` release from completing green while `build-cerebro-binaries` and `docker-image-cerebro` are silently skipped due to malformed `$GITHUB_OUTPUT` formatting.

---

## Tested Information

- `node --test scripts/release-contract.test.mjs`
  - Result: 54 tests passed, 0 failed.
- Verified the `build-cerebro-binaries` and `docker-image-cerebro` jobs still gate on `needs.publish.outputs.has_cerebro == 'true'`.

---

## Documentation Impact

- Docs updated in: none.
- No docs update required because this is a CI release workflow correctness fix covered by release contract tests.
- I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
