### PR TITLE
docs(cerebro): add production alerting guidance

### DIFF
--- a/clients/cerebro/README.md
+++ b/clients/cerebro/README.md
@@ -113,4 +113,14 @@ Cerebro also exposes Prometheus-compatible operational metrics at `GET /metrics`
 | `cerebro_readiness_failures_total` | counter | none | Readiness probe failures returned by `/readyz`. |
 | `cerebro_storage_errors_total` | counter | `operation` | Storage-layer errors by operation (`save`, `get`, `search`, `delete`, `timeline`, `count`, or `unknown`). |
 
-Production deployments should forward tracing logs and scrape `/metrics`; alert on repeated readiness failures, authorization failures, storage errors, and elevated tool latency.
+Production deployments should forward tracing logs and scrape `/metrics`; alert on repeated readiness failures, authorization failures, storage errors, elevated server-side error rates, and elevated tool latency. For internal production deployments, use these starting thresholds and tune them against the observed baseline:
+
+| Alert | Metric/log signal | Example threshold |
+| --- | --- | --- |
+| Repeated readiness failures | `cerebro_readiness_failures_total` plus failed `/readyz` probes | `>= 3` failures in 5 minutes or readiness success rate `< 95%` for 5 minutes |
+| Unusual auth failures | `cerebro_auth_failures_total` and `cerebro_requests_total{status="unauthorized"}`; enrich with ingress logs | `> 20` failures in 10 minutes or `> 5x` the 24-hour baseline |
+| Elevated server-side error rate | `cerebro_requests_total` with `status` matching storage or internal errors, divided by all MCP requests | warn above `2%` for 10 minutes; page above `5%` for 5 minutes |
+| Storage error spike | `cerebro_storage_errors_total` by `operation` | `>= 5` errors for one operation in 5 minutes |
+| Latency spike | `histogram_quantile(0.95, rate(cerebro_tool_latency_seconds_bucket{status="ok"}[10m]))` by `tool` | warn above p95 `1s`; page above p95 `2s` for 10 minutes |
+
+Keep auth/validation alerts separate from server-side error-rate alerts so broken or abusive clients do not hide storage or internal failures.

--- a/clients/cerebro/README.md
+++ b/clients/cerebro/README.md
@@ -121,6 +121,6 @@ Production deployments should forward tracing logs and scrape `/metrics`; alert 
 | Unusual auth failures | `cerebro_auth_failures_total` and `cerebro_requests_total{status="unauthorized"}`; enrich with ingress logs | `> 20` failures in 10 minutes or `> 5x` the 24-hour baseline |
 | Elevated server-side error rate | `cerebro_requests_total` with `status` matching storage or internal errors, divided by all MCP requests | warn above `2%` for 10 minutes; page above `5%` for 5 minutes |
 | Storage error spike | `cerebro_storage_errors_total` by `operation` | `>= 5` errors for one operation in 5 minutes |
-| Latency spike | `histogram_quantile(0.95, rate(cerebro_tool_latency_seconds_bucket{status="ok"}[10m]))` by `tool` | warn above p95 `1s`; page above p95 `2s` for 10 minutes |
+| Latency spike | `histogram_quantile(0.95, sum by (le, tool) (rate(cerebro_tool_latency_seconds_bucket{status="ok"}[10m])))` | warn above p95 `1s`; page above p95 `2s` for 10 minutes |
 
 Keep auth/validation alerts separate from server-side error-rate alerts so broken or abusive clients do not hide storage or internal failures.

--- a/clients/web/apps/docs/src/content/docs/cerebro/operations.md
+++ b/clients/web/apps/docs/src/content/docs/cerebro/operations.md
@@ -210,7 +210,7 @@ Tune thresholds to each deployment's normal traffic, but internal production dep
 
 Example Prometheus expressions:
 
-```promql
+```text
 # Readiness degradation
 increase(cerebro_readiness_failures_total[5m]) >= 3
 

--- a/clients/web/apps/docs/src/content/docs/cerebro/operations.md
+++ b/clients/web/apps/docs/src/content/docs/cerebro/operations.md
@@ -182,6 +182,55 @@ RUST_LOG=cerebro=debug,surrealdb=warn cerebro serve
 RUST_LOG=cerebro=trace cerebro serve
 ```
 
+### Metrics
+
+Cerebro exposes Prometheus-compatible metrics at `GET /metrics`. Scrape this endpoint from private monitoring networks only; it is intentionally unauthenticated like `/healthz` and `/readyz`.
+
+| Metric | Type | Labels | Use for alerting |
+|--------|------|--------|------------------|
+| `cerebro_requests_total` | counter | `method`, `status` | MCP traffic volume and error rates by outcome. |
+| `cerebro_tool_latency_seconds` | histogram | `tool`, `status` | Tool latency percentiles and slow backend behavior. |
+| `cerebro_auth_failures_total` | counter | none | Missing or invalid bearer tokens on MCP requests. |
+| `cerebro_readiness_failures_total` | counter | none | `/readyz` failures, including storage connectivity failures. |
+| `cerebro_storage_errors_total` | counter | `operation` | Storage-layer failures by operation. |
+
+Structured logs include service startup/shutdown, MCP request lifecycle, tool execution outcome and latency, storage fallback warnings, and readiness/auth failure context. Use logs to enrich metric alerts with request paths, HTTP statuses, storage operation names, and deployment metadata.
+
+### Recommended Production Alerts
+
+Tune thresholds to each deployment's normal traffic, but internal production deployments should start with these alerts:
+
+| Alert | Signal | Example threshold | Page when | Notes |
+|-------|--------|-------------------|-----------|-------|
+| Repeated readiness failures | `increase(cerebro_readiness_failures_total[5m])` and failed `GET /readyz` probes | `>= 3` failures in 5 minutes or readiness probe success rate `< 95%` for 5 minutes | A production instance remains unready for 5 minutes, or two consecutive probe windows fail | Indicates storage connectivity or service dependency degradation. Correlate with storage fallback warnings and `cerebro_storage_errors_total`. |
+| Unusual auth failures | `increase(cerebro_auth_failures_total[10m])` or `cerebro_requests_total{status="unauthorized"}` | `> 20` failures in 10 minutes, or `> 5x` the 24-hour baseline | Sustained for 10 minutes, or any sudden spike on a private deployment | Detects broken clients, leaked endpoints, bad token rollout, or scanning. Pair with ingress logs keyed by trusted client identity. |
+| Elevated MCP error rate | `sum(rate(cerebro_requests_total{status=~"storage_error/internal_error"}[5m])) / sum(rate(cerebro_requests_total[5m]))` after replacing `/` with the regex alternation character in the status matcher | `> 2%` for 10 minutes; page at `> 5%` for 5 minutes | User-facing requests are likely failing or storage is degraded | Keep validation/auth errors separate from server-side error-rate alerts so noisy clients do not mask service regressions. |
+| Storage operation error spike | `increase(cerebro_storage_errors_total[5m])` | `>= 5` errors in 5 minutes for one operation | Any write/read path repeatedly fails | Break down by `operation` (`save`, `get`, `search`, `delete`, `timeline`, `count`, or `unknown`) to identify affected tools. |
+| Latency spike | `histogram_quantile(0.95, rate(cerebro_tool_latency_seconds_bucket{status="ok"}[10m]))` | p95 `> 2s` for 10 minutes; warn at p95 `> 1s` | Slow tools persist after expected workload spikes | Compare by `tool` label. For internal deployments with strict SLOs, use the tool's normal p95 plus 2x as the warning threshold. |
+
+Example Prometheus expressions:
+
+```promql
+# Readiness degradation
+increase(cerebro_readiness_failures_total[5m]) >= 3
+
+# Auth anomaly
+increase(cerebro_auth_failures_total[10m]) > 20
+
+# Server-side MCP error ratio
+sum(rate(cerebro_requests_total{status=~"storage_error|internal_error"}[5m]))
+  /
+sum(rate(cerebro_requests_total[5m])) > 0.02
+
+# p95 successful tool latency
+histogram_quantile(
+  0.95,
+  sum by (le, tool) (rate(cerebro_tool_latency_seconds_bucket{status="ok"}[10m]))
+) > 2
+```
+
+Route readiness and server-side error alerts to the on-call operator for the deployment. Route auth anomalies to both service owners and the team that owns ingress or token distribution. Use warning-only notifications for validation errors and forbidden attempts unless they correlate with elevated server-side errors or known abuse.
+
 ### Health Check
 
 Send a `mem_stats` call to verify the service is responsive:

--- a/clients/web/apps/docs/src/content/docs/cerebro/operations.md
+++ b/clients/web/apps/docs/src/content/docs/cerebro/operations.md
@@ -204,9 +204,9 @@ Tune thresholds to each deployment's normal traffic, but internal production dep
 |-------|--------|-------------------|-----------|-------|
 | Repeated readiness failures | `increase(cerebro_readiness_failures_total[5m])` and failed `GET /readyz` probes | `>= 3` failures in 5 minutes or readiness probe success rate `< 95%` for 5 minutes | A production instance remains unready for 5 minutes, or two consecutive probe windows fail | Indicates storage connectivity or service dependency degradation. Correlate with storage fallback warnings and `cerebro_storage_errors_total`. |
 | Unusual auth failures | `increase(cerebro_auth_failures_total[10m])` or `cerebro_requests_total{status="unauthorized"}` | `> 20` failures in 10 minutes, or `> 5x` the 24-hour baseline | Sustained for 10 minutes, or any sudden spike on a private deployment | Detects broken clients, leaked endpoints, bad token rollout, or scanning. Pair with ingress logs keyed by trusted client identity. |
-| Elevated MCP error rate | `sum(rate(cerebro_requests_total{status=~"storage_error/internal_error"}[5m])) / sum(rate(cerebro_requests_total[5m]))` after replacing `/` with the regex alternation character in the status matcher | `> 2%` for 10 minutes; page at `> 5%` for 5 minutes | User-facing requests are likely failing or storage is degraded | Keep validation/auth errors separate from server-side error-rate alerts so noisy clients do not mask service regressions. |
+| Elevated MCP error rate | <code>(sum(rate(cerebro_requests_total{status=~"storage_error&#124;internal_error"}[5m])) / sum(rate(cerebro_requests_total[5m])))</code> | `> 2%` for 10 minutes; page at `> 5%` for 5 minutes | User-facing requests are likely failing or storage is degraded | Keep validation/auth errors separate from server-side error-rate alerts so noisy clients do not mask service regressions. |
 | Storage operation error spike | `increase(cerebro_storage_errors_total[5m])` | `>= 5` errors in 5 minutes for one operation | Any write/read path repeatedly fails | Break down by `operation` (`save`, `get`, `search`, `delete`, `timeline`, `count`, or `unknown`) to identify affected tools. |
-| Latency spike | `histogram_quantile(0.95, rate(cerebro_tool_latency_seconds_bucket{status="ok"}[10m]))` | p95 `> 2s` for 10 minutes; warn at p95 `> 1s` | Slow tools persist after expected workload spikes | Compare by `tool` label. For internal deployments with strict SLOs, use the tool's normal p95 plus 2x as the warning threshold. |
+| Latency spike | `histogram_quantile(0.95, sum by (le, tool) (rate(cerebro_tool_latency_seconds_bucket{status="ok"}[10m])))` | p95 `> 2s` for 10 minutes; warn at p95 `> 1s` | Slow tools persist after expected workload spikes | Compare by `tool` label. For internal deployments with strict SLOs, use the tool's normal p95 plus 2x as the warning threshold. |
 
 Example Prometheus expressions:
 
@@ -218,9 +218,11 @@ increase(cerebro_readiness_failures_total[5m]) >= 3
 increase(cerebro_auth_failures_total[10m]) > 20
 
 # Server-side MCP error ratio
-sum(rate(cerebro_requests_total{status=~"storage_error|internal_error"}[5m]))
+(
+  sum(rate(cerebro_requests_total{status=~"storage_error|internal_error"}[5m]))
   /
-sum(rate(cerebro_requests_total[5m])) > 0.02
+  sum(rate(cerebro_requests_total[5m]))
+) > 0.02
 
 # p95 successful tool latency
 histogram_quantile(

--- a/openspec/specs/client-surfaces/gateway-api.md
+++ b/openspec/specs/client-surfaces/gateway-api.md
@@ -44,9 +44,9 @@ Recommended internal production starting thresholds:
 
 - readiness degradation: alert when `increase(cerebro_readiness_failures_total[5m]) >= 3` or `/readyz` probe success rate is below `95%` for 5 minutes;
 - auth anomaly: alert when `increase(cerebro_auth_failures_total[10m]) > 20` or failures exceed `5x` the 24-hour baseline;
-- server-side error rate: warn above `2%` and page above `5%` for `storage_error` plus `internal_error` outcomes in `cerebro_requests_total`;
+- server-side error rate: warn above `2%` and page above `5%` for `cerebro_requests_total{status=~"storage_error|internal_error"}` outcomes divided by all MCP requests;
 - storage operation spike: alert when `increase(cerebro_storage_errors_total[5m]) >= 5` for one operation;
-- latency spike: warn when p95 successful `cerebro_tool_latency_seconds` exceeds `1s`, and page when it exceeds `2s` for 10 minutes.
+- latency spike: warn when p95 successful tool latency exceeds `1s`, and page when it exceeds `2s` for 10 minutes, using `histogram_quantile(0.95, sum by (le, tool) (rate(cerebro_tool_latency_seconds_bucket{status="ok"}[10m])))`.
 
 #### Scenario: Operators are alerted before degradation becomes user-visible
 

--- a/openspec/specs/client-surfaces/gateway-api.md
+++ b/openspec/specs/client-surfaces/gateway-api.md
@@ -35,3 +35,22 @@ Health, readiness, and metrics endpoints MUST remain outside the MCP concurrency
 Cerebro does not own request-frequency rate limiting inside the service. Production deployments that expose Cerebro beyond loopback MUST enforce rate limiting at ingress using a trusted client key such as source IP, mTLS identity, or authenticated gateway principal. Source-IP keys are acceptable only when ingress is the sole trusted hop and strips or validates `X-Forwarded-For` and other forwarding headers; otherwise, prefer non-spoofable identities such as mTLS identity or an authenticated gateway principal in production.
 
 Recommended baseline: `60 requests/minute` per trusted client with burst controls, tuned for known automation workloads.
+
+### Requirement: Exposed deployments define production alerts
+
+Production deployments of Cerebro MUST define alerting guidance tied to the service metrics, readiness probes, and structured logs. The guidance MUST cover repeated readiness failures, unusual authentication failures, elevated server-side error rates, storage error spikes, and latency spikes.
+
+Recommended internal production starting thresholds:
+
+- readiness degradation: alert when `increase(cerebro_readiness_failures_total[5m]) >= 3` or `/readyz` probe success rate is below `95%` for 5 minutes;
+- auth anomaly: alert when `increase(cerebro_auth_failures_total[10m]) > 20` or failures exceed `5x` the 24-hour baseline;
+- server-side error rate: warn above `2%` and page above `5%` for `storage_error` plus `internal_error` outcomes in `cerebro_requests_total`;
+- storage operation spike: alert when `increase(cerebro_storage_errors_total[5m]) >= 5` for one operation;
+- latency spike: warn when p95 successful `cerebro_tool_latency_seconds` exceeds `1s`, and page when it exceeds `2s` for 10 minutes.
+
+#### Scenario: Operators are alerted before degradation becomes user-visible
+
+- Given Cerebro is running in an internal production deployment
+- When readiness failures, auth failures, server-side errors, storage errors, or tool latency exceed the documented thresholds
+- Then the deployment's monitoring stack raises the corresponding alert
+- And the alert identifies the metric signal and relevant structured logs to inspect


### PR DESCRIPTION
## Related Issues

Fixes #701

---

## Summary

- Adds Cerebro production alerting guidance for readiness degradation, auth anomalies, server-side error rates, storage error spikes, and latency spikes.
- Ties recommended alerts to existing `/metrics`, `/readyz`, and structured log signals.
- Records the gateway/client-surface requirement in OpenSpec with internal production threshold examples.

---

## Tested Information

- Ran `git diff --check` successfully.
- Commit hooks ran the staged docs/config lychee offline check successfully.

---

## Documentation Impact

- Docs updated in:
  - `clients/web/apps/docs/src/content/docs/cerebro/operations.md`
  - `clients/cerebro/README.md`
  - `openspec/specs/client-surfaces/gateway-api.md`
- I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [ ] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).