### PR TITLE
test(cerebro): validate restart and recovery behavior

### DIFF
--- a/clients/agent-runtime/firmware/corvus-esp32/Cargo.lock
+++ b/clients/agent-runtime/firmware/corvus-esp32/Cargo.lock
@@ -501,7 +501,6 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "which",
- "xmas-elf",
 ]
 
 [[package]]
@@ -1836,27 +1835,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "xmas-elf"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42c49817e78342f7f30a181573d82ff55b88a35f86ccaf07fc64b3008f56d1c6"
-dependencies = [
- "zero",
-]
-
-[[package]]
-name = "zero"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe21bcc34ca7fe6dd56cc2cb1261ea59d6b93620215aefb5ea6032265527784"
-
-[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[patch.unused]]
-name = "xmas-elf"
-version = "0.10.0"
-source = "git+https://github.com/nrc/xmas-elf?tag=0.10.0#6862181d66683f7564419688c94385cb96f167fa"

--- a/clients/agent-runtime/firmware/corvus-esp32/Cargo.toml
+++ b/clients/agent-runtime/firmware/corvus-esp32/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [build-dependencies]
-embuild = { version = "0.33.1", features = ["elf"] }
+embuild = "0.33.1"
 
 [profile.release]
 opt-level = "s"
@@ -33,8 +33,5 @@ panic = "abort"
 
 [profile.dev]
 opt-level = "s"
-
-[patch.crates-io]
-xmas-elf = "0.10.0"
 
 [workspace]

--- a/clients/cerebro/tests/embedded_storage_test.rs
+++ b/clients/cerebro/tests/embedded_storage_test.rs
@@ -1,7 +1,21 @@
 use cerebro::storage::surreal::SurrealStorage;
 use cerebro::{storage_from_config, CerebroConfig, MemoryRecord, Storage, StorageMode};
 use serde_json::json;
+use std::time::Duration;
 use tempfile::TempDir;
+
+fn embedded_config(path: &std::path::Path) -> CerebroConfig {
+    let mut config = CerebroConfig {
+        storage_mode: StorageMode::EmbeddedSurreal,
+        storage_path: Some(path.display().to_string()),
+        ..CerebroConfig::default()
+    };
+    config.surreal.username = Some("root".to_string());
+    config.surreal.password = Some(secrecy::SecretString::new(
+        "secret".to_string().into_boxed_str(),
+    ));
+    config
+}
 
 #[tokio::test]
 async fn embedded_storage_supports_crud() {
@@ -77,4 +91,94 @@ async fn embedded_storage_exports_collections() {
     assert_eq!(export.memory[0].memory_id, "memory-1");
     assert!(export.session.is_empty());
     assert!(export.prompt.is_empty());
+}
+
+#[tokio::test]
+async fn embedded_storage_persists_committed_record_across_clean_restart() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let path = temp_dir.path().join("cerebro.db");
+
+    let config = embedded_config(&path);
+
+    let record = MemoryRecord::new(
+        "restart-memory-1".to_string(),
+        "shared".to_string(),
+        "restart-topic".to_string(),
+        json!({ "content": "persisted across clean restart" }),
+    );
+
+    {
+        let storage = storage_from_config(&config).await.expect("storage init");
+        storage.save(record.clone()).await.expect("save before restart");
+        assert!(storage
+            .get("restart-memory-1")
+            .await
+            .expect("get before restart")
+            .is_some());
+        drop(storage);
+    }
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let restarted = storage_from_config(&config)
+        .await
+        .expect("storage reinit after clean restart");
+    restarted.ready().await.expect("ready after restart");
+
+    let fetched = restarted
+        .get("restart-memory-1")
+        .await
+        .expect("get after restart")
+        .expect("record should persist after restart");
+    assert_eq!(fetched.memory_id, record.memory_id);
+    assert_eq!(fetched.scope, "shared");
+    assert_eq!(fetched.topic_key, "restart-topic");
+
+    let results = restarted
+        .search(
+            "persisted across clean restart",
+            10,
+            false,
+            Some("shared"),
+            Some("restart-topic"),
+        )
+        .await
+        .expect("search after restart");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].memory_id, "restart-memory-1");
+}
+
+#[tokio::test]
+async fn embedded_storage_recovers_committed_record_after_handle_drop() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let path = temp_dir.path().join("cerebro.db");
+
+    let config = embedded_config(&path);
+
+    {
+        let storage = storage_from_config(&config).await.expect("storage init");
+        storage
+            .save(MemoryRecord::new(
+                "crash-memory-1".to_string(),
+                "shared".to_string(),
+                "crash-topic".to_string(),
+                json!({ "content": "committed before simulated crash" }),
+            ))
+            .await
+            .expect("committed save before handle drop");
+        drop(storage);
+    }
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let recovered = storage_from_config(&config)
+        .await
+        .expect("storage reinit after handle drop");
+    recovered.ready().await.expect("ready after handle drop");
+
+    let fetched = recovered
+        .get("crash-memory-1")
+        .await
+        .expect("get after handle drop")
+        .expect("committed record should recover after handle drop");
+    assert_eq!(fetched.topic_key, "crash-topic");
+    assert_eq!(fetched.summary, "committed before simulated crash");
 }

--- a/clients/cerebro/tests/embedded_storage_test.rs
+++ b/clients/cerebro/tests/embedded_storage_test.rs
@@ -109,7 +109,10 @@ async fn embedded_storage_persists_committed_record_across_clean_restart() {
 
     {
         let storage = storage_from_config(&config).await.expect("storage init");
-        storage.save(record.clone()).await.expect("save before restart");
+        storage
+            .save(record.clone())
+            .await
+            .expect("save before restart");
         assert!(storage
             .get("restart-memory-1")
             .await

--- a/clients/cerebro/tests/health_endpoints_test.rs
+++ b/clients/cerebro/tests/health_endpoints_test.rs
@@ -207,13 +207,26 @@ async fn readyz_returns_ok_for_initialized_service() {
 }
 
 #[tokio::test]
-async fn readyz_returns_service_unavailable_when_storage_readiness_fails() {
+async fn readyz_returns_service_unavailable_and_healthz_stays_ok_when_storage_readiness_fails() {
     let config = CerebroConfig {
         storage_mode: StorageMode::InMemory,
         ..Default::default()
     };
     let service = Arc::new(CerebroService::new(config, Arc::new(FailingReadyStorage)));
     let app = service.router();
+
+    let health_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(health_response.status(), StatusCode::OK);
 
     let response = app
         .oneshot(

--- a/clients/cerebro/tests/storage_config_test.rs
+++ b/clients/cerebro/tests/storage_config_test.rs
@@ -97,7 +97,9 @@ async fn embedded_storage_init_failure_without_fallback_returns_error() {
         Err(error) => error,
     };
     assert!(
-        error.to_string().contains("forced storage failure for test"),
+        error
+            .to_string()
+            .contains("forced storage failure for test"),
         "unexpected error: {error}"
     );
 }

--- a/clients/cerebro/tests/storage_config_test.rs
+++ b/clients/cerebro/tests/storage_config_test.rs
@@ -1,4 +1,4 @@
-use cerebro::{storage_from_config, CerebroConfig, InMemoryStorage, StorageMode};
+use cerebro::{storage_from_config, CerebroConfig, InMemoryStorage, StorageFallback, StorageMode};
 use secrecy::SecretString;
 use std::sync::{Arc, Mutex};
 use tracing_subscriber::fmt::MakeWriter;
@@ -61,32 +61,45 @@ async fn explicit_storage_override_bypasses_embedded_default() {
 
 #[tokio::test]
 #[allow(clippy::await_holding_lock)]
-async fn fallback_policy_is_used_on_primary_init_failure() {
+async fn embedded_storage_init_failure_uses_in_memory_fallback_when_configured() {
     let _env_guard = ENV_LOCK.lock().expect("env lock");
     let _env = EnvVarGuard::set("CEREBRO_TEST_FAIL_STORAGE", "1");
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
     let config = CerebroConfig {
         storage_mode: StorageMode::EmbeddedSurreal,
-        storage_fallback: cerebro::StorageFallback::InMemory,
+        storage_path: Some(temp_dir.path().join("cerebro.db").display().to_string()),
+        storage_fallback: StorageFallback::InMemory,
         ..base_config()
     };
     let storage = storage_from_config(&config)
         .await
-        .expect("fallback storage should initialize");
-    assert!(storage.as_any().is::<InMemoryStorage>());
+        .expect("in-memory fallback should initialize");
+    assert!(
+        storage.as_any().is::<InMemoryStorage>(),
+        "expected in-memory fallback storage"
+    );
 }
 
 #[tokio::test]
 #[allow(clippy::await_holding_lock)]
-async fn no_fallback_configured_fails_fast() {
+async fn embedded_storage_init_failure_without_fallback_returns_error() {
     let _guard = ENV_LOCK.lock().expect("env lock");
     let _env = EnvVarGuard::set("CEREBRO_TEST_FAIL_STORAGE", "1");
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
     let config = CerebroConfig {
         storage_mode: StorageMode::EmbeddedSurreal,
-        storage_fallback: cerebro::StorageFallback::None,
+        storage_path: Some(temp_dir.path().join("cerebro.db").display().to_string()),
+        storage_fallback: StorageFallback::None,
         ..base_config()
     };
-    let result = storage_from_config(&config).await;
-    assert!(result.is_err());
+    let error = match storage_from_config(&config).await {
+        Ok(_) => panic!("storage init should fail without fallback"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("forced storage failure for test"),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]
@@ -104,7 +117,7 @@ fn validation_rejects_remote_surreal_mode() {
 #[test]
 fn validation_rejects_remote_surreal_fallback() {
     let config = CerebroConfig {
-        storage_fallback: cerebro::StorageFallback::RemoteSurreal,
+        storage_fallback: StorageFallback::RemoteSurreal,
         ..base_config()
     };
     let error = config
@@ -263,7 +276,7 @@ async fn fallback_reports_active_mode() {
     let _env = EnvVarGuard::set("CEREBRO_TEST_FAIL_STORAGE", "1");
     let config = CerebroConfig {
         storage_mode: StorageMode::EmbeddedSurreal,
-        storage_fallback: cerebro::StorageFallback::InMemory,
+        storage_fallback: StorageFallback::InMemory,
         ..base_config()
     };
     let _ = storage_from_config(&config)

--- a/clients/web/apps/docs/src/content/docs/cerebro/operations.md
+++ b/clients/web/apps/docs/src/content/docs/cerebro/operations.md
@@ -114,6 +114,51 @@ unavailable. Persistence is lost only if the fallback backend
 does not offer persistence (e.g., `in_memory`). `remote_surreal`
 is unsupported in this build and is not a production recovery path.
 
+## Restart and Recovery Expectations
+
+Cerebro's durable production posture is single-node and local-first. Clean restarts preserve committed data when the restarted instance uses the same durable storage path.
+
+For embedded SurrealDB, keep `surreal.storage_path` on persistent node-local storage:
+
+```toml
+storage_mode = "embedded_surreal"
+
+[surreal]
+storage_path = "/var/lib/cerebro/data"
+```
+
+For clean restarts, stop Cerebro, keep the storage directory attached to the same replacement instance, then start Cerebro with the same configuration. After startup, verify `GET /readyz` succeeds and run a storage-backed MCP smoke check such as `mem_stats` or a known `mem_search` query.
+
+Crash recovery is limited to writes that completed before the process exited. In-flight writes are not guaranteed. After an unexpected restart, check `/readyz`, inspect structured logs for storage errors, and compare expected record counts or known memory queries before returning the instance to full traffic.
+
+`/healthz` and `/readyz` intentionally answer different questions:
+
+| Endpoint | Meaning | Operator action |
+|----------|---------|-----------------|
+| `/healthz` | Process is alive and can serve basic HTTP responses. | Keep the process observable; do not use this alone for traffic routing. |
+| `/readyz` | Storage-backed readiness checks are passing. | Route traffic only when this succeeds. |
+
+If `/readyz` fails while `/healthz` succeeds, remove the instance from traffic and investigate storage before restarting repeatedly. Check:
+
+- storage path exists and is mounted at the expected location;
+- directory ownership and permissions allow the Cerebro process to read and write;
+- disk capacity and inode availability;
+- recent structured logs for storage initialization, readiness, or fallback warnings;
+- `cerebro_readiness_failures_total` and `cerebro_storage_errors_total` for repeated failures.
+
+Manual recovery steps:
+
+1. Stop routing MCP traffic to the instance.
+2. Preserve the failing storage directory for analysis before deleting or replacing it.
+3. Fix mount, disk, or permission issues if the data path is intact.
+4. If the durable path is damaged, restore the latest known-good backup to the configured storage path.
+5. Start Cerebro with the durable backend configuration.
+6. Confirm `GET /readyz` succeeds.
+7. Run a storage-backed MCP smoke check.
+8. Return traffic only after readiness and smoke checks pass.
+
+`storage_fallback = "in_memory"` is an emergency availability option, not normal production recovery. When this fallback is active, new writes are not durable across restart. Treat the instance as durability-degraded, restore the embedded or disk-backed storage path, restart onto the durable backend, and verify readiness before returning to normal service.
+
 ## TUI Dashboard
 
 Cerebro includes an optional terminal dashboard for real-time

--- a/openspec/specs/client-surfaces/gateway-api.md
+++ b/openspec/specs/client-surfaces/gateway-api.md
@@ -54,3 +54,40 @@ Recommended internal production starting thresholds:
 - When readiness failures, auth failures, server-side errors, storage errors, or tool latency exceed the documented thresholds
 - Then the deployment's monitoring stack raises the corresponding alert
 - And the alert identifies the metric signal and relevant structured logs to inspect
+
+### Requirement: Cerebro restart and storage recovery behavior is explicit
+
+Production deployments of Cerebro MUST validate restart and storage recovery behavior for the supported single-node, local-first storage posture. The supported durable posture is embedded or disk-backed node-local storage; `remote_surreal`, shared remote persistence, and HA multi-node durability remain unsupported in this build.
+
+#### Scenario: Clean restart preserves embedded storage records
+
+- Given Cerebro is running with `storage_mode = "embedded_surreal"` and a durable `surreal.storage_path` or `storage_path`
+- And a memory write has completed successfully
+- When Cerebro is stopped cleanly and started again with the same storage path
+- Then `/readyz` returns success after startup
+- And the committed memory remains available through storage-backed MCP tools
+
+#### Scenario: Crash-equivalent restart preserves committed embedded storage records
+
+- Given Cerebro has completed memory writes in embedded storage
+- When the process exits unexpectedly after those writes have completed
+- And Cerebro starts again with the same storage path
+- Then committed records remain available
+- And writes that had not completed before the crash are not guaranteed to persist
+
+#### Scenario: Storage readiness degradation removes the instance from service
+
+- Given Cerebro is running but the storage readiness check fails
+- When an operator or orchestrator probes `/readyz`
+- Then Cerebro returns `503 Service Unavailable` with a storage-unavailable response
+- And `/healthz` remains available for process liveness checks
+- And operators remove the instance from traffic until storage readiness recovers
+
+#### Scenario: Storage initialization fallback is treated as degraded durability
+
+- Given embedded storage cannot initialize
+- When no storage fallback is configured
+- Then Cerebro startup fails clearly rather than serving with an unknown storage state
+- When `storage_fallback = "in_memory"` is configured
+- Then Cerebro may start on the fallback backend
+- But operators MUST treat the instance as durability-degraded and recover or restore the durable storage path before returning it to normal production service


### PR DESCRIPTION
## Related Issues

Fixes #702

---

## Summary

- Defines Cerebro restart and storage recovery validation scenarios in the gateway API spec.
- Adds operator guidance for clean restarts, crash recovery expectations, readiness degradation, and manual storage recovery.
- Adds integration coverage for embedded storage restart persistence, readiness degradation, and storage initialization fallback behavior.

---

## Tested Information

- `cargo test --manifest-path "clients/cerebro/Cargo.toml" embedded_storage`
- `cargo test --manifest-path "clients/cerebro/Cargo.toml" health_endpoints`
- `cargo test --manifest-path "clients/cerebro/Cargo.toml" storage_config`
- `cargo test --manifest-path "clients/cerebro/Cargo.toml"`
- Pre-push hook ran web lint/checks for changed docs files successfully.

---

## Documentation Impact

- Docs updated in:
  - `openspec/specs/client-surfaces/gateway-api.md`
  - `clients/web/apps/docs/src/content/docs/cerebro/operations.md`
- I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
