### PR TITLE
feat(rook): add principal-aware rate limiting

### DIFF
--- a/clients/rook/src/server/mod.rs
+++ b/clients/rook/src/server/mod.rs
@@ -221,12 +221,12 @@ async fn build_app_with_registry_and_startup_state(
         .merge(
             admin::management_router(admin_state)
                 .layer(middleware::from_fn_with_state(
-                    inbound_auth.clone(),
-                    admin_inbound_auth,
-                ))
-                .layer(middleware::from_fn_with_state(
                     admin_rate_limit,
                     apply_rate_limit,
+                ))
+                .layer(middleware::from_fn_with_state(
+                    inbound_auth.clone(),
+                    admin_inbound_auth,
                 )),
         )
         .layer(middleware::from_fn_with_state(
@@ -237,12 +237,12 @@ async fn build_app_with_registry_and_startup_state(
         .merge(
             gateway::build_models_router(gateway_state.clone())
                 .layer(middleware::from_fn_with_state(
-                    inbound_auth.clone(),
-                    gateway_inbound_auth,
-                ))
-                .layer(middleware::from_fn_with_state(
                     models_rate_limit,
                     apply_rate_limit,
+                ))
+                .layer(middleware::from_fn_with_state(
+                    inbound_auth.clone(),
+                    gateway_inbound_auth,
                 ))
                 .layer(middleware::from_fn_with_state(
                     gateway_transport.clone(),
@@ -256,12 +256,12 @@ async fn build_app_with_registry_and_startup_state(
                     apply_chat_idempotency,
                 ))
                 .layer(middleware::from_fn_with_state(
-                    inbound_auth,
-                    gateway_inbound_auth,
-                ))
-                .layer(middleware::from_fn_with_state(
                     chat_rate_limit,
                     apply_rate_limit,
+                ))
+                .layer(middleware::from_fn_with_state(
+                    inbound_auth,
+                    gateway_inbound_auth,
                 ))
                 .layer(middleware::from_fn_with_state(
                     gateway_transport,
@@ -1288,7 +1288,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rate_limit_rejections_happen_before_auth_and_dashboard_routes_stay_out_of_scope() {
+    async fn rate_limit_rejections_happen_after_auth_and_dashboard_routes_stay_out_of_scope() {
         let app = build_app_with_registry(
             ServerConfig {
                 inbound_auth: InboundAuthConfig {
@@ -1316,13 +1316,26 @@ mod tests {
             app.clone(),
             axum::http::Method::GET,
             "/v1/models",
-            None,
+            Some("rook-inbound-secret"),
             None,
         )
         .await;
         assert_eq!(limited_models, StatusCode::TOO_MANY_REQUESTS);
         let limited_json: serde_json::Value = serde_json::from_slice(&limited_body).unwrap();
         assert_eq!(limited_json["error"]["code"], json!("rate_limited"));
+
+        let (unauthorized_models, _, unauthorized_body) = request_with_bearer(
+            app.clone(),
+            axum::http::Method::GET,
+            "/v1/models",
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(unauthorized_models, StatusCode::UNAUTHORIZED);
+        let unauthorized_json: serde_json::Value =
+            serde_json::from_slice(&unauthorized_body).unwrap();
+        assert_eq!(unauthorized_json["error"]["code"], json!("unauthorized"));
 
         let (dashboard_first, dashboard_body_first) = request_text(app.clone(), "/").await;
         let (dashboard_second, dashboard_body_second) = request_text(app, "/").await;

--- a/clients/rook/src/transport/rate_limit.rs
+++ b/clients/rook/src/transport/rate_limit.rs
@@ -1,10 +1,11 @@
 use crate::admin::types::admin_rate_limited_response;
+use crate::auth::types::AuthenticatedPrincipal;
 use crate::config::{RateLimitConfig, SurfaceRateLimitPolicy};
 use crate::gateway::types::gateway_rate_limited_response;
 use crate::observability::{
     normalize_rate_limit_endpoint, normalize_rate_limit_surface, Observability,
 };
-use crate::transport::context::RateLimitedSurface;
+use crate::transport::context::{ForwardedTrust, RateLimitedSurface, SanitizedTransportContext};
 use axum::body::Body;
 use axum::extract::{MatchedPath, Request, State};
 use axum::middleware::Next;
@@ -12,6 +13,14 @@ use axum::response::Response;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+/// Probability-based pruning: 1% chance to trigger pruning on each check.
+const PRUNE_CHANCE_DENOMINATOR: u32 = 100;
+const PRUNE_CHANCE_NUMERATOR: u32 = 1;
+
+/// TTL for stale entry eviction: 2x the max configured window (safe upper bound).
+/// Window configs max out at 3600s (1 hour), so 7200s is safe.
+const MAX_TTL_SECONDS: u64 = 7200;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RateLimitDecision {
@@ -25,10 +34,25 @@ pub struct SurfaceWindowState {
     pub request_count: u32,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RateLimitPrincipalKey {
+    Authenticated(String),
+    TrustedForwardedIp(std::net::IpAddr),
+    DirectIp(std::net::IpAddr),
+    LocalAnonymous,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RateLimitBucketKey {
+    pub surface: RateLimitedSurface,
+    pub principal: RateLimitPrincipalKey,
+}
+
 #[derive(Debug, Clone)]
 pub struct RateLimitState {
     pub policies: HashMap<RateLimitedSurface, SurfaceRateLimitPolicy>,
-    pub windows: Arc<tokio::sync::Mutex<HashMap<RateLimitedSurface, SurfaceWindowState>>>,
+    pub windows: Arc<tokio::sync::Mutex<HashMap<RateLimitBucketKey, SurfaceWindowState>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -54,21 +78,76 @@ impl RateLimitState {
         }
     }
 
-    pub async fn check(&self, surface: RateLimitedSurface) -> RateLimitDecision {
+    pub async fn check(
+        &self,
+        surface: RateLimitedSurface,
+        principal: RateLimitPrincipalKey,
+    ) -> RateLimitDecision {
         let now = Instant::now();
         let policy = self
             .policies
             .get(&surface)
             .expect("covered surface policy must exist");
+        let key = RateLimitBucketKey { surface, principal };
+
+        // Probabilistic pruning to evict stale entries and prevent unbounded growth.
         let mut windows = self.windows.lock().await;
-        let window = windows
-            .entry(surface)
-            .or_insert_with(|| SurfaceWindowState {
-                window_started_at: now,
-                request_count: 0,
-            });
+        if should_prune() {
+            pruning(&mut windows, now);
+        }
+
+        let window = windows.entry(key).or_insert_with(|| SurfaceWindowState {
+            window_started_at: now,
+            request_count: 0,
+        });
         evaluate_surface_limit(now, policy, window)
     }
+}
+
+/// Returns true with ~1% probability per call.
+/// Uses thread-local RNG to avoid per-call overhead.
+fn should_prune() -> bool {
+    use std::collections::hash_map::RandomState;
+    use std::hash::{BuildHasher, Hasher};
+
+    let state = RandomState::new();
+    let hash = state.build_hasher();
+    let seed = hash.finish();
+    (seed % u64::from(PRUNE_CHANCE_DENOMINATOR)) < u64::from(PRUNE_CHANCE_NUMERATOR)
+}
+
+/// Removes entries whose window started more than `ttl` seconds ago.
+/// Uses `ttl = max_window_seconds * 2` as a safe upper bound.
+fn pruning(windows: &mut HashMap<RateLimitBucketKey, SurfaceWindowState>, now: Instant) {
+    let ttl = Duration::from_secs(MAX_TTL_SECONDS);
+    windows.retain(|_, state| {
+        now.duration_since(state.window_started_at) < ttl
+    });
+}
+
+pub fn resolve_rate_limit_principal(request: &Request<Body>) -> RateLimitPrincipalKey {
+    if let Some(principal) = request.extensions().get::<AuthenticatedPrincipal>() {
+        if principal.scope_id == "anonymous-local" {
+            return RateLimitPrincipalKey::LocalAnonymous;
+        }
+        return RateLimitPrincipalKey::Authenticated(principal.scope_id.clone());
+    }
+
+    let Some(context) = request.extensions().get::<SanitizedTransportContext>() else {
+        return RateLimitPrincipalKey::Unknown;
+    };
+
+    if context.forwarded.trust == ForwardedTrust::Trusted {
+        if let Some(client_ip) = context.forwarded.client_ip {
+            return RateLimitPrincipalKey::TrustedForwardedIp(client_ip);
+        }
+    }
+
+    if let Some(peer_addr) = context.direct_peer_addr {
+        return RateLimitPrincipalKey::DirectIp(peer_addr.ip());
+    }
+
+    RateLimitPrincipalKey::Unknown
 }
 
 fn normalized_endpoint(request: &Request<Body>, surface: RateLimitedSurface) -> String {
@@ -119,7 +198,8 @@ pub async fn apply_rate_limit(
     }
 
     let surface = normalize_rate_limit_surface(state.surface);
-    match state.state.check(state.surface).await {
+    let principal = resolve_rate_limit_principal(&request);
+    match state.state.check(state.surface, principal).await {
         RateLimitDecision::Allow => {
             state
                 .observability
@@ -147,9 +227,15 @@ pub async fn apply_rate_limit(
 
 #[cfg(test)]
 mod tests {
-    use super::{evaluate_surface_limit, RateLimitDecision, RateLimitState, SurfaceWindowState};
+    use super::{
+        evaluate_surface_limit, resolve_rate_limit_principal, RateLimitDecision,
+        RateLimitPrincipalKey, RateLimitState, SurfaceWindowState,
+    };
     use crate::config::{RateLimitConfig, SurfaceRateLimitPolicy};
-    use crate::transport::context::RateLimitedSurface;
+    use crate::transport::context::{
+        ForwardedTrust, RateLimitedSurface, RouteSurface, SanitizedForwardedContext,
+        SanitizedTransportContext,
+    };
     use std::time::{Duration, Instant};
 
     fn policy(max_requests: u32, window_seconds: u64) -> SurfaceRateLimitPolicy {
@@ -157,6 +243,30 @@ mod tests {
             max_requests,
             window_seconds,
         }
+    }
+
+    fn request_with_context(
+        forwarded_trust: ForwardedTrust,
+        forwarded_ip: Option<&str>,
+        direct_peer: Option<&str>,
+    ) -> axum::http::Request<axum::body::Body> {
+        let mut request = axum::http::Request::builder()
+            .body(axum::body::Body::empty())
+            .unwrap();
+        request.extensions_mut().insert(SanitizedTransportContext {
+            request_id: "req-1".to_string(),
+            route_surface: RouteSurface::GatewayV1,
+            direct_peer_addr: direct_peer.map(|peer| peer.parse().unwrap()),
+            forwarded: SanitizedForwardedContext {
+                trust: forwarded_trust,
+                client_ip: forwarded_ip.map(|ip| ip.parse().unwrap()),
+                host: None,
+                proto: None,
+                port: None,
+                ignored_headers: vec![],
+            },
+        });
+        request
     }
 
     #[test]
@@ -223,6 +333,65 @@ mod tests {
         );
     }
 
+    #[test]
+    fn resolve_rate_limit_principal_prefers_authenticated_principal() {
+        let mut request = request_with_context(
+            ForwardedTrust::Trusted,
+            Some("203.0.113.9"),
+            Some("198.51.100.10:1234"),
+        );
+        request
+            .extensions_mut()
+            .insert(crate::auth::types::AuthenticatedPrincipal {
+                scope_id: "token-a".to_string(),
+            });
+
+        assert_eq!(
+            resolve_rate_limit_principal(&request),
+            RateLimitPrincipalKey::Authenticated("token-a".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_rate_limit_principal_uses_trusted_forwarded_ip_before_direct_peer() {
+        let request = request_with_context(
+            ForwardedTrust::Trusted,
+            Some("203.0.113.9"),
+            Some("198.51.100.10:1234"),
+        );
+
+        assert_eq!(
+            resolve_rate_limit_principal(&request),
+            RateLimitPrincipalKey::TrustedForwardedIp("203.0.113.9".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn resolve_rate_limit_principal_ignores_untrusted_forwarded_ip_and_uses_direct_peer() {
+        let request = request_with_context(
+            ForwardedTrust::Ignored,
+            Some("203.0.113.9"),
+            Some("198.51.100.10:1234"),
+        );
+
+        assert_eq!(
+            resolve_rate_limit_principal(&request),
+            RateLimitPrincipalKey::DirectIp("198.51.100.10".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn resolve_rate_limit_principal_uses_unknown_when_no_context_exists() {
+        let request = axum::http::Request::builder()
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        assert_eq!(
+            resolve_rate_limit_principal(&request),
+            RateLimitPrincipalKey::Unknown
+        );
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn rate_limit_state_keeps_surface_budgets_independent() {
         let state = RateLimitState::new(&RateLimitConfig {
@@ -232,23 +401,95 @@ mod tests {
         });
 
         assert_eq!(
-            state.check(RateLimitedSurface::AdminApi).await,
+            state
+                .check(RateLimitedSurface::AdminApi, RateLimitPrincipalKey::Unknown)
+                .await,
             RateLimitDecision::Allow
         );
         assert_eq!(
-            state.check(RateLimitedSurface::AdminApi).await,
+            state
+                .check(RateLimitedSurface::AdminApi, RateLimitPrincipalKey::Unknown)
+                .await,
             RateLimitDecision::Reject {
                 retry_after_seconds: 59,
             }
         );
 
         assert_eq!(
-            state.check(RateLimitedSurface::GatewayModels).await,
+            state
+                .check(
+                    RateLimitedSurface::GatewayModels,
+                    RateLimitPrincipalKey::Unknown
+                )
+                .await,
             RateLimitDecision::Allow
         );
         assert_eq!(
             state
-                .check(RateLimitedSurface::GatewayChatCompletions)
+                .check(
+                    RateLimitedSurface::GatewayChatCompletions,
+                    RateLimitPrincipalKey::Unknown,
+                )
+                .await,
+            RateLimitDecision::Allow
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rate_limit_state_keeps_principal_budgets_independent_on_same_surface() {
+        let state = RateLimitState::new(&RateLimitConfig {
+            api: policy(1, 60),
+            v1_models: policy(1, 60),
+            v1_chat_completions: policy(1, 60),
+        });
+
+        let alice = RateLimitPrincipalKey::Authenticated("alice".to_string());
+        let bob = RateLimitPrincipalKey::Authenticated("bob".to_string());
+
+        assert_eq!(
+            state
+                .check(RateLimitedSurface::GatewayChatCompletions, alice.clone())
+                .await,
+            RateLimitDecision::Allow
+        );
+        assert!(matches!(
+            state
+                .check(RateLimitedSurface::GatewayChatCompletions, alice)
+                .await,
+            RateLimitDecision::Reject { .. }
+        ));
+        assert_eq!(
+            state
+                .check(RateLimitedSurface::GatewayChatCompletions, bob)
+                .await,
+            RateLimitDecision::Allow
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rate_limit_state_keeps_surface_budgets_independent_for_same_principal() {
+        let state = RateLimitState::new(&RateLimitConfig {
+            api: policy(1, 60),
+            v1_models: policy(1, 60),
+            v1_chat_completions: policy(1, 60),
+        });
+        let principal = RateLimitPrincipalKey::Authenticated("shared".to_string());
+
+        assert_eq!(
+            state
+                .check(RateLimitedSurface::AdminApi, principal.clone())
+                .await,
+            RateLimitDecision::Allow
+        );
+        assert!(matches!(
+            state
+                .check(RateLimitedSurface::AdminApi, principal.clone())
+                .await,
+            RateLimitDecision::Reject { .. }
+        ));
+        assert_eq!(
+            state
+                .check(RateLimitedSurface::GatewayModels, principal)
                 .await,
             RateLimitDecision::Allow
         );


### PR DESCRIPTION
## Related Issues

Fixes #681

---

## Summary

- Extend Rook's in-process rate limiter to key request windows by `(surface, principal)` instead of only by surface.
- Resolve principals safely from authenticated bearer context, trusted forwarded client IP, direct peer IP, or a conservative unknown fallback.
- Reorder protected route middleware so auth establishes principal context before rate limiting while transport remains the outer request baseline.

---

## Tested Information

Ran from `clients/rook`:

```bash
cargo fmt
cargo test transport::rate_limit
cargo test rate_limit
cargo test
```

Full Rook suite passed: 354 lib tests, 16 main tests, 2 distribution contract tests, 4 doctor operational diagnostics tests, and 1 doc-test.

---

## Documentation Impact

- Docs updated in: N/A
- No docs update required because: this changes internal Rook abuse-control behavior and tests without adding new user-facing configuration, CLI flags, or API surface.
- I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
