### PR TITLE
fix(security): harden SecurityPolicy against quote-based bypasses (SONAR:SEC-001)

### DIFF
--- a/.agents/journal/sentinnel-journal.md
+++ b/.agents/journal/sentinnel-journal.md
@@ -17,6 +17,11 @@
 3. ✅ Validated path-like command arguments against path traversal and forbidden path rules.
 4. ✅ Expanded `contains_blocked_operators` to include backslash; glob chars blocked in `is_segment_valid`.
 
+## 2025-05-28 - Hardening SecurityPolicy against Quote-based Bypasses
+
+**Learning:** `SecurityPolicy` was vulnerable to path validation bypass using nested or partial quotes (e.g., `"/etc"/passwd`, `""/etc/passwd""`). The previous `strip_matching_quotes` only removed outer quotes, leaving internal quotes to disrupt prefix-based forbidden path and absolute path checks.
+**Action:** Implemented `strip_all_quotes` to remove all single and double quotes from command arguments and paths before security validation. In `is_path_allowed`, ensuring `iterative_url_decode` is called before `strip_all_quotes` to catch encoded quotes.
+
 ## 2025-05-20 - Flag-based Path Validation Hardening
 
 **Learning:** The `SecurityPolicy` was vulnerable to path validation bypass when absolute paths or traversal sequences were passed within command flags (e.g., `grep --file=/etc/passwd` or `git -C/etc status`). The argument validation loop was only checking standalone arguments and not extracting values from flag assignments.

--- a/.agents/journal/sentinnel-journal.md
+++ b/.agents/journal/sentinnel-journal.md
@@ -20,7 +20,7 @@
 ## 2025-05-28 - Hardening SecurityPolicy against Quote-based Bypasses
 
 **Learning:** `SecurityPolicy` was vulnerable to path validation bypass using nested or partial quotes (e.g., `"/etc"/passwd`, `""/etc/passwd""`). The previous `strip_matching_quotes` only removed outer quotes, leaving internal quotes to disrupt prefix-based forbidden path and absolute path checks.
-**Action:** Implemented `strip_all_quotes` to remove all single and double quotes from command arguments and paths before security validation. In `is_path_allowed`, ensuring `iterative_url_decode` is called before `strip_all_quotes` to catch encoded quotes.
+**Action:** Implemented `strip_all_quotes` to normalize command arguments and paths by removing all single and double quotes. In `is_path_allowed`, `iterative_url_decode` is still applied before quote stripping so encoded quotes are exposed before later processing.
 
 ## 2025-05-20 - Flag-based Path Validation Hardening
 

--- a/.agents/journal/sentinnel-journal.md
+++ b/.agents/journal/sentinnel-journal.md
@@ -17,11 +17,6 @@
 3. ✅ Validated path-like command arguments against path traversal and forbidden path rules.
 4. ✅ Expanded `contains_blocked_operators` to include backslash; glob chars blocked in `is_segment_valid`.
 
-## 2025-05-28 - Hardening SecurityPolicy against Quote-based Bypasses
-
-**Learning:** `SecurityPolicy` was vulnerable to path validation bypass using nested or partial quotes (e.g., `"/etc"/passwd`, `""/etc/passwd""`). The previous `strip_matching_quotes` only removed outer quotes, leaving internal quotes to disrupt prefix-based forbidden path and absolute path checks.
-**Action:** Implemented `strip_all_quotes` to normalize command arguments and paths by removing all single and double quotes. In `is_path_allowed`, `iterative_url_decode` is still applied before quote stripping so encoded quotes are exposed before later processing.
-
 ## 2025-05-20 - Flag-based Path Validation Hardening
 
 **Learning:** The `SecurityPolicy` was vulnerable to path validation bypass when absolute paths or traversal sequences were passed within command flags (e.g., `grep --file=/etc/passwd` or `git -C/etc status`). The argument validation loop was only checking standalone arguments and not extracting values from flag assignments.
@@ -31,3 +26,8 @@
 
 **Learning:** URL encoding was being used to bypass shell operator checks and risk classification in `is_command_allowed` and `command_risk_level`. While `is_path_allowed` was already decoding inputs, other entry points were vulnerable to encoded redirection (`%3e`), background (`%26`), and subshell (`%24%28`) operators.
 **Action:** Centralized iterative URL decoding into a helper function and applied it consistently at the start of `is_path_allowed`, `is_command_allowed`, and `command_risk_level`. This ensures that all security filters operate on normalized input, preventing obfuscation-based bypasses.
+
+## 2025-05-28 - Hardening SecurityPolicy against Quote-based Bypasses
+
+**Learning:** `SecurityPolicy` was vulnerable to path validation bypass using nested or partial quotes (e.g., `"/etc"/passwd`, `""/etc/passwd""`). The previous `strip_matching_quotes` only removed outer quotes, leaving internal quotes to disrupt prefix-based forbidden path and absolute path checks.
+**Action:** Implemented `strip_all_quotes` to normalize command arguments and paths by removing all single and double quotes. In `is_path_allowed`, `iterative_url_decode` is still applied before quote stripping so encoded quotes are exposed before later processing.

--- a/clients/agent-runtime/src/security/policy.rs
+++ b/clients/agent-runtime/src/security/policy.rs
@@ -595,6 +595,7 @@ impl SecurityPolicy {
     /// Check if a file path is allowed (no path traversal, within workspace)
     pub fn is_path_allowed(&self, path: &str) -> bool {
         let decoded = iterative_url_decode(path);
+        let dequoted = strip_all_quotes(&decoded);
 
         // Block null bytes (can truncate paths in C-backed syscalls)
         if decoded.contains('\0') {
@@ -811,29 +812,22 @@ fn expand_tilde(path: &str) -> String {
     path.to_string()
 }
 
-fn strip_matching_quotes(token: &str) -> &str {
-    if token.len() >= 2 {
-        let first = token.as_bytes()[0];
-        let last = token.as_bytes()[token.len() - 1];
-        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
-            return &token[1..token.len() - 1];
-        }
-    }
-    token
+fn strip_all_quotes(token: &str) -> String {
+    token.replace('"', "").replace('\'', "")
 }
 
 fn normalize_arg_for_path_checks(token: &str) -> Option<String> {
-    let dequoted = strip_matching_quotes(token);
+    let dequoted = strip_all_quotes(token);
     if dequoted == "$HOME" || dequoted == "${HOME}" || dequoted == "$PATH" || dequoted == "${PATH}"
     {
-        return Some(dequoted.to_string());
+        return Some(dequoted);
     }
     if dequoted.contains('$') || dequoted.starts_with('~') {
-        return shellexpand::full(dequoted)
+        return shellexpand::full(&dequoted)
             .ok()
             .map(|value| value.into_owned());
     }
-    Some(dequoted.to_string())
+    Some(dequoted)
 }
 
 /// Check whether `expanded` path starts with any of the forbidden paths.
@@ -2158,28 +2152,61 @@ mod tests {
             "Read must always be allowed regardless of autonomy level"
         );
     }
-}
 
-#[test]
-fn is_command_allowed_blocks_path_in_flags() {
-    let mut p = SecurityPolicy::default();
-    p.workspace_only = true;
-    p.allowed_commands = vec!["grep".into()];
-    p.forbidden_paths = vec!["/etc".into()];
+    #[test]
+    fn is_command_allowed_blocks_path_in_flags() {
+        let mut p = SecurityPolicy::default();
+        p.workspace_only = true;
+        p.allowed_commands = vec!["grep".into()];
+        p.forbidden_paths = vec!["/etc".into()];
 
-    // Case 1: Standalone absolute path - Should be BLOCKED (currently passes test)
-    assert!(!p.is_command_allowed("grep pattern /etc/passwd"));
+        // Case 1: Standalone absolute path
+        assert!(!p.is_command_allowed("grep pattern /etc/passwd"));
 
-    // Case 2: Path in flag - CURRENTLY BYPASSES (this test should fail if my hypothesis is correct)
-    assert!(
-        !p.is_command_allowed("grep --file=/etc/passwd pattern"),
-        "Should block absolute path in flag"
-    );
+        // Case 2: Path in flag
+        assert!(
+            !p.is_command_allowed("grep --file=/etc/passwd pattern"),
+            "Should block absolute path in flag"
+        );
 
-    // Case 3: git -C/etc status - CURRENTLY BYPASSES
-    p.allowed_commands.push("git".into());
-    assert!(
-        !p.is_command_allowed("git -C/etc status"),
-        "Should block absolute path in short flag"
-    );
+        // Case 3: git -C/etc status
+        p.allowed_commands.push("git".into());
+        assert!(
+            !p.is_command_allowed("git -C/etc status"),
+            "Should block absolute path in short flag"
+        );
+    }
+
+    #[test]
+    fn is_command_allowed_blocks_quote_bypasses() {
+        let mut p = SecurityPolicy::default();
+        p.workspace_only = true;
+        p.allowed_commands = vec!["cat".into(), "git".into()];
+        p.forbidden_paths = vec!["/etc".into()];
+
+        // Nested quotes
+        assert!(!p.is_command_allowed("cat '\"/etc/passwd\"'"));
+        assert!(!p.is_command_allowed("cat \"'/etc/passwd'\""));
+        assert!(!p.is_command_allowed("cat \"\"/etc/passwd\"\""));
+
+        // Partial quotes
+        assert!(!p.is_command_allowed("cat \"/etc\"/passwd"));
+        assert!(!p.is_command_allowed("cat /\"etc\"/passwd"));
+
+        // Quoted flags
+        assert!(!p.is_command_allowed("git -C\"/etc\" status"));
+        assert!(!p.is_command_allowed("git \"-C/etc\" status"));
+    }
+
+    #[test]
+    fn is_path_allowed_blocks_quoted_paths() {
+        let p = SecurityPolicy {
+            workspace_only: true,
+            ..SecurityPolicy::default()
+        };
+
+        assert!(!p.is_path_allowed("\"/etc/passwd\""));
+        assert!(!p.is_path_allowed("'/etc/passwd'"));
+        assert!(!p.is_path_allowed("\"../etc/passwd\""));
+    }
 }

--- a/clients/agent-runtime/src/security/policy.rs
+++ b/clients/agent-runtime/src/security/policy.rs
@@ -598,29 +598,29 @@ impl SecurityPolicy {
         let dequoted = strip_all_quotes(&decoded);
 
         // Block null bytes (can truncate paths in C-backed syscalls)
-        if decoded.contains('\0') {
+        if dequoted.contains('\0') {
             return false;
         }
 
         // Block backslashes (Windows-style separators or escaping)
-        if decoded.contains('\\') {
+        if dequoted.contains('\\') {
             return false;
         }
 
         // Block residual percent signs after decoding (incomplete or malicious encoding)
-        if decoded.contains('%') {
+        if dequoted.contains('%') {
             return false;
         }
 
         // Block path traversal: check for ".." as a path component
-        if Path::new(&decoded)
+        if Path::new(&dequoted)
             .components()
             .any(|c| matches!(c, std::path::Component::ParentDir))
         {
             return false;
         }
 
-        let expanded = expand_tilde(&decoded);
+        let expanded = expand_tilde(&dequoted);
 
         // Block absolute paths when workspace_only is set
         if self.workspace_only && Path::new(&expanded).is_absolute() {

--- a/clients/agent-runtime/src/security/policy.rs
+++ b/clients/agent-runtime/src/security/policy.rs
@@ -813,7 +813,13 @@ fn expand_tilde(path: &str) -> String {
 }
 
 fn strip_all_quotes(token: &str) -> String {
-    token.replace('"', "").replace('\'', "")
+    let mut stripped = String::with_capacity(token.len());
+    for ch in token.chars() {
+        if ch != '"' && ch != '\'' {
+            stripped.push(ch);
+        }
+    }
+    stripped
 }
 
 fn normalize_arg_for_path_checks(token: &str) -> Option<String> {


### PR DESCRIPTION
This PR hardens the `SecurityPolicy` in the `agent-runtime` against a class of path validation bypasses that use shell quoting to disrupt string-based prefix checks.

### Security Impact
- **Risk reduced:** Prevents bypasses of `workspace_only` and `forbidden_paths` restrictions via internal quoting (e.g., `cat "/et""c/passwd"`).
- **Attack surface narrowed:** Ensures that path validation always operates on the literal path string that would be resolved by the system, regardless of how it was quoted in the CLI.

### Performance Impact
- **Metric:** Argument normalization latency.
- **Before:** `strip_matching_quotes` performed basic length and character checks.
- **After:** `strip_all_quotes` uses two string replacements.
- **Expected improvement:** Negligible performance change; provides significant security gain with minimal overhead.

### Verification
- Verified with a standalone Rust reproduction script covering nested quotes, partial quotes, and quoted flags.
- Added regression tests to `clients/agent-runtime/src/security/policy.rs`.
- Manual code review confirmed the logic and order of operations (decode before dequote).

---
*PR created automatically by Jules for task [6869014117684958430](https://jules.google.com/task/6869014117684958430) started by @yacosta738*