### PR TITLE
feat(rook): add upstream resilience controls

### DIFF
--- a/clients/rook/src/gateway/handlers.rs
+++ b/clients/rook/src/gateway/handlers.rs
@@ -20,11 +20,10 @@ use crate::gateway::GatewayState;
 use crate::observability::{
     normalize_account_label, normalize_model_label, normalize_vendor_label,
 };
+use crate::routing::RoutingDecision;
 use crate::services::{
     health::HealthService as _, route::RouteService as _, usage::UsageService as _,
 };
-
-const FAILURE_COOLDOWN_SECS: u64 = 60;
 
 #[derive(Debug, Clone)]
 struct UpstreamMetricContext {
@@ -81,6 +80,27 @@ fn classify_upstream_error(error: &UpstreamError) -> &'static str {
         UpstreamError::Timeout { .. } => "timeout",
         UpstreamError::Transport { .. } | UpstreamError::ReadBody { .. } => "network_error",
     }
+}
+
+fn should_retry_buffered_upstream_error(error: &UpstreamError) -> bool {
+    match error {
+        UpstreamError::UpstreamStatus { status, .. } => {
+            status.is_server_error() || *status == StatusCode::TOO_MANY_REQUESTS
+        }
+        UpstreamError::Timeout { .. }
+        | UpstreamError::Transport { .. }
+        | UpstreamError::ReadBody { .. } => true,
+        UpstreamError::MissingBaseUrl { .. } | UpstreamError::MissingAuthHeader { .. } => false,
+    }
+}
+
+async fn mark_account_failure(state: &GatewayState, account_id: crate::domain::AccountId) {
+    let cooldown_secs = state.resilience_policy.failure_cooldown.as_secs();
+    state
+        .registry
+        .health()
+        .mark_failure(account_id, cooldown_secs)
+        .await;
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -199,103 +219,174 @@ async fn handle_buffered_chat_completions(
     body: Bytes,
     started_at: Instant,
 ) -> Response {
-    let decision = match state.engine.resolve(&request.model).await {
-        Ok(decision) => decision,
-        Err(error) => {
-            record_upstream_failure(state, &UpstreamMetricContext::unrouted(), "route_rejected");
-            tracing::warn!(model = %request.model, error = %error, "routing failed");
-            record_usage(
-                state,
-                UsageRecordInput {
-                    started_at,
-                    logical_model: request.model.clone(),
-                    context: UpstreamMetricContext::unrouted(),
-                    account_id: None,
-                    stream: request.stream.unwrap_or(false),
-                    outcome: "route_rejected",
-                    status: StatusCode::SERVICE_UNAVAILABLE,
-                    tokens: TokenUsageParts::none(),
+    let mut attempts = 0usize;
+    let max_attempts = state.resilience_policy.max_buffered_attempts.max(1);
+    let mut last_error: Option<(
+        UpstreamError,
+        UpstreamMetricContext,
+        crate::domain::AccountId,
+    )> = None;
+
+    loop {
+        attempts = attempts.saturating_add(1);
+        let decision = match state.engine.resolve(&request.model).await {
+            Ok(decision) => decision,
+            Err(error) => {
+                if let Some((error, metric_context, account_id)) = last_error.take() {
+                    let outcome = classify_upstream_error(&error);
+                    let response = map_upstream_error(error);
+                    record_usage(
+                        state,
+                        UsageRecordInput {
+                            started_at,
+                            logical_model: request.model.clone(),
+                            context: metric_context,
+                            account_id: Some(account_id.to_string()),
+                            stream: false,
+                            outcome,
+                            status: response.status(),
+                            tokens: TokenUsageParts::none(),
+                        },
+                    )
+                    .await;
+                    return response;
+                }
+
+                record_upstream_failure(
+                    state,
+                    &UpstreamMetricContext::unrouted(),
+                    "route_rejected",
+                );
+                tracing::warn!(model = %request.model, error = %error, "routing failed");
+                record_usage(
+                    state,
+                    UsageRecordInput {
+                        started_at,
+                        logical_model: request.model.clone(),
+                        context: UpstreamMetricContext::unrouted(),
+                        account_id: None,
+                        stream: request.stream.unwrap_or(false),
+                        outcome: "route_rejected",
+                        status: StatusCode::SERVICE_UNAVAILABLE,
+                        tokens: TokenUsageParts::none(),
+                    },
+                )
+                .await;
+                return error_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    &error.to_string(),
+                    "server_error",
+                    Some("model_not_found"),
+                );
+            }
+        };
+
+        match proxy_buffered_attempt(state, &request, &body, &decision).await {
+            Ok((upstream_response, metric_context, account_id)) => {
+                state.registry.health().mark_success(account_id).await;
+                let tokens = extract_token_usage(&upstream_response.body);
+                record_usage(
+                    state,
+                    UsageRecordInput {
+                        started_at,
+                        logical_model: request.model.clone(),
+                        context: metric_context.clone_static(),
+                        account_id: Some(account_id.to_string()),
+                        stream: false,
+                        outcome: "success",
+                        status: upstream_response.status,
+                        tokens,
+                    },
+                )
+                .await;
+
+                let mut response = Response::new(axum::body::Body::from(upstream_response.body));
+                *response.status_mut() = upstream_response.status;
+                response.headers_mut().insert(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_str(
+                        upstream_response
+                            .content_type
+                            .as_deref()
+                            .unwrap_or("application/json"),
+                    )
+                    .unwrap_or(HeaderValue::from_static("application/json")),
+                );
+                return response;
+            }
+            Err((error, metric_context, account_id)) => {
+                let outcome = classify_upstream_error(&error);
+                record_upstream_failure(state, &metric_context, outcome);
+                mark_account_failure(state, account_id).await;
+
+                let retryable = should_retry_buffered_upstream_error(&error);
+                last_error = Some((error, metric_context, account_id));
+                if !retryable || attempts >= max_attempts {
+                    let (error, metric_context, account_id) = last_error.take().unwrap();
+                    let response = map_upstream_error(error);
+                    record_usage(
+                        state,
+                        UsageRecordInput {
+                            started_at,
+                            logical_model: request.model.clone(),
+                            context: metric_context,
+                            account_id: Some(account_id.to_string()),
+                            stream: false,
+                            outcome,
+                            status: response.status(),
+                            tokens: TokenUsageParts::none(),
+                        },
+                    )
+                    .await;
+                    return response;
+                }
+
+                tokio::time::sleep(state.resilience_policy.retry_backoff).await;
+            }
+        }
+    }
+}
+
+async fn proxy_buffered_attempt(
+    state: &GatewayState,
+    request: &ChatCompletionRequest,
+    body: &Bytes,
+    decision: &RoutingDecision,
+) -> Result<
+    (
+        upstream::UpstreamResponse,
+        UpstreamMetricContext,
+        crate::domain::AccountId,
+    ),
+    (
+        UpstreamError,
+        UpstreamMetricContext,
+        crate::domain::AccountId,
+    ),
+> {
+    let metric_context = UpstreamMetricContext::from_decision(decision);
+    tracing::info!(model = %request.model, account_id = %decision.account.id, "proxying chat completion");
+
+    let permit = match state.upstream_concurrency.semaphore().acquire_owned().await {
+        Ok(permit) => permit,
+        Err(_) => {
+            return Err((
+                UpstreamError::Transport {
+                    message: "upstream concurrency limiter is closed".to_string(),
                 },
-            )
-            .await;
-            return error_response(
-                StatusCode::SERVICE_UNAVAILABLE,
-                &error.to_string(),
-                "server_error",
-                Some("model_not_found"),
-            );
+                metric_context,
+                decision.account.id,
+            ));
         }
     };
 
-    let metric_context = UpstreamMetricContext::from_decision(&decision);
-    tracing::info!(model = %request.model, account_id = %decision.account.id, "proxying chat completion");
+    let result =
+        upstream::proxy_chat_completion(&state.client, &decision.account, body.clone()).await;
+    drop(permit);
 
-    match upstream::proxy_chat_completion(&state.client, &decision.account, body).await {
-        Ok(upstream_response) => {
-            let registry = state.registry.clone();
-            let account_id = decision.account.id;
-            tokio::spawn(async move {
-                registry.health().mark_success(account_id).await;
-            });
-            let tokens = extract_token_usage(&upstream_response.body);
-            record_usage(
-                state,
-                UsageRecordInput {
-                    started_at,
-                    logical_model: request.model.clone(),
-                    context: metric_context.clone_static(),
-                    account_id: Some(account_id.to_string()),
-                    stream: false,
-                    outcome: "success",
-                    status: upstream_response.status,
-                    tokens,
-                },
-            )
-            .await;
-
-            let mut response = Response::new(axum::body::Body::from(upstream_response.body));
-            *response.status_mut() = upstream_response.status;
-            response.headers_mut().insert(
-                header::CONTENT_TYPE,
-                HeaderValue::from_str(
-                    upstream_response
-                        .content_type
-                        .as_deref()
-                        .unwrap_or("application/json"),
-                )
-                .unwrap_or(HeaderValue::from_static("application/json")),
-            );
-            response
-        }
-        Err(error) => {
-            let outcome = classify_upstream_error(&error);
-            record_upstream_failure(state, &metric_context, outcome);
-            let registry = state.registry.clone();
-            let account_id = decision.account.id;
-            tokio::spawn(async move {
-                registry
-                    .health()
-                    .mark_failure(account_id, FAILURE_COOLDOWN_SECS)
-                    .await;
-            });
-            let response = map_upstream_error(error);
-            record_usage(
-                state,
-                UsageRecordInput {
-                    started_at,
-                    logical_model: request.model.clone(),
-                    context: metric_context,
-                    account_id: Some(account_id.to_string()),
-                    stream: false,
-                    outcome,
-                    status: response.status(),
-                    tokens: TokenUsageParts::none(),
-                },
-            )
-            .await;
-            response
-        }
-    }
+    result
+        .map(|response| (response, metric_context.clone_static(), decision.account.id))
+        .map_err(|error| (error, metric_context, decision.account.id))
 }
 
 async fn handle_streaming_chat_completions(
@@ -336,10 +427,7 @@ async fn handle_streaming_chat_completions(
     let account_id = decision.account.id;
     match upstream::open_chat_completion_stream(&state.client, &decision.account, body).await {
         Ok(upstream_response) => {
-            let registry = state.registry.clone();
-            tokio::spawn(async move {
-                registry.health().mark_success(account_id).await;
-            });
+            state.registry.health().mark_success(account_id).await;
             let completion_state = state.clone();
             let completion_input = UsageRecordInput {
                 started_at,
@@ -368,13 +456,7 @@ async fn handle_streaming_chat_completions(
         Err(error) => {
             let outcome = classify_upstream_error(&error);
             record_upstream_failure(state, &metric_context, outcome);
-            let registry = state.registry.clone();
-            tokio::spawn(async move {
-                registry
-                    .health()
-                    .mark_failure(account_id, FAILURE_COOLDOWN_SECS)
-                    .await;
-            });
+            mark_account_failure(state, account_id).await;
             let response = map_upstream_error(error);
             record_usage(
                 state,
@@ -519,6 +601,16 @@ mod tests {
         }
     }
 
+    fn make_pool_with_members(account_ids: Vec<AccountId>) -> ProviderPool {
+        ProviderPool {
+            id: PoolId::generate(),
+            name: "test-pool".to_string(),
+            strategy: SelectionStrategy::Priority,
+            members: account_ids,
+            fallback_pool_id: None,
+        }
+    }
+
     fn make_route(logical_model: &str, pool_id: PoolId) -> ModelRoute {
         ModelRoute {
             id: RouteId::generate(),
@@ -536,11 +628,20 @@ mod tests {
             .timeout(std::time::Duration::from_secs(2))
             .build()
             .unwrap();
+        let resilience_policy = crate::gateway::UpstreamResiliencePolicy {
+            retry_backoff: std::time::Duration::from_millis(1),
+            ..Default::default()
+        };
+        let upstream_concurrency = crate::gateway::UpstreamConcurrency::new(
+            resilience_policy.max_concurrent_upstream_requests,
+        );
         let state = GatewayState {
             registry: registry.clone(),
             engine,
             client,
             observability: Arc::new(crate::observability::Observability::bootstrap()),
+            resilience_policy,
+            upstream_concurrency,
         };
         (build_router(state), registry)
     }
@@ -566,6 +667,26 @@ mod tests {
         registry.routes().create(route).await.unwrap();
 
         account_id
+    }
+
+    async fn seed_route_with_accounts(
+        registry: &RookRegistry,
+        logical_model: &str,
+        mut accounts: Vec<ProviderAccount>,
+    ) -> Vec<AccountId> {
+        let account_ids: Vec<AccountId> = accounts.iter().map(|account| account.id).collect();
+        for account in accounts.drain(..) {
+            registry.accounts().create(account).await.unwrap();
+        }
+
+        let pool = make_pool_with_members(account_ids.clone());
+        let pool_id = pool.id;
+        registry.pools().create(pool).await.unwrap();
+
+        let route = make_route(logical_model, pool_id);
+        registry.routes().create(route).await.unwrap();
+
+        account_ids
     }
 
     async fn wait_for_usage_requests(
@@ -628,6 +749,48 @@ mod tests {
         });
 
         (handle, url)
+    }
+
+    async fn mock_counting_upstream(
+        statuses: Vec<StatusCode>,
+    ) -> (
+        tokio::task::JoinHandle<()>,
+        String,
+        Arc<std::sync::atomic::AtomicUsize>,
+    ) {
+        use axum::routing::post;
+        use axum::{Json, Router};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::net::TcpListener;
+
+        async fn handler(
+            axum::extract::State((statuses, calls)): axum::extract::State<(
+                Arc<Vec<StatusCode>>,
+                Arc<AtomicUsize>,
+            )>,
+        ) -> (StatusCode, Json<Value>) {
+            let call_index = calls.fetch_add(1, Ordering::SeqCst);
+            let status = statuses
+                .get(call_index)
+                .copied()
+                .or_else(|| statuses.last().copied())
+                .unwrap_or(StatusCode::OK);
+            (status, Json(json!({"call": call_index + 1})))
+        }
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route("/v1/chat/completions", post(handler))
+            .with_state((Arc::new(statuses), calls.clone()));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}");
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        (handle, url, calls)
     }
 
     #[tokio::test]
@@ -997,6 +1160,142 @@ mod tests {
         assert_eq!(summary.totals.requests, 1);
         assert_eq!(summary.totals.failed_requests, 1);
         assert_eq!(summary.by_outcome[0].key, "http_error");
+    }
+
+    #[tokio::test]
+    async fn buffered_chat_retries_retryable_upstream_failure_on_next_account() {
+        use std::sync::atomic::Ordering;
+
+        let (_failing_server, failing_upstream, failing_calls) =
+            mock_counting_upstream(vec![StatusCode::INTERNAL_SERVER_ERROR]).await;
+        let (_success_server, success_upstream, success_calls) =
+            mock_counting_upstream(vec![StatusCode::OK]).await;
+        let (app, registry) = test_app().await;
+
+        let mut failing_account = make_account(ProviderVendor::OpenAi);
+        failing_account.api_base_override = Some(failing_upstream);
+        failing_account.api_key = Some("sk-test".to_string());
+        failing_account.priority = 0;
+        let failing_account_id = failing_account.id;
+
+        let mut success_account = make_account(ProviderVendor::OpenAi);
+        success_account.api_base_override = Some(success_upstream);
+        success_account.api_key = Some("sk-test".to_string());
+        success_account.priority = 1;
+        let success_account_id = success_account.id;
+
+        seed_route_with_accounts(&registry, "gpt-4o", vec![failing_account, success_account]).await;
+
+        let response = app
+            .oneshot(
+                Request::post("/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&body).unwrap(),
+            json!({"call": 1})
+        );
+        assert_eq!(failing_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(success_calls.load(Ordering::SeqCst), 1);
+
+        let failing_health = registry.health().get(failing_account_id).await;
+        assert_eq!(
+            failing_health.status,
+            crate::services::health::HealthStatus::Unhealthy
+        );
+        assert!(failing_health.cooldown_until.is_some());
+        assert!(!registry.health().is_available(failing_account_id).await);
+        assert_eq!(
+            registry.health().get(success_account_id).await.status,
+            crate::services::health::HealthStatus::Healthy
+        );
+    }
+
+    #[tokio::test]
+    async fn buffered_chat_does_not_retry_non_retryable_client_error() {
+        use std::sync::atomic::Ordering;
+
+        let (_server, upstream, calls) =
+            mock_counting_upstream(vec![StatusCode::BAD_REQUEST]).await;
+        let (app, registry) = test_app().await;
+        seed_route(
+            &registry,
+            "gpt-4o",
+            ProviderVendor::OpenAi,
+            Some(upstream),
+            Some("sk-test".to_string()),
+        )
+        .await;
+
+        let response = app
+            .oneshot(
+                Request::post("/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn streaming_chat_does_not_retry_after_upstream_failure() {
+        use std::sync::atomic::Ordering;
+
+        let (_failing_server, failing_upstream, failing_calls) =
+            mock_counting_upstream(vec![StatusCode::INTERNAL_SERVER_ERROR]).await;
+        let (_success_server, success_upstream, success_calls) =
+            mock_counting_upstream(vec![StatusCode::OK]).await;
+        let (app, registry) = test_app().await;
+
+        let mut failing_account = make_account(ProviderVendor::OpenAi);
+        failing_account.api_base_override = Some(failing_upstream);
+        failing_account.api_key = Some("sk-test".to_string());
+        failing_account.priority = 0;
+
+        let mut success_account = make_account(ProviderVendor::OpenAi);
+        success_account.api_base_override = Some(success_upstream);
+        success_account.api_key = Some("sk-test".to_string());
+        success_account.priority = 1;
+
+        seed_route_with_accounts(&registry, "gpt-4o", vec![failing_account, success_account]).await;
+
+        let response = app
+            .oneshot(
+                Request::post("/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "model":"gpt-4o",
+                            "stream": true,
+                            "messages":[{"role":"user","content":"Hello"}]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(failing_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(success_calls.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/clients/rook/src/gateway/mod.rs
+++ b/clients/rook/src/gateway/mod.rs
@@ -26,6 +26,44 @@ use crate::observability::Observability;
 use crate::registry::RookRegistry;
 use crate::routing::RoutingEngine;
 use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Semaphore;
+
+#[derive(Clone)]
+pub struct UpstreamResiliencePolicy {
+    pub max_buffered_attempts: usize,
+    pub failure_cooldown: Duration,
+    pub retry_backoff: Duration,
+    pub max_concurrent_upstream_requests: usize,
+}
+
+impl Default for UpstreamResiliencePolicy {
+    fn default() -> Self {
+        Self {
+            max_buffered_attempts: 3,
+            failure_cooldown: Duration::from_secs(60),
+            retry_backoff: Duration::from_millis(25),
+            max_concurrent_upstream_requests: 64,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct UpstreamConcurrency {
+    semaphore: Arc<Semaphore>,
+}
+
+impl UpstreamConcurrency {
+    pub fn new(max_permits: usize) -> Self {
+        Self {
+            semaphore: Arc::new(Semaphore::new(max_permits.max(1))),
+        }
+    }
+
+    pub fn semaphore(&self) -> Arc<Semaphore> {
+        self.semaphore.clone()
+    }
+}
 
 #[derive(Clone)]
 pub struct GatewayState {
@@ -33,6 +71,8 @@ pub struct GatewayState {
     pub engine: RoutingEngine,
     pub client: reqwest::Client,
     pub observability: Arc<Observability>,
+    pub resilience_policy: UpstreamResiliencePolicy,
+    pub upstream_concurrency: UpstreamConcurrency,
 }
 
 pub fn build_router(state: GatewayState) -> Router {

--- a/clients/rook/src/server/mod.rs
+++ b/clients/rook/src/server/mod.rs
@@ -169,11 +169,17 @@ async fn build_app_with_registry_and_startup_state(
         .map_err(|e| RookError::Gateway(format!("failed to build HTTP client: {e}")))?;
 
     let observability = Arc::new(Observability::bootstrap());
+    let resilience_policy = crate::gateway::UpstreamResiliencePolicy::default();
+    let upstream_concurrency = crate::gateway::UpstreamConcurrency::new(
+        resilience_policy.max_concurrent_upstream_requests,
+    );
     let gateway_state = GatewayState {
         registry: registry.clone(),
         engine,
         client,
         observability: observability.clone(),
+        resilience_policy,
+        upstream_concurrency,
     };
     let inbound_auth = config.inbound_auth.clone();
     let transport_config = Arc::new(config.transport.clone());

--- a/openspec/specs/gateway/spec.md
+++ b/openspec/specs/gateway/spec.md
@@ -365,7 +365,8 @@ The gateway MUST expose a `POST /v1/chat/completions` endpoint that:
 7. Sets `Content-Type: application/json` on the upstream request.
 8. Forwards the **original raw JSON request body** to the upstream provider.
 9. Returns the upstream response body and status to the client.
-10. After the upstream call, reports health feedback (R10).
+10. Applies policy-driven upstream resilience controls (R10A) before surfacing terminal failures.
+11. After each upstream attempt, reports health feedback (R10).
 
 **Response mapping**:
 
@@ -475,6 +476,55 @@ upstream status code.
 - GIVEN a valid request with extra vendor-specific fields (e.g., `"logprobs": true`)
 - WHEN the gateway forwards to the upstream
 - THEN the upstream request body MUST contain all original fields, including unknown ones
+
+---
+
+### R8A: Upstream Resilience Policy
+
+The gateway MUST apply explicit resilience policy for upstream attempts instead of ad hoc failure handling.
+
+Buffered, non-streaming chat completion requests MUST retry only failure classes that are safe to replay:
+
+- Retryable: upstream HTTP 5xx, HTTP 429, connection/transport errors, response body read errors, and request timeouts.
+- Non-retryable: upstream HTTP 4xx other than 429, missing base URL, and auth-header construction failures.
+
+For buffered requests, the default policy MUST allow at most 3 upstream attempts total. After each failed
+retryable attempt, the gateway MUST mark the attempted account unhealthy with the configured cooldown,
+wait for the configured backoff, resolve routing again, and avoid immediately thrashing the same unhealthy
+account when another healthy account is available. If no account remains after a retryable failure, the
+gateway MUST return the terminal upstream error mapping rather than replacing it with a routing error.
+
+Streaming requests MUST NOT retry after an upstream attempt has been made, because replaying a stream can
+violate client-visible semantics. Streaming requests MAY fail before bytes are sent using the normal upstream
+error mapping and MUST still mark the attempted account unhealthy.
+
+The gateway MUST bound concurrent upstream attempts with a shared concurrency control. The default timeout
+remains the configured `reqwest::Client` timeout (30 seconds in server wiring).
+
+#### Scenario: Buffered retryable failure retries on next healthy account
+
+- GIVEN a route resolves first to account A and then to account B after health filtering
+- AND account A returns HTTP 500
+- AND account B returns HTTP 200
+- WHEN the client sends a non-streaming chat completion request
+- THEN account A MUST be marked unhealthy with cooldown
+- AND the request MUST be retried against account B
+- AND the client MUST receive account B's successful upstream response
+
+#### Scenario: Buffered non-retryable client error is not retried
+
+- GIVEN a route resolves to an account that returns HTTP 400
+- WHEN the client sends a non-streaming chat completion request
+- THEN the gateway MUST return the upstream error mapping
+- AND no second upstream attempt MUST be made for that client error
+
+#### Scenario: Streaming upstream failure is not retried
+
+- GIVEN a streaming request resolves to account A and another healthy account B exists
+- AND account A returns an upstream failure before a stream is opened
+- WHEN the client sends `stream: true`
+- THEN the gateway MUST return the upstream error mapping
+- AND account B MUST NOT be attempted for that streaming request
 
 ---
 


### PR DESCRIPTION
## Related Issues

Fixes #686

---

## Summary

- Adds explicit upstream resilience policy defaults for buffered retries, cooldown/backoff, and shared upstream concurrency limiting.
- Retries buffered retryable upstream failures by re-resolving routing after marking the failed account unhealthy, while preserving terminal upstream error mapping when no account remains.
- Keeps streaming requests non-retryable after an upstream attempt and documents the resilience contract in `openspec/specs/gateway/spec.md`.

---

## Tested Information

- `cargo test`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`

---

## Documentation Impact

- Docs updated in: `openspec/specs/gateway/spec.md`
- I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).