### PR TITLE
docs(cerebro): add deployment runbook

### DIFF
--- a/clients/cerebro/README.md
+++ b/clients/cerebro/README.md
@@ -39,6 +39,8 @@ cargo run -- serve --tui
 Cerebro's bundled container config is for local/demo boot only.
 The bundled Docker config binds `host = "127.0.0.1"` inside the container, so `docker -p` port mapping will not expose the service unless you override the host (for example to `0.0.0.0`) and supply a real `auth_token`.
 
+For the full operator checklist, deployment topology, token rotation procedure, readiness troubleshooting flow, and storage recovery steps, see the [Cerebro Deployment Runbook](../../clients/web/apps/docs/src/content/docs/cerebro/deployment-runbook.md).
+
 For production deployments you must provide explicit configuration for at least:
 - `auth_token`
 - non-placeholder storage credentials

--- a/clients/web/apps/docs/astro.config.mjs
+++ b/clients/web/apps/docs/astro.config.mjs
@@ -301,6 +301,13 @@ export default defineConfig({
                 es: "Operaciones",
               },
             },
+            {
+              label: "Deployment Runbook",
+              slug: "cerebro/deployment-runbook",
+              translations: {
+                es: "Runbook de despliegue",
+              },
+            },
           ],
         },
       ],

--- a/clients/web/apps/docs/src/content/docs/cerebro/deployment-runbook.md
+++ b/clients/web/apps/docs/src/content/docs/cerebro/deployment-runbook.md
@@ -1,0 +1,310 @@
+---
+title: Cerebro Deployment Runbook
+description: >-
+  Operational deployment runbook for Cerebro production rollouts,
+  incidents, token rotation, readiness troubleshooting, and storage recovery.
+owner: team-platform
+status: canonical
+lastReviewed: 2026-05-02
+appliesTo: main
+docType: runbook
+---
+
+# Cerebro Deployment Runbook
+
+Use this runbook when deploying or operating Cerebro as a production MCP memory service. It is intentionally operational: it covers the required secrets, configuration, topology, probes, rollout checks, incident response, token rotation, readiness troubleshooting, and storage recovery steps an on-call operator needs.
+
+For deeper background, keep these references nearby:
+
+- [Cerebro configuration](configuration.md)
+- [Running Cerebro](running.md)
+- [Cerebro operations](operations.md)
+
+## Production posture
+
+Cerebro's supported durable production posture in this build is **single-node and local-first**:
+
+- run one writable Cerebro instance per durable storage path;
+- use embedded SurrealDB or disk-backed node-local storage for durable data;
+- attach the storage path to persistent node-local disk or a persistent volume that is mounted by only one active Cerebro instance;
+- route application traffic only after `/readyz` succeeds;
+- keep `/healthz`, `/readyz`, and `/metrics` private to the orchestrator and monitoring network;
+- expose `POST /mcp` only behind trusted ingress, gateway, private network, or service mesh controls.
+
+`remote_surreal`, shared remote persistence, active-active HA, and multiple writers on the same storage path are unsupported in this build.
+
+## Required secrets
+
+| Secret | Required | How to provide | Rotation notes |
+|--------|----------|----------------|----------------|
+| `CEREBRO_AUTH_TOKEN` | Required for production and for any non-loopback bind. | Secret manager or orchestrator secret environment variable. Prefer env injection over config files. | Rotate with a short dual-token compatibility window at ingress or caller config level. Cerebro accepts one configured token at a time. |
+| `surreal.password` | Required when `storage_mode = "embedded_surreal"`. | Secret manager template, mounted secret file rendered into config, or protected deployment config. | Rotate during a maintenance window. Restart Cerebro after updating the secret and verify `/readyz`. |
+| `CEREBRO_AUDIT_TOKEN` | Optional. | Secret manager or orchestrator secret environment variable. | Rotate like other service-to-service credentials if audit integrations rely on it. |
+
+Never commit production tokens, generated config with live secrets, storage snapshots, or backup archives to source control.
+
+## Required configuration
+
+Production deployments must set or verify these values explicitly:
+
+| Setting | Production guidance |
+|---------|---------------------|
+| `host` | Use `127.0.0.1` for sidecar or local gateway topologies. Use `0.0.0.0` only inside a private pod/container network or behind trusted ingress. Cerebro refuses non-loopback bind without `CEREBRO_AUTH_TOKEN`. |
+| `port` | Default `4040`; keep consistent with Service, ingress, and probe definitions. |
+| `scheme` | Usually inferred. Set only when generated endpoint URLs must reflect gateway TLS termination. |
+| `request_timeout_secs` | Start with `30`. Increase only for measured slow storage or known long-running tools. |
+| `max_concurrent_mcp_requests` | Start with `32`. Lower for small nodes or slow disks; raise only with CPU, memory, and storage headroom. |
+| `storage_mode` | `embedded_surreal` for the default durable production mode. `disk` is a simpler node-local durable alternative. Do not use `in_memory` for normal production. |
+| `surreal.storage_path` or `storage_path` | Use an explicit durable path such as `/var/lib/cerebro/data`. Avoid relying on the process working directory. |
+| `storage_fallback` | Prefer `none` for normal production so startup fails clearly if durable storage is unavailable. Use `in_memory` only as an emergency availability mode with durability-degraded incident tracking. |
+| `RUST_LOG` | Start with `info`. Temporarily use `cerebro=debug,surrealdb=warn` for investigations. |
+
+## Minimal production config
+
+This example assumes Cerebro runs in a private container or pod network behind ingress that provides TLS, rate limiting, and network access control. Secrets are injected by the orchestrator.
+
+```toml
+# /etc/cerebro/config.toml
+host = "0.0.0.0"
+port = 4040
+scheme = "https"
+request_timeout_secs = 30
+max_concurrent_mcp_requests = 32
+
+storage_mode = "embedded_surreal"
+storage_fallback = "none"
+
+[surreal]
+namespace = "cerebro"
+database = "cerebro"
+storage_path = "/var/lib/cerebro/data"
+username = "cerebro"
+# Render from a secret manager or protected config template.
+password = "${CEREBRO_SURREAL_PASSWORD}"
+
+[tui]
+enabled = false
+```
+
+Runtime environment:
+
+```bash
+CEREBRO_AUTH_TOKEN=<generated-service-token>
+CEREBRO_SURREAL_PASSWORD=<generated-storage-password>
+RUST_LOG=info
+```
+
+If your config renderer does not expand `${...}` placeholders, render the final file before startup or use the deployment platform's supported secret projection mechanism.
+
+## Deployment topology
+
+A minimal production topology has these layers:
+
+1. **Trusted ingress or gateway** terminates TLS, enforces request-frequency rate limits, strips or validates forwarding headers, and forwards only approved callers to Cerebro.
+2. **Cerebro service instance** listens on the private network and protects `POST /mcp` with bearer authentication, body limits, timeout limits, and concurrency limits.
+3. **Durable node-local storage** is mounted at the configured storage path and attached to only one active Cerebro process.
+4. **Monitoring stack** scrapes `/metrics` and probes `/healthz` and `/readyz` from a private monitoring network.
+5. **Log pipeline** collects structured logs with deployment, instance, and storage-path metadata.
+
+Do not expose Cerebro directly to the public internet. Source-IP rate limits are acceptable only when ingress is the sole trusted hop and strips or validates `X-Forwarded-For`; otherwise use non-spoofable identities such as mTLS identity or authenticated gateway principal.
+
+## Probe configuration
+
+| Probe | Endpoint | Purpose | Routing decision |
+|-------|----------|---------|------------------|
+| Liveness | `GET /healthz` | Confirms the HTTP process is alive. | Restart only after repeated failures. Do not use as the sole traffic gate. |
+| Readiness | `GET /readyz` | Confirms storage-backed readiness checks pass. | Send MCP traffic only while this succeeds. |
+| Metrics | `GET /metrics` | Prometheus-compatible operational metrics. | Scrape privately; do not expose publicly. |
+| Application smoke | Authenticated `POST /mcp` with `mem_stats` or known `mem_search`. | Confirms authenticated MCP and storage-backed tool execution. | Run after deploy, restore, or incident mitigation. |
+
+Example Kubernetes-style probe targets:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 4040
+  periodSeconds: 10
+  failureThreshold: 3
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 4040
+  periodSeconds: 10
+  failureThreshold: 2
+```
+
+`/healthz`, `/readyz`, and `/metrics` are intentionally unauthenticated. Restrict them with network policy, security groups, service mesh policy, or private service topology.
+
+## Deployment checklist
+
+Before rollout:
+
+- [ ] Generate a strong `CEREBRO_AUTH_TOKEN` and store it in the deployment secret manager.
+- [ ] Generate non-placeholder embedded SurrealDB credentials.
+- [ ] Confirm config does not use demo values such as `local-dev-only`, `CHANGE_ME_BEFORE_PRODUCTION`, `root` as a password, or placeholder bearer tokens.
+- [ ] Configure explicit durable storage path and mount ownership for the Cerebro runtime user.
+- [ ] Confirm only one active Cerebro instance can write to the configured storage path.
+- [ ] Configure trusted ingress or gateway TLS, authentication boundary, body limits, and rate limiting.
+- [ ] Configure liveness and readiness probes using `/healthz` and `/readyz`.
+- [ ] Configure private metrics scraping for `/metrics`.
+- [ ] Configure alerts for readiness failures, auth failures, storage errors, server-side error rate, and p95 tool latency.
+- [ ] Confirm backup and restore procedures have been tested against the configured storage path.
+
+During rollout:
+
+1. Deploy the new instance with traffic disabled or readiness-gated.
+2. Confirm startup logs show the expected bind address, storage mode, and storage path without fallback warnings.
+3. Check liveness:
+
+   ```bash
+   curl -f http://<private-cerebro-host>:4040/healthz
+   ```
+
+4. Check readiness:
+
+   ```bash
+   curl -f http://<private-cerebro-host>:4040/readyz
+   ```
+
+5. Run an authenticated MCP smoke check:
+
+   ```bash
+   curl -fsS -X POST http://<private-cerebro-host>:4040/mcp \
+     -H "Content-Type: application/json" \
+     -H "Authorization: Bearer ${CEREBRO_AUTH_TOKEN}" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"mem_stats","arguments":{}}}' \
+     | jq .
+   ```
+
+6. Confirm `/metrics` is being scraped and new time series are visible.
+7. Enable traffic after readiness and smoke checks pass.
+8. Watch `cerebro_requests_total`, `cerebro_tool_latency_seconds`, `cerebro_storage_errors_total`, and structured logs for at least one normal traffic window.
+
+Rollback triggers:
+
+- `/readyz` remains failed after storage mount and permission checks;
+- storage initialization errors or fallback warnings appear unexpectedly;
+- server-side MCP error ratio exceeds the deployment's page threshold;
+- p95 successful tool latency remains above the page threshold after rollback-safe traffic reduction;
+- auth failures spike because callers were not updated with the expected token.
+
+## Token rotation
+
+Cerebro accepts one `CEREBRO_AUTH_TOKEN` at a time. Use caller or ingress compatibility to avoid downtime.
+
+Planned rotation:
+
+1. Generate a new token and store it in the secret manager.
+2. Update MCP clients, gateway secret mappings, or ingress auth policy so callers can send the new token. If your gateway supports dual validation, allow both old and new tokens temporarily at the gateway while Cerebro still uses the old token.
+3. Deploy the new `CEREBRO_AUTH_TOKEN` to Cerebro and restart or roll the service according to your orchestrator.
+4. Run `/readyz` and an authenticated `mem_stats` smoke check with the new token.
+5. Confirm old-token calls fail with `401 Unauthorized` after the compatibility window closes.
+6. Remove the old token from clients, gateway policy, secret stores, runbooks, and incident notes.
+7. Watch `cerebro_auth_failures_total` and ingress logs for stale callers.
+
+Emergency rotation for suspected leak:
+
+1. Block suspicious sources at ingress if possible.
+2. Generate and deploy a new token immediately.
+3. Restart/roll Cerebro so the new token is active.
+4. Update trusted clients or gateway mappings.
+5. Revoke the old token everywhere.
+6. Review `cerebro_auth_failures_total`, `cerebro_requests_total{status="unauthorized"}`, and ingress logs for continued use of the old token.
+
+Expected post-rotation symptoms:
+
+- Missing or stale tokens return `401 Unauthorized`.
+- Auth failures may temporarily rise while clients refresh secrets.
+- Readiness should remain healthy; token rotation should not affect storage readiness.
+
+## Readiness troubleshooting
+
+Use this flow when `/readyz` fails.
+
+1. Confirm scope:
+   - Does `/healthz` still return `200`?
+   - Is only one instance failing, or all instances for this deployment?
+   - Did failure start after deploy, restart, storage move, token change, or node maintenance?
+2. Remove the failing instance from MCP traffic. Do not rely on `/healthz` for routing.
+3. Check logs for storage initialization errors, readiness failures, storage fallback warnings, or permission errors.
+4. Check storage path:
+   - path exists at the configured `surreal.storage_path` or `storage_path`;
+   - persistent volume or disk is mounted read-write;
+   - runtime user owns or can read/write the directory;
+   - disk capacity and inodes are available;
+   - no second Cerebro process is using the same storage path.
+5. Check metrics:
+   - `increase(cerebro_readiness_failures_total[5m])`;
+   - `increase(cerebro_storage_errors_total[5m])` by `operation`;
+   - server-side error ratio from `cerebro_requests_total{status=~"storage_error|internal_error"}`.
+6. Fix the underlying mount, permission, or capacity issue.
+7. Restart Cerebro only after preserving useful failure evidence and confirming the configured storage path is correct.
+8. Verify `/readyz` succeeds.
+9. Run authenticated `mem_stats` or a known `mem_search` smoke check.
+10. Return traffic only after readiness and smoke checks pass.
+
+If `/healthz` fails too, treat it as a process or runtime incident: inspect crash logs, container exit code, scheduler events, memory pressure, and binary/config compatibility before focusing on storage.
+
+## Storage recovery
+
+Use this flow for storage corruption, accidental deletion, bad migration, or persistent readiness failures tied to the durable path.
+
+Immediate containment:
+
+1. Stop routing MCP traffic to the instance.
+2. Stop Cerebro gracefully if possible.
+3. Preserve the current storage directory for analysis before deleting or overwriting it.
+4. Record the configured storage path, binary version, config hash, last successful readiness time, and backup candidate.
+
+Restore from backup:
+
+1. Keep Cerebro stopped. Embedded SurrealDB uses RocksDB; do not take or restore file-level backups while Cerebro is running.
+2. Move the damaged storage directory aside instead of deleting it:
+
+   ```bash
+   sudo mv /var/lib/cerebro/data /var/lib/cerebro/data.failed.$(date +%Y%m%d-%H%M%S)
+   ```
+
+3. Restore the latest known-good backup to the configured path:
+
+   ```bash
+   sudo cp -a /backup/cerebro-20260501-120000 /var/lib/cerebro/data
+   sudo chown -R cerebro:cerebro /var/lib/cerebro/data
+   ```
+
+4. Start Cerebro with the same durable backend configuration.
+5. Confirm `/readyz` succeeds.
+6. Run `mem_stats` and compare counts with pre-incident or pre-backup expectations.
+7. Run a known `mem_search` query for representative data.
+8. Return traffic only after data checks pass.
+9. Keep the failed storage copy until the incident review is complete.
+
+Emergency fallback:
+
+- `storage_fallback = "in_memory"` may keep the service available if durable storage cannot initialize, but new writes are not durable across restart.
+- Declare the instance durability-degraded, notify service owners, and prioritize restoration to embedded or disk-backed durable storage.
+- Do not treat in-memory fallback as a completed recovery.
+
+## Incident response quick reference
+
+| Symptom | First action | Likely area | Verification |
+|---------|--------------|-------------|--------------|
+| `/healthz` fails | Inspect process/container state and recent logs. | Process crash, runtime config, scheduler/node failure. | `/healthz` returns `200`; process remains stable. |
+| `/readyz` fails but `/healthz` passes | Remove from traffic and inspect storage path, permissions, capacity, and storage logs. | Storage connectivity or storage initialization. | `/readyz` returns `200`; `mem_stats` succeeds. |
+| Spike in `401` responses | Check token rollout, stale clients, ingress logs, and possible scanning. | Authentication or leaked endpoint. | New token succeeds; old token fails; auth failures return to baseline. |
+| Server-side MCP error ratio rises | Check storage errors, internal error logs, and recent deploys. | Storage or service regression. | Error ratio returns below warning threshold. |
+| Tool p95 latency rises | Check storage saturation, CPU, memory, request concurrency, and slow tool labels. | Capacity or backend performance. | p95 latency returns to baseline. |
+| Storage errors spike by operation | Identify affected operation and inspect durable path. | Partial storage failure or data path issue. | `cerebro_storage_errors_total` stops increasing and smoke checks pass. |
+
+## Alert starting points
+
+Tune thresholds to your deployment baseline. Good production defaults are:
+
+- readiness degradation: `increase(cerebro_readiness_failures_total[5m]) >= 3` or `/readyz` success rate below `95%` for 5 minutes;
+- auth anomaly: `increase(cerebro_auth_failures_total[10m]) > 20` or more than `5x` the 24-hour baseline;
+- server-side error rate: warn above `2%` and page above `5%` for `cerebro_requests_total{status=~"storage_error|internal_error"}` divided by all MCP requests;
+- storage operation spike: `increase(cerebro_storage_errors_total[5m]) >= 5` for one operation;
+- latency spike: warn when p95 successful tool latency exceeds `1s`, and page when it exceeds `2s` for 10 minutes.
+
+Keep validation and authentication alerts separate from server-side error alerts so broken clients do not mask storage or internal failures.

--- a/clients/web/apps/docs/src/content/docs/es/cerebro/deployment-runbook.md
+++ b/clients/web/apps/docs/src/content/docs/es/cerebro/deployment-runbook.md
@@ -152,6 +152,14 @@ Durante el rollout:
 7. Habilitar tráfico cuando readiness y smoke checks pasen.
 8. Observar `cerebro_requests_total`, `cerebro_tool_latency_seconds`, `cerebro_storage_errors_total` y logs durante una ventana normal de tráfico.
 
+Triggers de rollback:
+
+- `/readyz` permanece fallido después de verificar mount y permisos de storage;
+- errores de inicialización de storage o warnings de fallback aparecen inesperadamente;
+- el ratio de error MCP server-side supera el umbral de page del despliegue;
+- la latencia p95 de herramientas exitosas permanece sobre el umbral de page después de reducción de tráfico segura para rollback;
+- los fallos de auth se disparan porque los callers no fueron actualizados con el token esperado.
+
 ## Rotación de token
 
 Cerebro acepta un `CEREBRO_AUTH_TOKEN` a la vez. Usa compatibilidad en clientes o ingress para evitar downtime.
@@ -165,6 +173,12 @@ Rotación planificada:
 5. Confirmar que llamadas con el token viejo fallen con `401 Unauthorized` al cerrar la ventana de compatibilidad.
 6. Eliminar el token viejo de clientes, gateway, secretos y notas de incidente.
 7. Vigilar `cerebro_auth_failures_total` e ingress logs por clientes obsoletos.
+
+Síntomas esperados post-rotación:
+
+- Tokens faltantes u obsoletos retornan `401 Unauthorized`.
+- Los fallos de auth pueden subir temporalmente mientras los clientes refrescan secretos.
+- Readiness debe permanecer saludable; la rotación de token no debe afectar readiness de storage.
 
 Rotación de emergencia por posible filtración:
 
@@ -246,6 +260,7 @@ Fallback de emergencia:
 | Pico de `401` | Revisar rollout de token, clientes viejos, ingress logs y posible scanning. | Auth o endpoint filtrado. | Token nuevo funciona; token viejo falla; auth vuelve a baseline. |
 | Error ratio MCP server-side sube | Revisar errores de storage, logs internos y deploys recientes. | Storage o regresión de servicio. | Ratio vuelve bajo umbral de warning. |
 | p95 de herramienta sube | Revisar saturación de storage, CPU, memoria, concurrencia y tool labels. | Capacidad o performance backend. | p95 vuelve a baseline. |
+| Pico de errores de storage por operación | Identificar operación afectada e inspeccionar ruta durable. | Fallo parcial de storage o problema en data path. | `cerebro_storage_errors_total` deja de incrementar y smoke checks pasan. |
 
 ## Alertas iniciales
 

--- a/clients/web/apps/docs/src/content/docs/es/cerebro/deployment-runbook.md
+++ b/clients/web/apps/docs/src/content/docs/es/cerebro/deployment-runbook.md
@@ -1,0 +1,260 @@
+---
+title: Runbook de despliegue de Cerebro
+description: >-
+  Runbook operativo para despliegues de producción de Cerebro,
+  incidentes, rotación de tokens, diagnóstico de readiness y recuperación de almacenamiento.
+owner: team-platform
+status: canonical
+lastReviewed: 2026-05-02
+appliesTo: main
+docType: runbook
+---
+
+# Runbook de despliegue de Cerebro
+
+Usa este runbook para desplegar u operar Cerebro como servicio MCP de memoria en producción. Cubre secretos requeridos, configuración, topología, probes, verificaciones de despliegue, respuesta a incidentes, rotación de tokens, diagnóstico de readiness y recuperación de almacenamiento.
+
+Referencias relacionadas:
+
+- [Configuración de Cerebro](configuration.md)
+- [Ejecución de Cerebro](running.md)
+- [Operaciones de Cerebro](operations.md)
+
+## Postura de producción
+
+La postura durable soportada para producción en esta versión es **nodo único y local-first**:
+
+- ejecuta una sola instancia escritora de Cerebro por ruta de almacenamiento durable;
+- usa SurrealDB embebido o almacenamiento `disk` local al nodo para datos durables;
+- monta la ruta de almacenamiento en disco persistente o volumen persistente usado por una sola instancia activa;
+- enruta tráfico de aplicación solo después de que `/readyz` responda correctamente;
+- mantén `/healthz`, `/readyz` y `/metrics` privados para el orquestador y la red de monitoreo;
+- expón `POST /mcp` solo detrás de ingress, gateway, red privada o service mesh confiables.
+
+`remote_surreal`, persistencia remota compartida, HA activo-activo y múltiples escritores sobre la misma ruta no están soportados en esta versión.
+
+## Secretos requeridos
+
+| Secreto | Requerido | Cómo proveerlo | Notas de rotación |
+|---------|-----------|----------------|-------------------|
+| `CEREBRO_AUTH_TOKEN` | Requerido para producción y cualquier bind no-loopback. | Secret manager o variable de entorno secreta del orquestador. Prefiere env vars sobre archivos de configuración. | Rota con una ventana corta de compatibilidad dual en ingress o clientes. Cerebro acepta un token configurado a la vez. |
+| `surreal.password` | Requerido con `storage_mode = "embedded_surreal"`. | Plantilla desde secret manager, archivo secreto montado o configuración protegida. | Rota en ventana de mantenimiento. Reinicia Cerebro y verifica `/readyz`. |
+| `CEREBRO_AUDIT_TOKEN` | Opcional. | Secret manager o variable de entorno secreta. | Rota como otras credenciales servicio-a-servicio si integraciones de auditoría dependen de él. |
+
+Nunca subas tokens de producción, configuraciones generadas con secretos reales, snapshots de almacenamiento o respaldos al repositorio.
+
+## Configuración requerida
+
+| Setting | Guía de producción |
+|---------|--------------------|
+| `host` | Usa `127.0.0.1` para sidecar o gateway local. Usa `0.0.0.0` solo dentro de red privada de pod/contenedor o detrás de ingress confiable. Cerebro rechaza bind no-loopback sin `CEREBRO_AUTH_TOKEN`. |
+| `port` | Default `4040`; mantenlo alineado con Service, ingress y probes. |
+| `scheme` | Normalmente se infiere. Configúralo solo cuando URLs generadas deban reflejar TLS terminado en gateway. |
+| `request_timeout_secs` | Empieza con `30`. Súbelo solo por almacenamiento medidamente lento o herramientas de larga duración. |
+| `max_concurrent_mcp_requests` | Empieza con `32`. Bájalo para nodos pequeños o discos lentos; súbelo solo con margen de CPU, memoria y almacenamiento. |
+| `storage_mode` | `embedded_surreal` para producción durable por defecto. `disk` es una alternativa durable local al nodo. No uses `in_memory` para producción normal. |
+| `surreal.storage_path` o `storage_path` | Usa una ruta durable explícita como `/var/lib/cerebro/data`. Evita depender del directorio de trabajo. |
+| `storage_fallback` | Prefiere `none` para que el arranque falle claramente si el almacenamiento durable no está disponible. Usa `in_memory` solo como emergencia degradada en durabilidad. |
+| `RUST_LOG` | Empieza con `info`. Usa temporalmente `cerebro=debug,surrealdb=warn` para investigaciones. |
+
+## Configuración mínima de producción
+
+Este ejemplo asume que Cerebro corre en una red privada de contenedor o pod detrás de ingress que provee TLS, rate limiting y control de acceso. Los secretos los inyecta el orquestador.
+
+```toml
+# /etc/cerebro/config.toml
+host = "0.0.0.0"
+port = 4040
+scheme = "https"
+request_timeout_secs = 30
+max_concurrent_mcp_requests = 32
+
+storage_mode = "embedded_surreal"
+storage_fallback = "none"
+
+[surreal]
+namespace = "cerebro"
+database = "cerebro"
+storage_path = "/var/lib/cerebro/data"
+username = "cerebro"
+# Renderiza desde secret manager o plantilla protegida.
+password = "${CEREBRO_SURREAL_PASSWORD}"
+
+[tui]
+enabled = false
+```
+
+Variables de entorno:
+
+```bash
+CEREBRO_AUTH_TOKEN=<token-de-servicio-generado>
+CEREBRO_SURREAL_PASSWORD=<password-de-almacenamiento-generado>
+RUST_LOG=info
+```
+
+Si tu renderizador no expande placeholders `${...}`, genera el archivo final antes del arranque o usa el mecanismo de proyección de secretos de la plataforma.
+
+## Topología de despliegue
+
+Una topología mínima de producción tiene estas capas:
+
+1. **Ingress o gateway confiable** termina TLS, aplica rate limiting, elimina o valida headers de forwarding y permite solo callers aprobados.
+2. **Instancia Cerebro** escucha en la red privada y protege `POST /mcp` con bearer auth, límites de tamaño, timeouts y concurrencia.
+3. **Almacenamiento durable local al nodo** montado en la ruta configurada y adjunto a un solo proceso activo.
+4. **Stack de monitoreo** scrapea `/metrics` y sondea `/healthz` y `/readyz` desde red privada.
+5. **Pipeline de logs** recolecta logs estructurados con metadatos de despliegue, instancia y ruta de almacenamiento.
+
+No expongas Cerebro directamente a Internet. Rate limits por IP son aceptables solo si ingress es el único hop confiable y elimina o valida `X-Forwarded-For`; si no, usa identidades no falsificables como mTLS o principal autenticado de gateway.
+
+## Probes
+
+| Probe | Endpoint | Propósito | Decisión de enrutamiento |
+|-------|----------|-----------|--------------------------|
+| Liveness | `GET /healthz` | Confirma que el proceso HTTP está vivo. | Reinicia solo tras fallos repetidos. No lo uses como único gate de tráfico. |
+| Readiness | `GET /readyz` | Confirma readiness respaldada por almacenamiento. | Envía MCP traffic solo mientras responda correctamente. |
+| Metrics | `GET /metrics` | Métricas Prometheus. | Scrapea en privado; no lo expongas públicamente. |
+| Smoke de aplicación | `POST /mcp` autenticado con `mem_stats` o `mem_search` conocido. | Confirma MCP autenticado y herramienta con almacenamiento. | Ejecuta después de despliegue, restore o mitigación. |
+
+`/healthz`, `/readyz` y `/metrics` no requieren autenticación por diseño. Restringe acceso con network policy, security groups, service mesh o topología privada.
+
+## Checklist de despliegue
+
+Antes del rollout:
+
+- [ ] Generar `CEREBRO_AUTH_TOKEN` fuerte y guardarlo en secret manager.
+- [ ] Generar credenciales no-placeholder para SurrealDB embebido.
+- [ ] Confirmar que la configuración no usa valores demo como `local-dev-only`, `CHANGE_ME_BEFORE_PRODUCTION`, passwords `root` o bearer tokens placeholder.
+- [ ] Configurar ruta durable explícita y ownership para el usuario runtime de Cerebro.
+- [ ] Confirmar que solo una instancia activa puede escribir en la ruta configurada.
+- [ ] Configurar ingress/gateway confiable con TLS, límite de cuerpo y rate limiting.
+- [ ] Configurar probes `/healthz` y `/readyz`.
+- [ ] Configurar scraping privado de `/metrics`.
+- [ ] Configurar alertas por readiness, auth, storage, error rate y p95 de latencia.
+- [ ] Probar backup y restore contra la ruta configurada.
+
+Durante el rollout:
+
+1. Desplegar la nueva instancia con tráfico deshabilitado o gated por readiness.
+2. Confirmar en logs el bind, storage mode y storage path esperados, sin warnings de fallback.
+3. Verificar liveness: `curl -f http://<private-cerebro-host>:4040/healthz`.
+4. Verificar readiness: `curl -f http://<private-cerebro-host>:4040/readyz`.
+5. Ejecutar smoke MCP autenticado:
+
+   ```bash
+   curl -fsS -X POST http://<private-cerebro-host>:4040/mcp \
+     -H "Content-Type: application/json" \
+     -H "Authorization: Bearer ${CEREBRO_AUTH_TOKEN}" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"mem_stats","arguments":{}}}' \
+     | jq .
+   ```
+
+6. Confirmar que `/metrics` se scrapea.
+7. Habilitar tráfico cuando readiness y smoke checks pasen.
+8. Observar `cerebro_requests_total`, `cerebro_tool_latency_seconds`, `cerebro_storage_errors_total` y logs durante una ventana normal de tráfico.
+
+## Rotación de token
+
+Cerebro acepta un `CEREBRO_AUTH_TOKEN` a la vez. Usa compatibilidad en clientes o ingress para evitar downtime.
+
+Rotación planificada:
+
+1. Generar token nuevo y guardarlo en secret manager.
+2. Actualizar clientes MCP, gateway o ingress para enviar o aceptar el token nuevo. Si el gateway soporta doble validación, permite token viejo y nuevo temporalmente mientras Cerebro usa el viejo.
+3. Desplegar el nuevo `CEREBRO_AUTH_TOKEN` en Cerebro y reiniciar o hacer rollout.
+4. Verificar `/readyz` y un `mem_stats` autenticado con el token nuevo.
+5. Confirmar que llamadas con el token viejo fallen con `401 Unauthorized` al cerrar la ventana de compatibilidad.
+6. Eliminar el token viejo de clientes, gateway, secretos y notas de incidente.
+7. Vigilar `cerebro_auth_failures_total` e ingress logs por clientes obsoletos.
+
+Rotación de emergencia por posible filtración:
+
+1. Bloquear fuentes sospechosas en ingress si es posible.
+2. Generar y desplegar token nuevo inmediatamente.
+3. Reiniciar o hacer rollout de Cerebro.
+4. Actualizar clientes confiables o mappings del gateway.
+5. Revocar el token viejo en todas partes.
+6. Revisar `cerebro_auth_failures_total`, `cerebro_requests_total{status="unauthorized"}` e ingress logs.
+
+## Diagnóstico de readiness
+
+Usa este flujo cuando `/readyz` falle:
+
+1. Confirmar alcance: ¿`/healthz` responde `200`? ¿Falla una instancia o todo el despliegue? ¿Empezó tras deploy, reinicio, cambio de storage, token o mantenimiento de nodo?
+2. Sacar la instancia fallida del tráfico MCP. No uses `/healthz` como gate de tráfico.
+3. Revisar logs por errores de inicialización de storage, readiness, fallback o permisos.
+4. Revisar la ruta de storage:
+   - existe en `surreal.storage_path` o `storage_path`;
+   - volumen/disco montado read-write;
+   - usuario runtime puede leer y escribir;
+   - hay capacidad e inodos disponibles;
+   - no hay otro proceso Cerebro usando la misma ruta.
+5. Revisar métricas: `cerebro_readiness_failures_total`, `cerebro_storage_errors_total` y error ratio server-side.
+6. Corregir mount, permisos o capacidad.
+7. Reiniciar solo después de preservar evidencia útil y confirmar la ruta configurada.
+8. Verificar `/readyz`.
+9. Ejecutar `mem_stats` o `mem_search` conocido.
+10. Devolver tráfico solo después de readiness y smoke checks correctos.
+
+Si también falla `/healthz`, trátalo como incidente de proceso/runtime: revisa crash logs, exit code, eventos del scheduler, presión de memoria y compatibilidad de binario/configuración antes de enfocarte en storage.
+
+## Recuperación de almacenamiento
+
+Usa este flujo para corrupción, borrado accidental, migración problemática o fallos persistentes de readiness ligados a la ruta durable.
+
+Contención inmediata:
+
+1. Dejar de enrutar tráfico MCP a la instancia.
+2. Detener Cerebro limpiamente si es posible.
+3. Preservar el directorio actual de storage antes de borrarlo o sobrescribirlo.
+4. Registrar ruta configurada, versión del binario, hash de config, última readiness correcta y backup candidato.
+
+Restore desde backup:
+
+1. Mantener Cerebro detenido. SurrealDB embebido usa RocksDB; no hagas backups/restores de archivos mientras Cerebro corre.
+2. Mover la ruta dañada en vez de borrarla:
+
+   ```bash
+   sudo mv /var/lib/cerebro/data /var/lib/cerebro/data.failed.$(date +%Y%m%d-%H%M%S)
+   ```
+
+3. Restaurar el último backup conocido como bueno:
+
+   ```bash
+   sudo cp -a /backup/cerebro-20260501-120000 /var/lib/cerebro/data
+   sudo chown -R cerebro:cerebro /var/lib/cerebro/data
+   ```
+
+4. Arrancar Cerebro con la misma configuración durable.
+5. Confirmar `/readyz`.
+6. Ejecutar `mem_stats` y comparar conteos esperados.
+7. Ejecutar un `mem_search` conocido.
+8. Devolver tráfico solo cuando las verificaciones pasen.
+9. Conservar la copia fallida hasta cerrar la revisión del incidente.
+
+Fallback de emergencia:
+
+- `storage_fallback = "in_memory"` puede mantener disponibilidad si el almacenamiento durable no inicializa, pero las escrituras nuevas no sobreviven reinicios.
+- Declara la instancia degradada en durabilidad, notifica a owners y prioriza restaurar almacenamiento durable.
+- No trates fallback in-memory como recuperación completada.
+
+## Respuesta a incidentes rápida
+
+| Síntoma | Primera acción | Área probable | Verificación |
+|---------|----------------|---------------|--------------|
+| `/healthz` falla | Inspeccionar proceso/contenedor y logs recientes. | Crash, config runtime, nodo/scheduler. | `/healthz` responde `200` y el proceso queda estable. |
+| `/readyz` falla pero `/healthz` pasa | Sacar de tráfico y revisar ruta, permisos, capacidad y logs de storage. | Conectividad o inicialización de storage. | `/readyz` responde `200`; `mem_stats` funciona. |
+| Pico de `401` | Revisar rollout de token, clientes viejos, ingress logs y posible scanning. | Auth o endpoint filtrado. | Token nuevo funciona; token viejo falla; auth vuelve a baseline. |
+| Error ratio MCP server-side sube | Revisar errores de storage, logs internos y deploys recientes. | Storage o regresión de servicio. | Ratio vuelve bajo umbral de warning. |
+| p95 de herramienta sube | Revisar saturación de storage, CPU, memoria, concurrencia y tool labels. | Capacidad o performance backend. | p95 vuelve a baseline. |
+
+## Alertas iniciales
+
+Ajusta umbrales al baseline del despliegue. Buenos defaults:
+
+- readiness: `increase(cerebro_readiness_failures_total[5m]) >= 3` o éxito de `/readyz` bajo `95%` por 5 minutos;
+- auth: `increase(cerebro_auth_failures_total[10m]) > 20` o más de `5x` el baseline de 24 horas;
+- error server-side: warning sobre `2%` y page sobre `5%` para `cerebro_requests_total{status=~"storage_error|internal_error"}` dividido por todas las requests MCP;
+- storage: `increase(cerebro_storage_errors_total[5m]) >= 5` para una operación;
+- latencia: warning cuando p95 de herramientas exitosas supere `1s`, page cuando supere `2s` por 10 minutos.
+
+Mantén alertas de validación y autenticación separadas de alertas server-side para que clientes rotos no oculten fallos de storage o internos.


### PR DESCRIPTION
## Related Issues

Fixes #698

---

## Summary

Adds a dedicated Cerebro operational deployment runbook for production operators, covering required secrets, production configuration, deployment topology, probes, rollout checks, token rotation, readiness troubleshooting, storage recovery, incident response, and alerting guidance.

Also links the runbook from the primary Cerebro README and adds it to the docs sidebar with an ES locale counterpart so docs metadata validation passes.

---

## Tested Information

- `pnpm --filter @corvus/docs run validate:content`
- Commit hook lychee offline check passed for staged docs/config links.

---

## Documentation Impact

- Docs updated in:
  - `clients/web/apps/docs/src/content/docs/cerebro/deployment-runbook.md`
  - `clients/web/apps/docs/src/content/docs/es/cerebro/deployment-runbook.md`
  - `clients/cerebro/README.md`
  - `clients/web/apps/docs/astro.config.mjs`
- I verified the documentation matches the current behavior described by the existing Cerebro configuration and operations docs.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [ ] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
