### PR TITLE
feat: Persist Rook provider account health state

### DIFF
--- a/clients/agent-runtime/src/security/policy.rs
+++ b/clients/agent-runtime/src/security/policy.rs
@@ -594,33 +594,30 @@ impl SecurityPolicy {
 
     /// Check if a file path is allowed (no path traversal, within workspace)
     pub fn is_path_allowed(&self, path: &str) -> bool {
-        let decoded = iterative_url_decode(path);
-        let dequoted = strip_all_quotes(&decoded);
-
         // Block null bytes (can truncate paths in C-backed syscalls)
-        if dequoted.contains('\0') {
+        if path.contains('\0') {
             return false;
         }
 
         // Block backslashes (Windows-style separators or escaping)
-        if dequoted.contains('\\') {
+        if path.contains('\\') {
             return false;
         }
 
-        // Block residual percent signs after decoding (incomplete or malicious encoding)
-        if dequoted.contains('%') {
+        // Block percent signs rather than decoding direct path inputs here.
+        if path.contains('%') {
             return false;
         }
 
         // Block path traversal: check for ".." as a path component
-        if Path::new(&dequoted)
+        if Path::new(path)
             .components()
             .any(|c| matches!(c, std::path::Component::ParentDir))
         {
             return false;
         }
 
-        let expanded = expand_tilde(&dequoted);
+        let expanded = expand_tilde(path);
 
         // Block absolute paths when workspace_only is set
         if self.workspace_only && Path::new(&expanded).is_absolute() {
@@ -823,7 +820,12 @@ fn strip_all_quotes(token: &str) -> String {
 }
 
 fn normalize_arg_for_path_checks(token: &str) -> Option<String> {
-    let dequoted = strip_all_quotes(token);
+    let decoded = iterative_url_decode(token);
+    if decoded.contains('%') {
+        return None;
+    }
+
+    let dequoted = strip_all_quotes(&decoded);
     if dequoted == "$HOME" || dequoted == "${HOME}" || dequoted == "$PATH" || dequoted == "${PATH}"
     {
         return Some(dequoted);
@@ -2205,14 +2207,28 @@ mod tests {
     }
 
     #[test]
-    fn is_path_allowed_blocks_quoted_paths() {
+    fn is_path_allowed_validates_raw_paths_without_dequoting() {
         let p = SecurityPolicy {
             workspace_only: true,
             ..SecurityPolicy::default()
         };
 
-        assert!(!p.is_path_allowed("\"/etc/passwd\""));
-        assert!(!p.is_path_allowed("'/etc/passwd'"));
-        assert!(!p.is_path_allowed("\"../etc/passwd\""));
+        assert!(p.is_path_allowed("\"relative/file.txt\""));
+        assert!(p.is_path_allowed("\"/etc/passwd\""));
+        assert!(!p.is_path_allowed("%2e%2e/etc/passwd"));
+        assert!(!p.is_path_allowed(".."));
+        assert!(!p.is_path_allowed("../etc/passwd"));
+    }
+
+    #[test]
+    fn command_path_checks_decode_and_dequote_shell_arguments() {
+        let mut p = SecurityPolicy::default();
+        p.workspace_only = true;
+        p.allowed_commands = vec!["cat".into()];
+        p.forbidden_paths = vec!["/etc".into()];
+
+        assert!(!p.is_command_allowed("cat %2fetc%2fpasswd"));
+        assert!(!p.is_command_allowed("cat '\"/etc/passwd\"'"));
+        assert!(!p.is_command_allowed("cat %252e%252e%252fetc%252fpasswd"));
     }
 }

--- a/clients/rook/Cargo.lock
+++ b/clients/rook/Cargo.lock
@@ -326,7 +326,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corvus-traits"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/clients/rook/Cargo.toml
+++ b/clients/rook/Cargo.toml
@@ -68,7 +68,7 @@ crossterm = { version = "0.29", default-features = false, features = ["events"] 
 ratatui = { version = "0.30", default-features = false, features = ["crossterm_0_29"] }
 
 # Shared runtime contracts (no internal corvus binary dependency)
-corvus-traits = { version = "0.1.0", path = "../agent-runtime/crates/corvus-traits" }
+corvus-traits = { version = "0.2.2", path = "../agent-runtime/crates/corvus-traits" }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/clients/rook/migrations/0006_health_persistence.sql
+++ b/clients/rook/migrations/0006_health_persistence.sql
@@ -1,0 +1,11 @@
+-- Persist provider account health and cooldown state across Rook restarts.
+
+CREATE TABLE IF NOT EXISTS provider_account_health (
+    account_id TEXT PRIMARY KEY,
+    status TEXT NOT NULL,
+    last_checked TEXT,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    cooldown_until TEXT,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (account_id) REFERENCES provider_accounts(id) ON DELETE CASCADE
+);

--- a/clients/rook/src/db/health.rs
+++ b/clients/rook/src/db/health.rs
@@ -1,0 +1,237 @@
+//! Persistence helpers for provider account health state.
+
+use crate::db::SqliteDb;
+use crate::domain::{AccountId, RookError};
+use crate::services::health::{AccountHealth, HealthStatus};
+use chrono::{DateTime, Utc};
+use sqlx::Row;
+use uuid::Uuid;
+
+fn status_to_db_str(status: &HealthStatus) -> &'static str {
+    match status {
+        HealthStatus::Healthy => "healthy",
+        HealthStatus::Degraded => "degraded",
+        HealthStatus::Unhealthy => "unhealthy",
+        HealthStatus::Unknown => "unknown",
+    }
+}
+
+fn db_str_to_status(value: &str) -> Result<HealthStatus, RookError> {
+    match value {
+        "healthy" => Ok(HealthStatus::Healthy),
+        "degraded" => Ok(HealthStatus::Degraded),
+        "unhealthy" => Ok(HealthStatus::Unhealthy),
+        "unknown" => Ok(HealthStatus::Unknown),
+        other => Err(RookError::Registry(format!(
+            "invalid provider account health status '{other}'"
+        ))),
+    }
+}
+
+fn parse_optional_rfc3339(
+    value: Option<String>,
+    column: &str,
+) -> Result<Option<DateTime<Utc>>, RookError> {
+    value
+        .map(|timestamp| {
+            DateTime::parse_from_rfc3339(&timestamp)
+                .map(|dt| dt.with_timezone(&Utc))
+                .map_err(|e| RookError::Registry(format!("invalid {column} timestamp: {e}")))
+        })
+        .transpose()
+}
+
+fn row_to_health(row: &sqlx::sqlite::SqliteRow) -> Result<AccountHealth, RookError> {
+    let account_id_str: String = row
+        .try_get("account_id")
+        .map_err(|e| RookError::Registry(format!("missing account_id: {e}")))?;
+    let account_id = AccountId::new(
+        Uuid::parse_str(&account_id_str)
+            .map_err(|e| RookError::Registry(format!("invalid account UUID: {e}")))?,
+    );
+
+    let status_str: String = row
+        .try_get("status")
+        .map_err(|e| RookError::Registry(format!("missing status: {e}")))?;
+    let status = db_str_to_status(&status_str)?;
+
+    let last_checked = parse_optional_rfc3339(
+        row.try_get("last_checked")
+            .map_err(|e| RookError::Registry(format!("missing last_checked: {e}")))?,
+        "last_checked",
+    )?;
+    let cooldown_until = parse_optional_rfc3339(
+        row.try_get("cooldown_until")
+            .map_err(|e| RookError::Registry(format!("missing cooldown_until: {e}")))?,
+        "cooldown_until",
+    )?;
+
+    let consecutive_failures: i64 = row
+        .try_get("consecutive_failures")
+        .map_err(|e| RookError::Registry(format!("missing consecutive_failures: {e}")))?;
+    let consecutive_failures = u32::try_from(consecutive_failures).map_err(|_| {
+        RookError::Registry(format!(
+            "consecutive_failures out of range: {consecutive_failures}"
+        ))
+    })?;
+
+    Ok(AccountHealth {
+        account_id,
+        status,
+        last_checked,
+        consecutive_failures,
+        cooldown_until,
+    })
+}
+
+impl SqliteDb {
+    pub async fn get_account_health(
+        &self,
+        account_id: &AccountId,
+    ) -> Result<Option<AccountHealth>, RookError> {
+        let account_id = account_id.to_string();
+        let row = sqlx::query(
+            "SELECT account_id, status, last_checked, consecutive_failures, cooldown_until, updated_at \
+             FROM provider_account_health WHERE account_id = ?",
+        )
+        .bind(&account_id)
+        .fetch_optional(self.pool())
+        .await
+        .map_err(|e| RookError::Registry(format!("get_account_health failed: {e}")))?;
+
+        row.map(|row| row_to_health(&row)).transpose()
+    }
+
+    pub async fn upsert_account_health_success(
+        &self,
+        account_id: AccountId,
+    ) -> Result<(), RookError> {
+        let now = Utc::now().to_rfc3339();
+        let account_id = account_id.to_string();
+
+        sqlx::query(
+            "INSERT INTO provider_account_health \
+             (account_id, status, last_checked, consecutive_failures, cooldown_until, updated_at) \
+             VALUES (?, ?, ?, 0, NULL, ?) \
+             ON CONFLICT(account_id) DO UPDATE SET \
+                 status = excluded.status, \
+                 last_checked = excluded.last_checked, \
+                 consecutive_failures = 0, \
+                 cooldown_until = NULL, \
+                 updated_at = excluded.updated_at",
+        )
+        .bind(&account_id)
+        .bind(status_to_db_str(&HealthStatus::Healthy))
+        .bind(&now)
+        .bind(&now)
+        .execute(self.pool())
+        .await
+        .map_err(|e| RookError::Registry(format!("upsert_account_health_success failed: {e}")))?;
+
+        Ok(())
+    }
+
+    pub async fn upsert_account_health_failure(
+        &self,
+        account_id: AccountId,
+        cooldown_seconds: u64,
+    ) -> Result<(), RookError> {
+        let now = Utc::now();
+        let cooldown_secs = i64::try_from(cooldown_seconds).unwrap_or(i64::MAX);
+        let cooldown_until = now + chrono::Duration::seconds(cooldown_secs);
+        let now = now.to_rfc3339();
+        let cooldown_until = cooldown_until.to_rfc3339();
+        let account_id = account_id.to_string();
+
+        sqlx::query(
+            "INSERT INTO provider_account_health \
+             (account_id, status, last_checked, consecutive_failures, cooldown_until, updated_at) \
+             VALUES (?, ?, ?, 1, ?, ?) \
+             ON CONFLICT(account_id) DO UPDATE SET \
+                 status = excluded.status, \
+                 last_checked = excluded.last_checked, \
+                 consecutive_failures = provider_account_health.consecutive_failures + 1, \
+                 cooldown_until = excluded.cooldown_until, \
+                 updated_at = excluded.updated_at",
+        )
+        .bind(&account_id)
+        .bind(status_to_db_str(&HealthStatus::Unhealthy))
+        .bind(&now)
+        .bind(&cooldown_until)
+        .bind(&now)
+        .execute(self.pool())
+        .await
+        .map_err(|e| RookError::Registry(format!("upsert_account_health_failure failed: {e}")))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{ProviderAccount, ProviderVendor};
+
+    fn make_account() -> ProviderAccount {
+        ProviderAccount {
+            id: AccountId::generate(),
+            display_name: "Health Test Account".to_string(),
+            vendor: ProviderVendor::OpenAi,
+            api_base_override: None,
+            api_key: None,
+            enabled: true,
+            weight: 100,
+            priority: 0,
+            tags: vec![],
+            capabilities: vec!["chat".to_string()],
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_health_row_returns_none() {
+        let db = SqliteDb::open_in_memory().await.unwrap();
+        let id = AccountId::generate();
+
+        let health = db.get_account_health(&id).await.unwrap();
+
+        assert!(health.is_none());
+    }
+
+    #[tokio::test]
+    async fn failure_health_round_trips_and_increments() {
+        let db = SqliteDb::open_in_memory().await.unwrap();
+        let account = make_account();
+        let id = account.id;
+        db.insert_account(&account).await.unwrap();
+
+        db.upsert_account_health_failure(id, 60).await.unwrap();
+        db.upsert_account_health_failure(id, 60).await.unwrap();
+
+        let health = db.get_account_health(&id).await.unwrap().unwrap();
+
+        assert_eq!(health.account_id, id);
+        assert_eq!(health.status, HealthStatus::Unhealthy);
+        assert_eq!(health.consecutive_failures, 2);
+        assert!(health.last_checked.is_some());
+        assert!(health.cooldown_until.is_some());
+        assert!(health.cooldown_until.unwrap() > Utc::now());
+    }
+
+    #[tokio::test]
+    async fn success_health_clears_cooldown_and_failures() {
+        let db = SqliteDb::open_in_memory().await.unwrap();
+        let account = make_account();
+        let id = account.id;
+        db.insert_account(&account).await.unwrap();
+
+        db.upsert_account_health_failure(id, 60).await.unwrap();
+        db.upsert_account_health_success(id).await.unwrap();
+
+        let health = db.get_account_health(&id).await.unwrap().unwrap();
+
+        assert_eq!(health.status, HealthStatus::Healthy);
+        assert_eq!(health.consecutive_failures, 0);
+        assert!(health.last_checked.is_some());
+        assert!(health.cooldown_until.is_none());
+    }
+}

--- a/clients/rook/src/db/mod.rs
+++ b/clients/rook/src/db/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod account;
 pub mod audit;
+pub mod health;
 pub mod idempotency;
 pub mod pool;
 pub mod route;
@@ -43,6 +44,11 @@ const MIGRATION_SQL_0004: &str = include_str!(concat!(
 const MIGRATION_SQL_0005: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/migrations/0005_admin_audit_events.sql"
+));
+
+const MIGRATION_SQL_0006: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/migrations/0006_health_persistence.sql"
 ));
 
 /// A handle to the Rook SQLite database.
@@ -240,6 +246,21 @@ impl SqliteDb {
 
         if row_0005.is_none() {
             apply_migration(pool, version_0005, MIGRATION_SQL_0005).await?;
+        }
+
+        // ── Migration 0006: provider account health persistence ───────────────
+        let version_0006 = "0006_health_persistence";
+        let row_0006: Option<(String,)> =
+            sqlx::query_as("SELECT version FROM schema_migrations WHERE version = ?")
+                .bind(version_0006)
+                .fetch_optional(pool)
+                .await
+                .map_err(|e| {
+                    RookError::Registry(format!("failed to check migration 0006 status: {e}"))
+                })?;
+
+        if row_0006.is_none() {
+            apply_migration(pool, version_0006, MIGRATION_SQL_0006).await?;
         }
 
         Ok(())
@@ -482,6 +503,45 @@ mod tests {
         assert_eq!(
             row.map(|(version,)| version),
             Some("0005_admin_audit_events".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn open_in_memory_applies_health_persistence_migration() {
+        let db = SqliteDb::open_in_memory().await.unwrap();
+
+        let columns = sqlx::query("PRAGMA table_info(provider_account_health)")
+            .fetch_all(db.pool())
+            .await
+            .unwrap();
+
+        let column_names: Vec<String> = columns
+            .iter()
+            .filter_map(|row| row.try_get::<String, _>("name").ok())
+            .collect();
+
+        assert!(column_names.contains(&"account_id".to_string()));
+        assert!(column_names.contains(&"status".to_string()));
+        assert!(column_names.contains(&"last_checked".to_string()));
+        assert!(column_names.contains(&"consecutive_failures".to_string()));
+        assert!(column_names.contains(&"cooldown_until".to_string()));
+        assert!(column_names.contains(&"updated_at".to_string()));
+    }
+
+    #[tokio::test]
+    async fn open_in_memory_records_health_persistence_migration_version() {
+        let db = SqliteDb::open_in_memory().await.unwrap();
+
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT version FROM schema_migrations WHERE version = ?")
+                .bind("0006_health_persistence")
+                .fetch_optional(db.pool())
+                .await
+                .unwrap();
+
+        assert_eq!(
+            row.map(|(version,)| version),
+            Some("0006_health_persistence".to_string())
         );
     }
 }

--- a/clients/rook/src/registry/mod.rs
+++ b/clients/rook/src/registry/mod.rs
@@ -1,7 +1,7 @@
 //! Registry — the composition root for Rook's persistence layer.
 //!
 //! [`RookRegistry`] owns a [`SqliteDb`] handle and exposes each domain
-//! service as a concrete `SqliteXxxService` (or `InMemory` for health).
+//! service as a concrete `SqliteXxxService`.
 //!
 //! Consumers (gateway, TUI, dashboard) depend on the service traits via
 //! generic bounds or direct method calls on the concrete types returned here.
@@ -24,7 +24,7 @@
 use crate::db::{DbStartupReadiness, SqliteDb};
 use crate::domain::RookError;
 use crate::services::{
-    account::SqliteAccountService, audit::SqliteAuditService, health::InMemoryHealthService,
+    account::SqliteAccountService, audit::SqliteAuditService, health::SqliteHealthService,
     idempotency::SqliteIdempotencyService, pool::SqlitePoolService, route::SqliteRouteService,
     settings::SqliteSettingsService,
 };
@@ -40,7 +40,7 @@ pub struct RookRegistry {
     routes: SqliteRouteService,
     settings: SqliteSettingsService,
     idempotency: SqliteIdempotencyService,
-    health: InMemoryHealthService,
+    health: SqliteHealthService,
     #[cfg(test)]
     db: SqliteDb,
 }
@@ -79,7 +79,7 @@ impl RookRegistry {
             routes: SqliteRouteService::new(db.clone()),
             settings: SqliteSettingsService::new(db.clone()),
             idempotency: SqliteIdempotencyService::new(db.clone()),
-            health: InMemoryHealthService::new(),
+            health: SqliteHealthService::new(db.clone()),
             #[cfg(test)]
             db,
         }
@@ -124,7 +124,7 @@ impl RookRegistry {
     }
 
     /// Health service — track per-account health state.
-    pub fn health(&self) -> &InMemoryHealthService {
+    pub fn health(&self) -> &SqliteHealthService {
         &self.health
     }
 }
@@ -136,8 +136,8 @@ mod tests {
     use super::*;
     use crate::domain::RookSettings;
     use crate::services::{
-        account::AccountService as _, pool::PoolService as _, route::RouteService as _,
-        settings::SettingsService as _,
+        account::AccountService as _, health::HealthService as _, pool::PoolService as _,
+        route::RouteService as _, settings::SettingsService as _,
     };
 
     async fn registry() -> RookRegistry {
@@ -215,5 +215,45 @@ mod tests {
 
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].id, "audit-1");
+    }
+
+    #[tokio::test]
+    async fn registry_health_state_survives_reopen() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let db_path = dir.path().join("rook-health-reopen.db");
+        let db_path = db_path.to_string_lossy().to_string();
+        let account_id = crate::domain::AccountId::generate();
+
+        {
+            let registry = RookRegistry::open(&db_path).await.unwrap();
+            registry
+                .accounts()
+                .create(crate::domain::ProviderAccount {
+                    id: account_id,
+                    display_name: "Health Reopen Account".to_string(),
+                    vendor: crate::domain::ProviderVendor::OpenAi,
+                    api_base_override: None,
+                    api_key: None,
+                    enabled: true,
+                    weight: 100,
+                    priority: 0,
+                    tags: vec![],
+                    capabilities: vec!["chat".to_string()],
+                })
+                .await
+                .unwrap();
+            registry.health().mark_failure(account_id, 9999).await;
+        }
+
+        let reopened = RookRegistry::open(&db_path).await.unwrap();
+        let health = reopened.health().get(account_id).await;
+
+        assert_eq!(
+            health.status,
+            crate::services::health::HealthStatus::Unhealthy
+        );
+        assert_eq!(health.consecutive_failures, 1);
+        assert!(health.cooldown_until.is_some());
+        assert!(!reopened.health().is_available(account_id).await);
     }
 }

--- a/clients/rook/src/services/health.rs
+++ b/clients/rook/src/services/health.rs
@@ -189,11 +189,103 @@ impl HealthService for InMemoryHealthService {
     }
 }
 
+// ── SQLite implementation ─────────────────────────────────────────────────────
+
+/// SQLite-backed [`HealthService`] for production provider account health state.
+#[derive(Clone, Debug)]
+pub struct SqliteHealthService {
+    db: crate::db::SqliteDb,
+}
+
+impl SqliteHealthService {
+    /// Wrap an existing [`crate::db::SqliteDb`].
+    pub fn new(db: crate::db::SqliteDb) -> Self {
+        Self { db }
+    }
+}
+
+impl HealthService for SqliteHealthService {
+    async fn get(&self, account_id: AccountId) -> AccountHealth {
+        match self.db.get_account_health(&account_id).await {
+            Ok(Some(health)) => health,
+            Ok(None) => AccountHealth::new(account_id),
+            Err(e) => {
+                tracing::warn!(
+                    account_id = %account_id,
+                    error = %e,
+                    "failed to read health state"
+                );
+                AccountHealth::new(account_id)
+            }
+        }
+    }
+
+    async fn mark_success(&self, account_id: AccountId) {
+        if let Err(e) = self.db.upsert_account_health_success(account_id).await {
+            tracing::warn!(
+                account_id = %account_id,
+                error = %e,
+                "failed to persist health state"
+            );
+        }
+    }
+
+    async fn mark_failure(&self, account_id: AccountId, cooldown_seconds: u64) {
+        if let Err(e) = self
+            .db
+            .upsert_account_health_failure(account_id, cooldown_seconds)
+            .await
+        {
+            tracing::warn!(
+                account_id = %account_id,
+                error = %e,
+                "failed to persist health state"
+            );
+        }
+    }
+
+    async fn is_available(&self, account_id: AccountId) -> bool {
+        let health = self.get(account_id).await;
+        if let Some(until) = health.cooldown_until {
+            if Utc::now() < until {
+                return false;
+            }
+        }
+        true
+    }
+
+    async fn list_healthy(&self, account_ids: &[AccountId]) -> Vec<AccountId> {
+        let mut result = Vec::new();
+        for id in account_ids {
+            if self.is_available(*id).await {
+                result.push(*id);
+            }
+        }
+        result
+    }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::{ProviderAccount, ProviderVendor};
+
+    fn make_account(id: AccountId) -> ProviderAccount {
+        ProviderAccount {
+            id,
+            display_name: "Health Test Account".to_string(),
+            vendor: ProviderVendor::OpenAi,
+            api_base_override: None,
+            api_key: None,
+            enabled: true,
+            weight: 100,
+            priority: 0,
+            tags: vec![],
+            capabilities: vec!["chat".to_string()],
+        }
+    }
 
     #[tokio::test]
     async fn initial_health_is_unknown_and_available() {
@@ -282,5 +374,63 @@ mod tests {
         svc.mark_failure(id, 1).await;
         svc.mark_success(id).await;
         assert_eq!(svc.get(id).await.status, HealthStatus::Healthy);
+    }
+
+    #[tokio::test]
+    async fn sqlite_health_missing_row_is_unknown_and_available() {
+        let db = crate::db::SqliteDb::open_in_memory().await.unwrap();
+        let svc = SqliteHealthService::new(db);
+        let id = AccountId::generate();
+
+        let health = svc.get(id).await;
+
+        assert_eq!(health.status, HealthStatus::Unknown);
+        assert_eq!(health.consecutive_failures, 0);
+        assert!(health.cooldown_until.is_none());
+        assert!(svc.is_available(id).await);
+    }
+
+    #[tokio::test]
+    async fn sqlite_health_persists_cooldown_across_service_instances() {
+        let db = crate::db::SqliteDb::open_in_memory().await.unwrap();
+        let id = AccountId::generate();
+        db.insert_account(&make_account(id)).await.unwrap();
+        let first = SqliteHealthService::new(db.clone());
+        let second = SqliteHealthService::new(db);
+
+        first.mark_failure(id, 9999).await;
+
+        let health = second.get(id).await;
+        assert_eq!(health.status, HealthStatus::Unhealthy);
+        assert_eq!(health.consecutive_failures, 1);
+        assert!(health.cooldown_until.is_some());
+        assert!(!second.is_available(id).await);
+    }
+
+    #[tokio::test]
+    async fn sqlite_health_expired_cooldown_is_available() {
+        let db = crate::db::SqliteDb::open_in_memory().await.unwrap();
+        let id = AccountId::generate();
+        db.insert_account(&make_account(id)).await.unwrap();
+        let svc = SqliteHealthService::new(db);
+
+        svc.mark_failure(id, 0).await;
+
+        assert!(svc.is_available(id).await);
+    }
+
+    #[tokio::test]
+    async fn sqlite_health_concurrent_failures_do_not_lose_increments() {
+        let db = crate::db::SqliteDb::open_in_memory().await.unwrap();
+        let id = AccountId::generate();
+        db.insert_account(&make_account(id)).await.unwrap();
+        let svc = SqliteHealthService::new(db);
+
+        let first = svc.mark_failure(id, 9999);
+        let second = svc.mark_failure(id, 9999);
+        tokio::join!(first, second);
+
+        let health = svc.get(id).await;
+        assert_eq!(health.consecutive_failures, 2);
     }
 }


### PR DESCRIPTION
## Summary
- add SQLite persistence for provider account health/cooldown state
- wire RookRegistry to use SqliteHealthService for runtime health checks
- preserve missing-row Unknown semantics and recover availability after expired cooldowns

## Tests
- cargo test --manifest-path clients/rook/Cargo.toml

Closes #683