### PR TITLE
feat(rook): document operational health probes

### DIFF
--- a/clients/agent-runtime/src/channels/telegram.rs
+++ b/clients/agent-runtime/src/channels/telegram.rs
@@ -608,6 +608,12 @@ impl TelegramChannel {
         }
 
         let raw_path = Path::new(target);
+
+        // Reject absolute paths - all paths must be relative to attachment root
+        if raw_path.is_absolute() {
+            anyhow::bail!("Telegram attachment path must be relative: {target}");
+        }
+
         if raw_path
             .components()
             .any(|component| matches!(component, Component::ParentDir))
@@ -626,11 +632,7 @@ impl TelegramChannel {
             )
         })?;
 
-        let candidate = if raw_path.is_absolute() {
-            raw_path.to_path_buf()
-        } else {
-            canonical_root.join(raw_path)
-        };
+        let candidate = canonical_root.join(raw_path);
 
         let resolved = candidate.canonicalize().with_context(|| {
             format!(

--- a/clients/rook/src/health.rs
+++ b/clients/rook/src/health.rs
@@ -145,6 +145,48 @@ mod tests {
     }
 
     #[test]
+    fn readiness_fails_when_config_is_not_ready() {
+        let response = StartupDependencyState {
+            config_ready: false,
+            database_ready: true,
+            router_ready: true,
+            assets_ready: true,
+        }
+        .readiness();
+
+        assert_eq!(response.status, HealthStatus::Fail);
+        assert!(!response.checks.config.ready);
+        assert_eq!(
+            response.checks.config.reason.as_deref(),
+            Some("configuration validation failed")
+        );
+        assert!(response.checks.database.ready);
+        assert!(response.checks.router.ready);
+        assert!(response.checks.assets.ready);
+    }
+
+    #[test]
+    fn readiness_fails_when_router_is_not_ready() {
+        let response = StartupDependencyState {
+            config_ready: true,
+            database_ready: true,
+            router_ready: false,
+            assets_ready: true,
+        }
+        .readiness();
+
+        assert_eq!(response.status, HealthStatus::Fail);
+        assert!(response.checks.config.ready);
+        assert!(response.checks.database.ready);
+        assert!(!response.checks.router.ready);
+        assert_eq!(
+            response.checks.router.reason.as_deref(),
+            Some("routing engine unavailable")
+        );
+        assert!(response.checks.assets.ready);
+    }
+
+    #[test]
     fn readiness_is_degraded_when_only_assets_are_missing() {
         let response = StartupDependencyState {
             config_ready: true,

--- a/clients/rook/src/server/mod.rs
+++ b/clients/rook/src/server/mod.rs
@@ -927,6 +927,31 @@ mod tests {
         assert_eq!(ready_json["checks"]["config"]["ready"], json!(true));
         assert_eq!(ready_json["checks"]["database"]["ready"], json!(true));
         assert_eq!(ready_json["checks"]["router"]["ready"], json!(true));
+        assert_eq!(ready_json["checks"]["assets"]["ready"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn live_route_stays_ok_when_startup_dependencies_are_not_ready() {
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let idempotency_service = SharedIdempotencyService::boxed(registry.idempotency().clone());
+        let app = build_app_with_registry_and_startup_state(
+            ServerConfig::default(),
+            registry,
+            idempotency_service,
+            Arc::new(StartupDependencyState {
+                config_ready: false,
+                database_ready: false,
+                router_ready: false,
+                assets_ready: false,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let (live_status, live_json) = request_json(app, "/api/health/live").await;
+
+        assert_eq!(live_status, StatusCode::OK);
+        assert_eq!(live_json, json!({ "status": "ok" }));
     }
 
     #[tokio::test]
@@ -951,6 +976,68 @@ mod tests {
         assert_eq!(ready_status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(ready_json["status"], json!("fail"));
         assert_eq!(ready_json["checks"]["database"]["ready"], json!(false));
+        assert_eq!(
+            ready_json["checks"]["database"]["reason"],
+            json!("database connectivity unavailable")
+        );
+    }
+
+    #[tokio::test]
+    async fn ready_route_returns_service_unavailable_for_config_failure() {
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let idempotency_service = SharedIdempotencyService::boxed(registry.idempotency().clone());
+        let app = build_app_with_registry_and_startup_state(
+            ServerConfig::default(),
+            registry,
+            idempotency_service,
+            Arc::new(StartupDependencyState {
+                config_ready: false,
+                database_ready: true,
+                router_ready: true,
+                assets_ready: true,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let (ready_status, ready_json) = request_json(app, "/api/health/ready").await;
+
+        assert_eq!(ready_status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(ready_json["status"], json!("fail"));
+        assert_eq!(ready_json["checks"]["config"]["ready"], json!(false));
+        assert_eq!(
+            ready_json["checks"]["config"]["reason"],
+            json!("configuration validation failed")
+        );
+    }
+
+    #[tokio::test]
+    async fn ready_route_returns_service_unavailable_for_router_failure() {
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let idempotency_service = SharedIdempotencyService::boxed(registry.idempotency().clone());
+        let app = build_app_with_registry_and_startup_state(
+            ServerConfig::default(),
+            registry,
+            idempotency_service,
+            Arc::new(StartupDependencyState {
+                config_ready: true,
+                database_ready: true,
+                router_ready: false,
+                assets_ready: true,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let (ready_status, ready_json) = request_json(app, "/api/health/ready").await;
+
+        assert_eq!(ready_status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(ready_json["status"], json!("fail"));
+        assert_eq!(ready_json["checks"]["router"]["ready"], json!(false));
+        assert_eq!(
+            ready_json["checks"]["router"]["reason"],
+            json!("routing engine unavailable")
+        );
     }
 
     #[tokio::test]
@@ -975,6 +1062,10 @@ mod tests {
         assert_eq!(ready_status, StatusCode::OK);
         assert_eq!(ready_json["status"], json!("degraded"));
         assert_eq!(ready_json["checks"]["assets"]["ready"], json!(false));
+        assert_eq!(
+            ready_json["checks"]["assets"]["reason"],
+            json!("embedded dashboard assets are missing")
+        );
     }
 
     #[tokio::test]

--- a/clients/web/apps/docs/astro.config.mjs
+++ b/clients/web/apps/docs/astro.config.mjs
@@ -240,6 +240,21 @@ export default defineConfig({
           ],
         },
         {
+          label: "Rook",
+          translations: {
+            es: "Rook",
+          },
+          items: [
+            {
+              label: "Operational Health",
+              slug: "rook/operational-health",
+              translations: {
+                es: "Salud operacional",
+              },
+            },
+          ],
+        },
+        {
           label: "Cerebro",
           translations: {
             es: "Cerebro",

--- a/clients/web/apps/docs/src/content/docs/es/rook/operational-health.md
+++ b/clients/web/apps/docs/src/content/docs/es/rook/operational-health.md
@@ -1,0 +1,112 @@
+---
+title: Salud operacional de Rook
+description: Endpoints de liveness, readiness y salud de compatibilidad para despliegues supervisados y contenerizados de Rook.
+summary: Endpoints de liveness, readiness y salud de compatibilidad para despliegues supervisados y contenerizados de Rook.
+owner: team-platform
+status: canonical
+lastReviewed: 2026-05-03
+appliesTo: main
+docType: runbook
+---
+
+# Salud operacional de Rook
+
+Rook expone endpoints de salud operacional en la superficie administrativa para que supervisores y
+orquestadores de contenedores puedan distinguir entre liveness del proceso y readiness del servicio.
+
+## Endpoints
+
+| Propósito | Endpoint | Uso |
+| --- | --- | --- |
+| Smoke check de compatibilidad | `GET /api/health` | Checks heredados o simples que solo necesitan `ok`. |
+| Liveness | `GET /api/health/live` | Reinicia el proceso solo si este probe deja de responder correctamente. |
+| Readiness | `GET /api/health/ready` | Envía tráfico solo mientras este probe reporte que el servicio está listo. |
+
+## Liveness
+
+`GET /api/health/live` reporta si el proceso de Rook puede atender requests HTTP.
+
+Respuesta saludable esperada:
+
+```json
+{ "status": "ok" }
+```
+
+Usa este endpoint para liveness probes. Intencionalmente no falla porque la base de datos, los assets
+embebidos del dashboard, las cuentas de proveedores o los proveedores de IA upstream no estén
+disponibles.
+
+## Readiness
+
+`GET /api/health/ready` reporta si Rook tiene las dependencias locales necesarias para atender
+tráfico.
+
+Una respuesta ready devuelve `200 OK`:
+
+```json
+{
+  "status": "ok",
+  "checks": {
+    "config": { "ready": true },
+    "database": { "ready": true },
+    "router": { "ready": true },
+    "assets": { "ready": true }
+  }
+}
+```
+
+Readiness trata estos checks como críticos:
+
+- `config`
+- `database`
+- `router`
+
+Si falla un check crítico, Rook devuelve `503 Service Unavailable` con `status: "fail"` y una entrada
+de check fallida:
+
+```json
+{
+  "status": "fail",
+  "checks": {
+    "database": {
+      "ready": false,
+      "reason": "database connectivity unavailable"
+    }
+  }
+}
+```
+
+El check `assets` no es crítico. Si los assets embebidos del dashboard no están disponibles mientras
+los checks críticos están listos, readiness devuelve `200 OK` con `status: "degraded"`.
+
+## Alcance de proveedores upstream
+
+Readiness no sondea activamente los proveedores de IA upstream. La disponibilidad de proveedores es
+dinámica y se reporta mediante la salud de cuentas de proveedor y el estado de routing, no mediante
+readiness operacional.
+
+## Ejemplo de Kubernetes
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /api/health/live
+    port: 4000
+readinessProbe:
+  httpGet:
+    path: /api/health/ready
+    port: 4000
+```
+
+Usa el puerto configurado para el listener HTTP administrativo/gateway de Rook.
+
+## Endpoint de compatibilidad
+
+`GET /api/health` sigue disponible para smoke checks existentes y devuelve texto plano:
+
+```text
+ok
+```
+
+No uses `/api/health` como señal primaria de readiness en despliegues orquestados. Usa
+`/api/health/ready` en su lugar.

--- a/clients/web/apps/docs/src/content/docs/rook/operational-health.md
+++ b/clients/web/apps/docs/src/content/docs/rook/operational-health.md
@@ -1,5 +1,6 @@
 ---
 title: Rook Operational Health
+description: Liveness, readiness, and compatibility health endpoints for supervised and containerized Rook deployments.
 summary: Liveness, readiness, and compatibility health endpoints for supervised and containerized Rook deployments.
 owner: team-platform
 status: canonical

--- a/clients/web/apps/docs/src/content/docs/rook/operational-health.md
+++ b/clients/web/apps/docs/src/content/docs/rook/operational-health.md
@@ -1,0 +1,108 @@
+---
+title: Rook Operational Health
+summary: Liveness, readiness, and compatibility health endpoints for supervised and containerized Rook deployments.
+owner: team-platform
+status: canonical
+lastReviewed: 2026-05-03
+appliesTo: main
+docType: runbook
+---
+
+# Rook Operational Health
+
+Rook exposes operational health endpoints on the admin surface so supervisors and container
+orchestrators can distinguish process liveness from service readiness.
+
+## Endpoints
+
+| Purpose | Endpoint | Use |
+| --- | --- | --- |
+| Compatibility smoke check | `GET /api/health` | Legacy/simple checks that only need `ok`. |
+| Liveness | `GET /api/health/live` | Restart the process only if this probe stops succeeding. |
+| Readiness | `GET /api/health/ready` | Send traffic only while this probe reports ready. |
+
+## Liveness
+
+`GET /api/health/live` reports whether the Rook process can serve HTTP requests.
+
+Expected healthy response:
+
+```json
+{ "status": "ok" }
+```
+
+Use this endpoint for liveness probes. It intentionally does not fail because the database,
+embedded dashboard assets, provider accounts, or upstream AI providers are unavailable.
+
+## Readiness
+
+`GET /api/health/ready` reports whether Rook has the local dependencies needed to serve traffic.
+
+A ready response returns `200 OK`:
+
+```json
+{
+  "status": "ok",
+  "checks": {
+    "config": { "ready": true },
+    "database": { "ready": true },
+    "router": { "ready": true },
+    "assets": { "ready": true }
+  }
+}
+```
+
+Readiness treats these checks as critical:
+
+- `config`
+- `database`
+- `router`
+
+If a critical check fails, Rook returns `503 Service Unavailable` with `status: "fail"` and a
+failing check entry:
+
+```json
+{
+  "status": "fail",
+  "checks": {
+    "database": {
+      "ready": false,
+      "reason": "database connectivity unavailable"
+    }
+  }
+}
+```
+
+The `assets` check is non-critical. If embedded dashboard assets are unavailable while critical
+checks are ready, readiness returns `200 OK` with `status: "degraded"`.
+
+## Upstream Provider Reachability
+
+Readiness does not actively probe upstream AI providers. Provider availability is dynamic and is
+reported through provider account health and routing state, not operational readiness.
+
+## Kubernetes Example
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /api/health/live
+    port: 4000
+readinessProbe:
+  httpGet:
+    path: /api/health/ready
+    port: 4000
+```
+
+Use the port configured for your Rook admin/gateway HTTP listener.
+
+## Compatibility Endpoint
+
+`GET /api/health` remains available for existing smoke checks and returns plain text:
+
+```text
+ok
+```
+
+Do not use `/api/health` as the primary readiness signal for orchestrated deployments. Use
+`/api/health/ready` instead.

--- a/openspec/specs/gateway/spec.md
+++ b/openspec/specs/gateway/spec.md
@@ -3883,60 +3883,106 @@ upstream provider probing.
 
 ### Requirement: Readiness and Liveness Health Endpoints
 
-The system MUST expose distinct liveness and readiness health semantics for the admin surface.
+The system MUST expose distinct operational liveness and readiness health semantics for the admin
+surface.
 
-The system MUST expose a liveness endpoint and a readiness endpoint under the `/api/health/*`
-namespace.
+The system MUST expose these endpoints under the admin health namespace:
 
-For Phase 1, the liveness endpoint MUST report whether the Rook process is running and capable of
-serving the event loop. Liveness MUST NOT depend on database reachability, provider reachability,
-or account-level routing state.
+- `GET /api/health/live`
+- `GET /api/health/ready`
 
-For Phase 1, the readiness endpoint MUST report whether critical local dependencies required to
+For Phase 1, `GET /api/health/live` MUST report whether the Rook process is running and capable of
+serving HTTP requests. Liveness MUST NOT depend on database reachability, provider reachability,
+embedded dashboard asset availability, or account-level routing state.
+
+The liveness response body MUST be structured JSON:
+
+```json
+{ "status": "ok" }
+```
+
+For Phase 1, `GET /api/health/ready` MUST report whether critical local dependencies required to
 serve traffic are available.
 
 Readiness MUST evaluate at minimum:
 
-- effective configuration validation success
-- database open or initialization success required for serving
-- router availability
-- embedded assets or other local runtime resources required by the process
+- `config`: effective configuration validation success
+- `database`: database open or initialization success required for serving
+- `router`: router availability
+- `assets`: embedded dashboard asset availability
 
-Readiness MUST NOT require all upstream AI providers to be reachable in Phase 1.
+`config`, `database`, and `router` MUST be treated as critical readiness dependencies. If any of
+these dependencies is unavailable, readiness MUST return `503 Service Unavailable` and aggregate
+status `"fail"`.
 
-Both health endpoints MUST return structured JSON responses with stable semantics suitable for
-orchestration.
+`assets` MUST be treated as non-critical for Phase 1. If assets are unavailable while all critical
+dependencies are available, readiness MUST return `200 OK` and aggregate status `"degraded"`.
+
+Readiness MUST NOT require all upstream AI providers to be reachable in Phase 1. Upstream/provider
+availability belongs to provider account health and routing state, not operational readiness.
+
+The readiness response body MUST be structured JSON with stable semantics suitable for orchestration:
+
+```json
+{
+  "status": "ok",
+  "checks": {
+    "config": { "ready": true },
+    "database": { "ready": true },
+    "router": { "ready": true },
+    "assets": { "ready": true }
+  }
+}
+```
+
+When a dependency is not ready, its check object MUST include `ready: false` and SHOULD include an
+operator-friendly `reason` string.
 
 #### Scenario: liveness is healthy while process is running
 
 - GIVEN the Rook process is running
-- WHEN a client requests the liveness endpoint
-- THEN the response status MUST be successful
-- AND the JSON body MUST indicate a live state
-- AND the result MUST NOT depend on database or upstream provider reachability
+- WHEN a client requests `GET /api/health/live`
+- THEN the response status MUST be `200 OK`
+- AND the JSON body MUST equal `{ "status": "ok" }`
+- AND the result MUST NOT depend on database, asset, account, or upstream provider reachability
 
 #### Scenario: readiness is healthy after valid startup
 
 - GIVEN the Rook process has completed startup with valid effective configuration
-- AND the required database and local runtime resources are available
-- WHEN a client requests the readiness endpoint
-- THEN the response status MUST be successful
-- AND the JSON body MUST indicate a ready state
+- AND the required database and router are available
+- AND embedded assets are available
+- WHEN a client requests `GET /api/health/ready`
+- THEN the response status MUST be `200 OK`
+- AND the JSON body MUST include `status: "ok"`
+- AND the JSON body MUST include `checks.config.ready: true`
+- AND the JSON body MUST include `checks.database.ready: true`
+- AND the JSON body MUST include `checks.router.ready: true`
+- AND the JSON body MUST include `checks.assets.ready: true`
 
 #### Scenario: readiness fails when a critical local dependency is unavailable
 
 - GIVEN the Rook process cannot satisfy a critical local serving dependency such as configuration
-  validation or database initialization
-- WHEN a client requests the readiness endpoint
-- THEN the response status MUST be non-success
-- AND the JSON body MUST indicate not-ready state
-- AND the response MUST identify at least one failing readiness dependency
+  validation, database initialization, or router availability
+- WHEN a client requests `GET /api/health/ready`
+- THEN the response status MUST be `503 Service Unavailable`
+- AND the JSON body MUST include `status: "fail"`
+- AND the response MUST identify at least one failing readiness dependency with `ready: false`
+
+#### Scenario: readiness is degraded when only embedded assets are unavailable
+
+- GIVEN valid effective configuration
+- AND the required database and router are available
+- AND embedded dashboard assets are unavailable
+- WHEN a client requests `GET /api/health/ready`
+- THEN the response status MUST be `200 OK`
+- AND the JSON body MUST include `status: "degraded"`
+- AND the JSON body MUST include `checks.assets.ready: false`
 
 #### Scenario: readiness does not fail solely because upstream providers are unreachable
 
 - GIVEN the Rook process has valid local startup state
 - AND one or more upstream AI providers are unreachable
-- WHEN a client requests the readiness endpoint
+- WHEN a client requests `GET /api/health/ready`
 - THEN readiness MUST continue to report ready for Phase 1
 - AND upstream provider reachability MUST NOT be required by this requirement
 
@@ -3946,16 +3992,19 @@ orchestration.
 
 The existing `GET /api/health` admin route MUST remain available for compatibility during Phase 1.
 
-If distinct readiness and liveness routes are added, `GET /api/health` MUST continue to return a
-successful lightweight health response or a documented compatibility view, and it MUST NOT be
-removed by this change.
+`GET /api/health` MUST continue to return `200 OK` with plain text body `ok` for a running process.
+It MUST NOT be redefined to aggregate dependency readiness or provider account health.
+
+Operators SHOULD use `GET /api/health/live` for liveness probes and `GET /api/health/ready` for
+readiness probes. `GET /api/health` is retained for legacy/simple smoke checks.
 
 #### Scenario: existing base health endpoint remains available after readiness/liveness are added
 
 - GIVEN Phase 1 readiness and liveness endpoints are implemented
 - WHEN a client requests `GET /api/health`
 - THEN the route MUST still exist
-- AND the response MUST remain successful for a healthy running process
+- AND the response status MUST be `200 OK`
+- AND the response body MUST equal `ok`
 
 ---
 


### PR DESCRIPTION
## Related Issues

Fixes #682

---

## Summary

- Formalizes Rook operational health semantics for `/api/health/live` and `/api/health/ready` in the gateway/admin API spec.
- Adds focused coverage for liveness independence and readiness failures across critical startup dependencies.
- Documents operator usage for supervised/containerized deployments and registers the new docs page.

---

## Tested Information

- `cargo test health::tests` from `clients/rook`
- `cargo test server::tests::` from `clients/rook`
- `cargo fmt --check` from `clients/rook`
- `pnpm --dir clients/web/apps/docs build`

---

## Documentation Impact

- Docs updated in:
  - `openspec/specs/gateway/spec.md`
  - `clients/web/apps/docs/src/content/docs/rook/operational-health.md`
  - `clients/web/apps/docs/astro.config.mjs`
- I verified the documentation matches the current behavior with the docs build and focused Rook health tests.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
