### PR TITLE
ci(cerebro): smoke test Docker image before publish

### DIFF
--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -710,6 +710,155 @@ jobs:
             type=raw,value=latest,enable=${{ needs.publish.outputs.release_channel == 'stable' }}
             type=raw,value=beta,enable=${{ needs.publish.outputs.release_channel == 'beta' }}
 
+      - name: 🧪 Build Cerebro Docker image for smoke test
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: clients/cerebro/Dockerfile.release-prebuilt
+          target: release
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: cerebro:smoke-${{ github.run_id }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
+
+      - name: 🧪 Smoke test Cerebro Docker image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image="cerebro:smoke-${{ github.run_id }}"
+          container="cerebro-smoke-${{ github.run_id }}"
+          host_port="4040"
+          smoke_dir="$RUNNER_TEMP/cerebro-smoke"
+          token="cerebro-smoke-token-${{ github.run_id }}"
+
+          rm -rf "$smoke_dir"
+          mkdir -p "$smoke_dir/data"
+
+          cat > "$smoke_dir/config.toml" <<'EOF'
+          host = "0.0.0.0"
+          port = 4040
+          storage_mode = "embedded_surreal"
+
+          [surreal]
+          namespace = "cerebro_smoke"
+          database = "cerebro_smoke"
+          username = "root"
+          password = "local-smoke-only"
+          EOF
+
+          cleanup() {
+            status=$?
+            echo "--- Cerebro smoke container logs ---"
+            docker logs "$container" 2>/dev/null || true
+            docker rm -f "$container" >/dev/null 2>&1 || true
+            exit "$status"
+          }
+          trap cleanup EXIT
+
+          docker rm -f "$container" >/dev/null 2>&1 || true
+          docker run \
+            --detach \
+            --name "$container" \
+            --env CEREBRO_AUTH_TOKEN="$token" \
+            --publish "127.0.0.1:${host_port}:4040" \
+            --mount "type=bind,source=${smoke_dir}/config.toml,target=/etc/cerebro/config.toml,readonly" \
+            --mount "type=bind,source=${smoke_dir}/data,target=/cerebro-data" \
+            "$image"
+
+          assert_container_running() {
+            if ! docker inspect -f '{{.State.Running}}' "$container" | grep -q '^true$'; then
+              echo "Cerebro smoke container exited unexpectedly"
+              exit 1
+            fi
+          }
+
+          wait_for_json_status() {
+            local path="$1"
+            local expected_status="$2"
+            local response_file="$smoke_dir/response.json"
+            local code
+
+            for attempt in $(seq 1 30); do
+              assert_container_running
+              code=$(curl --silent --show-error --output "$response_file" --write-out '%{http_code}' "http://127.0.0.1:${host_port}${path}" || true)
+              if [[ "$code" == "200" ]] && python3 - "$response_file" "$expected_status" <<'PY'
+          import json
+          import sys
+
+          path, expected = sys.argv[1], sys.argv[2]
+          with open(path, "r", encoding="utf-8") as handle:
+              payload = json.load(handle)
+          if payload.get("status") != expected:
+              raise SystemExit(1)
+          PY
+              then
+                return 0
+              fi
+              echo "Waiting for ${path} to report ${expected_status}; attempt ${attempt}/30 returned HTTP ${code}"
+              sleep 1
+            done
+
+            echo "Timed out waiting for ${path} to report ${expected_status}"
+            echo "Last response body:"
+            cat "$response_file" || true
+            exit 1
+          }
+
+          post_mcp() {
+            local response_file="$1"
+            shift
+            curl --silent --show-error --output "$response_file" --write-out '%{http_code}' \
+              --request POST \
+              --header 'Content-Type: application/json' \
+              "$@" \
+              --data '{"jsonrpc":"2.0","id":"smoke-tools-list","method":"tools/list"}' \
+              "http://127.0.0.1:${host_port}/mcp"
+          }
+
+          wait_for_json_status "/healthz" "ok"
+          wait_for_json_status "/readyz" "ready"
+
+          unauth_response="$smoke_dir/mcp-unauth.json"
+          unauth_code=$(post_mcp "$unauth_response")
+          if [[ "$unauth_code" != "401" ]]; then
+            echo "Expected unauthenticated MCP request to return HTTP 401, got ${unauth_code}"
+            cat "$unauth_response" || true
+            exit 1
+          fi
+          python3 - "$unauth_response" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], "r", encoding="utf-8") as handle:
+              payload = json.load(handle)
+          error = payload.get("error") or {}
+          if error.get("code") != -32001:
+              raise SystemExit(f"expected auth error code -32001, got {error!r}")
+          PY
+
+          auth_response="$smoke_dir/mcp-auth.json"
+          auth_code=$(post_mcp "$auth_response" --header "Authorization: Bearer ${token}")
+          if [[ "$auth_code" != "200" ]]; then
+            echo "Expected authenticated MCP request to return HTTP 200, got ${auth_code}"
+            cat "$auth_response" || true
+            exit 1
+          fi
+          python3 - "$auth_response" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], "r", encoding="utf-8") as handle:
+              payload = json.load(handle)
+          if payload.get("error") is not None:
+              raise SystemExit(f"expected no MCP error, got {payload['error']!r}")
+          if "result" not in payload:
+              raise SystemExit(f"expected MCP result in payload, got {payload!r}")
+          PY
+
+          echo "Cerebro Docker image smoke test passed"
+
       - name: 🐳 Build and push Cerebro Docker image
         continue-on-error: true
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -19,5 +19,5 @@ clients/androidApp/src/main/AndroidManifest.xml
 # Pinning is not always appropriate and can break certificate rotation
 clients/iosApp/iosApp/Info.plist
 
-# False positive: Insecure WebSocket in test validating rejection of ws://
+# False positive: Insecure WebSocket in test validating rejection of insecure protocol
 clients/agent-runtime/tests/mcp_config_validation.rs

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,23 @@
+# Semgrep ignore patterns for Corvus monorepo
+# See: https://semgrep.dev/docs/ignoring-files-folders-code/
+
+# False positive: PGP header examples in documentation (not real keys)
+clients/web/apps/docs/src/content/docs/*/guides/gpg-setup.md
+clients/web/apps/docs/src/content/docs/guides/gpg-setup.md
+
+# False positive: Mustache unescaping in OpenAPI generator templates
+# These are code generation templates, not runtime XSS vectors
+gradle/configs/openapi/scripts/**/*.mustache
+
+# False positive: SonarQube workflow uses secrets.SONAR_TOKEN, not hardcoded
+.github/workflows/sonarqube-analysis.yml
+
+# False positive: Android launcher activity requires exported=true for Android 12+
+clients/androidApp/src/main/AndroidManifest.xml
+
+# False positive: iOS ATS pinning recommendation (not a vulnerability)
+# Pinning is not always appropriate and can break certificate rotation
+clients/iosApp/iosApp/Info.plist
+
+# False positive: Insecure WebSocket in test validating rejection of ws://
+clients/agent-runtime/tests/mcp_config_validation.rs

--- a/clients/agent-runtime/examples/custom_tool.rs
+++ b/clients/agent-runtime/examples/custom_tool.rs
@@ -80,7 +80,8 @@ impl Tool for HttpGetTool {
         }
 
         // Host is restricted to ALLOWED_HOSTS above; Semgrep does not model that allowlist guard.
-        match reqwest::get(parsed_url).await { // nosemgrep: rust.actix.ssrf.reqwest-taint.reqwest-taint
+        match reqwest::get(parsed_url).await {
+            // nosemgrep: rust.actix.ssrf.reqwest-taint.reqwest-taint
             Ok(resp) => {
                 let status = resp.status().as_u16();
                 let len = resp.content_length().unwrap_or(0);

--- a/clients/agent-runtime/examples/custom_tool.rs
+++ b/clients/agent-runtime/examples/custom_tool.rs
@@ -6,6 +6,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::{json, Value};
+use url::Url;
 
 /// Mirrors src/tools/traits.rs
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -22,6 +23,8 @@ pub trait Tool: Send + Sync {
     fn parameters_schema(&self) -> Value;
     async fn execute(&self, args: Value) -> Result<ToolResult>;
 }
+
+const ALLOWED_HOSTS: &[&str] = &["api.github.com", "example.com"];
 
 /// Example: A tool that fetches a URL and returns the status code
 pub struct HttpGetTool;
@@ -50,8 +53,34 @@ impl Tool for HttpGetTool {
         let url = args["url"]
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Missing 'url' parameter"))?;
+        let parsed_url = Url::parse(url).map_err(|_| anyhow::anyhow!("Invalid URL"))?;
 
-        match reqwest::get(url).await {
+        if !matches!(parsed_url.scheme(), "http" | "https") {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("Only HTTP and HTTPS URLs are supported".to_string()),
+            });
+        }
+
+        let Some(host) = parsed_url.host_str() else {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("URL must include a host".to_string()),
+            });
+        };
+
+        if !ALLOWED_HOSTS.contains(&host) {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Host {host} is not in the example allowlist")),
+            });
+        }
+
+        // Host is restricted to ALLOWED_HOSTS above; Semgrep does not model that allowlist guard.
+        match reqwest::get(parsed_url).await { // nosemgrep: rust.actix.ssrf.reqwest-taint.reqwest-taint
             Ok(resp) => {
                 let status = resp.status().as_u16();
                 let len = resp.content_length().unwrap_or(0);

--- a/scripts/resolve-release-context.mjs
+++ b/scripts/resolve-release-context.mjs
@@ -32,23 +32,38 @@ function parseAffectedComponentsOverride(affectedComponentsRaw, graph) {
   return sortStrings([...new Set(parsed)]);
 }
 
+function parseVersionSuffix(versionSuffix) {
+  const match = /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta\.([0-9]+))?$/.exec(versionSuffix);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, major, minor, patch, betaNumber] = match;
+  return {
+    major,
+    minor,
+    patch,
+    betaNumber,
+    version: betaNumber ? `${major}.${minor}.${patch}-beta.${betaNumber}` : `${major}.${minor}.${patch}`,
+    channel: betaNumber ? "beta" : "stable",
+  };
+}
+
 function parseComponentReleaseTag(releaseTag, publishableComponents) {
   for (const componentId of publishableComponents) {
-    const escapedComponentId = componentId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const match = new RegExp(`^${escapedComponentId}-v([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-beta\\.([0-9]+))?$`).exec(
-      releaseTag,
-    );
+    const prefix = `${componentId}-v`;
 
-    if (match) {
-      const [, major, minor, patch, betaNumber] = match;
+    if (!releaseTag.startsWith(prefix)) {
+      continue;
+    }
+
+    const parsedVersion = parseVersionSuffix(releaseTag.slice(prefix.length));
+
+    if (parsedVersion) {
       return {
         componentId,
-        major,
-        minor,
-        patch,
-        betaNumber,
-        version: betaNumber ? `${major}.${minor}.${patch}-beta.${betaNumber}` : `${major}.${minor}.${patch}`,
-        channel: betaNumber ? "beta" : "stable",
+        ...parsedVersion,
       };
     }
   }

--- a/scripts/validate-docs-metadata.mjs
+++ b/scripts/validate-docs-metadata.mjs
@@ -149,9 +149,12 @@ function extractFrontmatter(contents) {
 }
 
 function getField(frontmatter, fieldName) {
-  const regex = new RegExp(String.raw`^${fieldName}:\s*(.+)$`, "m");
-  const match = frontmatter.match(regex);
-  return match ? match[1].trim().replaceAll(/^['"]|['"]$/g, "") : "";
+  const prefix = `${fieldName}:`;
+  const line = frontmatter
+    .split("\n")
+    .find((candidate) => candidate.startsWith(prefix));
+
+  return line ? line.slice(prefix.length).trim().replaceAll(/^['"]|['"]$/g, "") : "";
 }
 
 function getMetadata(filePath) {


### PR DESCRIPTION
## Related Issues

Fixes #693

---

## Summary

Adds a required Cerebro Docker image smoke gate before the release publish step.

- Builds the release-prebuilt Cerebro image locally for `linux/amd64` with `load: true`.
- Runs the container with explicit CI-only config and `CEREBRO_AUTH_TOKEN`.
- Verifies `/healthz`, `/readyz`, unauthenticated MCP rejection, and authenticated MCP success before multi-arch publish proceeds.

---

## Tested Information

- `git diff --check -- .github/workflows/_publish.yml`
- Workflow structural validation fallback because PyYAML is not installed locally.
- Explicit ordering validation confirmed smoke build < smoke run < publish and no smoke step uses `continue-on-error`.
- Commit hook ran the repository's lychee offline check on staged workflow/config files and passed.

---

## Documentation Impact

- Docs updated in:
- No docs update required because this changes CI release validation only and does not change Cerebro runtime behavior, setup, user-facing APIs, or operations contracts.
- I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).