### PR TITLE
feat(runtime): add slash command registry core

### DIFF
--- a/clients/agent-runtime/src/gateway/mod.rs
+++ b/clients/agent-runtime/src/gateway/mod.rs
@@ -2177,6 +2177,7 @@ fn map_session_command_failure_code(
         crate::session_commands::SessionCommandFailureKind::UnsupportedBackend => {
             "unsupported_backend"
         }
+        crate::session_commands::SessionCommandFailureKind::UnknownCommand => "unknown_command",
         crate::session_commands::SessionCommandFailureKind::UnknownSession => "unknown_session",
         crate::session_commands::SessionCommandFailureKind::InvalidState => "invalid_state",
         crate::session_commands::SessionCommandFailureKind::MissingSnapshot => "missing_snapshot",

--- a/clients/agent-runtime/src/pre_execution/mod.rs
+++ b/clients/agent-runtime/src/pre_execution/mod.rs
@@ -54,7 +54,10 @@ pub async fn evaluate_ingress(
 ) -> IngressDecision {
     let service = SessionCommandService::with_tool_snapshot(memory, tool_snapshot);
     let session_id = context.session.session_id.clone();
-    if let Some(outcome) = default_registry().dispatch(&service, context, prompt).await {
+    if let Some(outcome) = default_registry()
+        .dispatch_prompt(&service, context, prompt)
+        .await
+    {
         return IngressDecision::SessionCommand { outcome };
     }
 

--- a/clients/agent-runtime/src/pre_execution/session_command_adapter.rs
+++ b/clients/agent-runtime/src/pre_execution/session_command_adapter.rs
@@ -52,6 +52,7 @@ fn classify_session_command_failure(kind: SessionCommandFailureKind) -> SessionC
             SessionCommandFailureClass::PermissionDenied
         }
         SessionCommandFailureKind::UnsupportedBackend
+        | SessionCommandFailureKind::UnknownCommand
         | SessionCommandFailureKind::UnknownSession
         | SessionCommandFailureKind::InvalidState
         | SessionCommandFailureKind::MissingSnapshot

--- a/clients/agent-runtime/src/security/policy.rs
+++ b/clients/agent-runtime/src/security/policy.rs
@@ -2262,12 +2262,7 @@ mod tests {
 #[test]
 fn test_package_manager_risk_hardening() {
     let mut p = SecurityPolicy::default();
-    p.allowed_commands = vec![
-        "npm".into(),
-        "pnpm".into(),
-        "yarn".into(),
-        "cargo".into(),
-    ];
+    p.allowed_commands = vec!["npm".into(), "pnpm".into(), "yarn".into(), "cargo".into()];
 
     // is_args_safe hardening
     assert!(!p.is_command_allowed("npm config set editor malicious"));
@@ -2275,10 +2270,16 @@ fn test_package_manager_risk_hardening() {
     assert!(!p.is_command_allowed("yarn set version berry"));
 
     // is_medium_risk_command hardening (npm)
-    assert_eq!(p.command_risk_level("npm run build"), CommandRiskLevel::Medium);
+    assert_eq!(
+        p.command_risk_level("npm run build"),
+        CommandRiskLevel::Medium
+    );
     assert_eq!(p.command_risk_level("npm test"), CommandRiskLevel::Medium);
     assert_eq!(p.command_risk_level("npm t"), CommandRiskLevel::Medium);
-    assert_eq!(p.command_risk_level("pnpm run-script start"), CommandRiskLevel::Medium);
+    assert_eq!(
+        p.command_risk_level("pnpm run-script start"),
+        CommandRiskLevel::Medium
+    );
     assert_eq!(p.command_risk_level("yarn it"), CommandRiskLevel::Medium);
 
     // is_medium_risk_command hardening (cargo)

--- a/clients/agent-runtime/src/session_commands/mod.rs
+++ b/clients/agent-runtime/src/session_commands/mod.rs
@@ -1,3 +1,11 @@
+//! Slash command platform for runtime ingress.
+//!
+//! This module owns the runtime slash-command extension point. New slash
+//! commands define a [`SlashCommandDescriptor`] plus a [`SlashCommandHandler`]
+//! and are registered through [`SlashCommandRegistry`]. Ingress surfaces parse
+//! raw prompts, then delegate lookup, alias resolution, requirement checks, and
+//! handler dispatch to the registry instead of matching command names locally.
+
 pub mod parser;
 pub mod registry;
 pub mod service;

--- a/clients/agent-runtime/src/session_commands/registry.rs
+++ b/clients/agent-runtime/src/session_commands/registry.rs
@@ -140,9 +140,7 @@ impl SlashCommandRegistry {
         prompt: &str,
     ) -> Option<SessionCommandOutcome> {
         let raw = SessionCommandParser::parse(prompt)?;
-        if self.resolve_registration(&raw.invoked_name).is_none() {
-            return None;
-        }
+        self.resolve_registration(&raw.invoked_name)?;
         Some(self.dispatch_raw(service, context, raw).await)
     }
 

--- a/clients/agent-runtime/src/session_commands/registry.rs
+++ b/clients/agent-runtime/src/session_commands/registry.rs
@@ -9,6 +9,13 @@ use super::types::{
 use std::collections::BTreeMap;
 use std::sync::{Arc, OnceLock};
 
+/// Central slash-command registry for runtime ingress paths.
+///
+/// The registry is the single runtime abstraction responsible for slash-command
+/// registration, metadata discovery, name/alias resolution, argument-shape
+/// validation, requirement checks, and dispatch into command handlers. CLI,
+/// gateway, webhook, and channel ingress should call through this registry
+/// instead of matching on slash command names directly.
 pub struct SlashCommandRegistry {
     registrations: Vec<SlashCommandRegistration>,
     by_canonical_name: BTreeMap<&'static str, usize>,
@@ -116,34 +123,55 @@ impl SlashCommandRegistry {
             .map(|registration| &registration.descriptor)
     }
 
-    fn iter(&self) -> impl Iterator<Item = &SlashCommandDescriptor> {
+    pub fn contains(&self, name: &str) -> bool {
+        self.resolve_registration(name).is_some()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &SlashCommandDescriptor> {
         self.registrations
             .iter()
             .map(|registration| &registration.descriptor)
     }
 
-    pub async fn dispatch(
+    pub async fn dispatch_prompt(
         &self,
         service: &SessionCommandService<'_>,
         context: CommandContext,
         prompt: &str,
     ) -> Option<SessionCommandOutcome> {
         let raw = SessionCommandParser::parse(prompt)?;
-        let registration = self.resolve_registration(&raw.invoked_name)?;
+        if self.resolve_registration(&raw.invoked_name).is_none() {
+            return None;
+        }
+        Some(self.dispatch_raw(service, context, raw).await)
+    }
+
+    pub async fn dispatch_raw(
+        &self,
+        service: &SessionCommandService<'_>,
+        context: CommandContext,
+        raw: RawSlashInvocation,
+    ) -> SessionCommandOutcome {
+        let Some(registration) = self.resolve_registration(&raw.invoked_name) else {
+            return SessionCommandOutcome::Failure(SessionCommandFailure {
+                command: "/",
+                kind: SessionCommandFailureKind::UnknownCommand,
+                session_id: Some(context.session.session_id.clone()),
+                message: format!("unknown slash command: {}", raw.invoked_name),
+            });
+        };
         let invocation = match validate_invocation(&registration.descriptor, raw) {
             Ok(invocation) => invocation,
-            Err(error) => return Some(SessionCommandOutcome::Failure(error)),
+            Err(error) => return SessionCommandOutcome::Failure(error),
         };
         if let Err(error) = validate_requirements(&registration.descriptor, &context) {
-            return Some(SessionCommandOutcome::Failure(error));
+            return SessionCommandOutcome::Failure(error);
         }
 
-        Some(
-            registration
-                .handler
-                .handle(service, context, invocation)
-                .await,
-        )
+        registration
+            .handler
+            .handle(service, context, invocation)
+            .await
     }
 
     fn resolve_registration(&self, name: &str) -> Option<&SlashCommandRegistration> {
@@ -738,6 +766,58 @@ mod tests {
     }
 
     #[test]
+    fn registry_rejects_duplicate_aliases_within_one_descriptor() {
+        let mut registry = SlashCommandRegistry::empty();
+
+        let error = registry
+            .register(registration(
+                "/resume",
+                &["/continue", "/continue"],
+                "resume a session",
+                SlashCommandArgumentShape::OptionalTargetThenText,
+            ))
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            SlashRegistryError::DuplicateAlias {
+                alias: "/continue".to_string(),
+                existing_canonical_name: "/resume".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn registry_rejects_canonical_names_that_collide_with_existing_aliases() {
+        let mut registry = SlashCommandRegistry::empty();
+        registry
+            .register(registration(
+                "/resume",
+                &["/continue"],
+                "resume a session",
+                SlashCommandArgumentShape::OptionalTargetThenText,
+            ))
+            .unwrap();
+
+        let error = registry
+            .register(registration(
+                "/continue",
+                &[],
+                "continue a session",
+                SlashCommandArgumentShape::OptionalTargetThenText,
+            ))
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            SlashRegistryError::AliasCollidesWithCanonical {
+                alias: "/continue".to_string(),
+                canonical_name: "/resume".to_string(),
+            }
+        );
+    }
+
+    #[test]
     fn registry_rejects_alias_collisions_with_canonical_names() {
         let mut registry = SlashCommandRegistry::empty();
         registry
@@ -790,6 +870,55 @@ mod tests {
                 .get("/continue")
                 .map(|descriptor| descriptor.canonical_name),
             Some("/resume")
+        );
+        assert!(registry.contains("/resume"));
+        assert!(registry.contains("/continue"));
+        assert!(!registry.contains("/missing"));
+    }
+
+    #[test]
+    fn registry_iteration_exposes_discoverable_metadata_in_registration_order() {
+        let mut registry = SlashCommandRegistry::empty();
+        registry
+            .register(registration(
+                "/tools",
+                &[],
+                "list tools",
+                SlashCommandArgumentShape::None,
+            ))
+            .unwrap();
+        registry
+            .register(registration(
+                "/resume",
+                &["/continue"],
+                "resume a session",
+                SlashCommandArgumentShape::OptionalTargetThenText,
+            ))
+            .unwrap();
+
+        let metadata = registry
+            .iter()
+            .map(|descriptor| {
+                (
+                    descriptor.canonical_name,
+                    descriptor.aliases,
+                    descriptor.description,
+                    descriptor.argument_shape.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(metadata.len(), 2);
+        assert_eq!(metadata[0].0, "/tools");
+        assert_eq!(metadata[0].1, &[] as &[&str]);
+        assert_eq!(metadata[0].2, "list tools");
+        assert_eq!(metadata[0].3, SlashCommandArgumentShape::None);
+        assert_eq!(metadata[1].0, "/resume");
+        assert_eq!(metadata[1].1, &["/continue"] as &[&str]);
+        assert_eq!(metadata[1].2, "resume a session");
+        assert_eq!(
+            metadata[1].3,
+            SlashCommandArgumentShape::OptionalTargetThenText
         );
     }
 
@@ -880,11 +1009,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dispatch_raw_reports_unknown_registered_command() {
+        let service = SessionCommandService::new(&RegistryMemory);
+
+        let result = default_registry()
+            .dispatch_raw(
+                &service,
+                CommandContext::for_cli(
+                    "session-1",
+                    CommandSessionSource::Existing,
+                    ExecutionMode::Standard,
+                    None,
+                ),
+                RawSlashInvocation {
+                    invoked_name: "/missing".to_string(),
+                    raw_args: String::new(),
+                },
+            )
+            .await;
+
+        assert_eq!(
+            result,
+            SessionCommandOutcome::Failure(SessionCommandFailure {
+                command: "/",
+                kind: SessionCommandFailureKind::UnknownCommand,
+                session_id: Some("session-1".to_string()),
+                message: "unknown slash command: /missing".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_prompt_falls_through_unknown_slash_commands() {
+        let service = SessionCommandService::new(&RegistryMemory);
+
+        let result = default_registry()
+            .dispatch_prompt(
+                &service,
+                CommandContext::for_cli(
+                    "session-1",
+                    CommandSessionSource::Existing,
+                    ExecutionMode::Standard,
+                    None,
+                ),
+                "/missing",
+            )
+            .await;
+
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
     async fn dispatch_denies_command_when_declared_caller_scope_permission_is_missing() {
         let service = SessionCommandService::new(&RegistryMemory);
 
         let result = default_registry()
-            .dispatch(
+            .dispatch_prompt(
                 &service,
                 CommandContext::for_cli(
                     "session-1",
@@ -912,7 +1092,7 @@ mod tests {
         let service = SessionCommandService::new(&RegistryMemory);
 
         let result = default_registry()
-            .dispatch(
+            .dispatch_prompt(
                 &service,
                 CommandContext::for_cli(
                     "session-1",
@@ -946,7 +1126,7 @@ mod tests {
         let service = SessionCommandService::with_tool_snapshot(&RegistryMemory, &tools);
 
         let result = default_registry()
-            .dispatch(
+            .dispatch_prompt(
                 &service,
                 CommandContext::for_cli(
                     "session-1",
@@ -980,7 +1160,7 @@ mod tests {
         let service = SessionCommandService::with_tool_snapshot(&RegistryMemory, &tools);
 
         let result = default_registry()
-            .dispatch(
+            .dispatch_prompt(
                 &service,
                 CommandContext::for_cli(
                     "session-1",
@@ -1008,7 +1188,7 @@ mod tests {
         let service = SessionCommandService::new(&memory);
 
         let result = default_registry()
-            .dispatch(
+            .dispatch_prompt(
                 &service,
                 CommandContext::for_cli(
                     "session-1",
@@ -1038,7 +1218,7 @@ mod tests {
         let service = SessionCommandService::new(&memory);
 
         let result = default_registry()
-            .dispatch(
+            .dispatch_prompt(
                 &service,
                 CommandContext::for_cli(
                     "session-1",
@@ -1080,7 +1260,7 @@ mod tests {
             .unwrap();
 
         let result = registry
-            .dispatch(
+            .dispatch_prompt(
                 &service,
                 CommandContext::for_cli(
                     "session-1",
@@ -1109,7 +1289,7 @@ mod tests {
         let service = SessionCommandService::new(&memory);
 
         let result = default_registry()
-            .dispatch(
+            .dispatch_prompt(
                 &service,
                 CommandContext::for_cli(
                     "session-1",
@@ -1137,7 +1317,7 @@ mod tests {
         let service = SessionCommandService::new(&RegistryMemory);
 
         let result = default_registry()
-            .dispatch(
+            .dispatch_prompt(
                 &service,
                 CommandContext::for_cli(
                     "session-1",
@@ -1165,7 +1345,7 @@ mod tests {
         let service = SessionCommandService::new(&RegistryMemory);
 
         let result = default_registry()
-            .dispatch(
+            .dispatch_prompt(
                 &service,
                 CommandContext::for_cli(
                     "session-1",
@@ -1193,7 +1373,7 @@ mod tests {
         let service = SessionCommandService::new(&RegistryMemory);
 
         let result = default_registry()
-            .dispatch(
+            .dispatch_prompt(
                 &service,
                 CommandContext::for_cli(
                     "session-1",
@@ -1223,7 +1403,7 @@ mod tests {
         let service = SessionCommandService::new(&memory);
 
         let result = default_registry()
-            .dispatch(
+            .dispatch_prompt(
                 &service,
                 CommandContext::for_cli(
                     "session-1",
@@ -1251,7 +1431,7 @@ mod tests {
         let service = SessionCommandService::new(&RegistryMemory);
 
         let result = default_registry()
-            .dispatch(
+            .dispatch_prompt(
                 &service,
                 CommandContext::for_cli(
                     "session-1",

--- a/clients/agent-runtime/src/session_commands/types.rs
+++ b/clients/agent-runtime/src/session_commands/types.rs
@@ -532,6 +532,7 @@ pub struct SessionCommandFailure {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionCommandFailureKind {
     UnsupportedBackend,
+    UnknownCommand,
     UnknownSession,
     InvalidState,
     MissingSnapshot,

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/architecture.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/architecture.md
@@ -202,6 +202,27 @@ and gateway-specific channel hooks. This keeps channel key normalization, suppor
 validation, and constructor wiring in one place instead of reimplementing `match` blocks across the
 runtime.
 
+### Slash Commands
+
+Slash commands are a runtime-owned ingress capability under `session_commands/`. The core abstraction
+is `SlashCommandRegistry`, which stores `SlashCommandRegistration` values made from a discoverable
+`SlashCommandDescriptor` and a `SlashCommandHandler` implementation.
+
+The layering is intentionally narrow:
+
+- ingress surfaces such as CLI, gateway, webhooks, and channels pass raw user text to the registry;
+- `SessionCommandParser` only identifies slash-shaped input and preserves the raw argument text;
+- `SlashCommandRegistry` owns canonical-name lookup, alias lookup, duplicate detection, metadata
+  discovery, argument-shape validation, requirement checks, and handler dispatch;
+- command handlers delegate behavior to `SessionCommandService`, which owns access to memory,
+  settings, tool snapshots, and other runtime state.
+
+New slash commands should extend the platform by adding a descriptor and handler, then registering
+that pair in the registry builder. Do not add new per-ingress `match` statements for command names:
+if a command is reachable by users, it should be discoverable through registry metadata and dispatched
+through the central registry entrypoint. Follow-up work can move additional command families into the
+same extension point without changing ingress routing.
+
 ### Memory
 
 The memory system (`memory/`) is one of the most differentiating components of the Agent Runtime.

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/architecture.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/architecture.md
@@ -3,7 +3,7 @@ title: Agent Runtime Architecture
 description: Architecture overview of the Rust agent runtime, including subsystem boundaries, design goals, and execution model.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-03-26
+lastReviewed: 2026-05-05
 appliesTo: main
 docType: architecture
 ---

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/architecture.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/architecture.md
@@ -210,6 +210,31 @@ notificaciones de updates, delivery del scheduler y hooks específicos del gatew
 normalización de nombres, la validación de channels soportados y el wiring de constructores viven en
 un solo lugar en vez de repetir bloques `match` por varias partes del runtime.
 
+### Comandos Slash
+
+Los comandos slash son una capacidad de ingreso propia del runtime bajo `session_commands/`. La
+abstracción central es `SlashCommandRegistry`, que almacena valores `SlashCommandRegistration`
+compuestos por un `SlashCommandDescriptor` descubrible y una implementación de `SlashCommandHandler`.
+
+El layering es intencionalmente estrecho:
+
+- las superficies de ingreso como CLI, gateway, webhooks y channels pasan el texto crudo del usuario
+  al registry;
+- `SessionCommandParser` solo identifica entradas con forma slash y preserva el texto crudo de
+  argumentos;
+- `SlashCommandRegistry` se encarga de lookup por nombre canónico, lookup por alias, detección de
+  duplicados, descubrimiento de metadata, validación de forma de argumentos, checks de requisitos y
+  dispatch hacia handlers;
+- los handlers de comandos delegan el comportamiento a `SessionCommandService`, que posee acceso a
+  memoria, settings, snapshots de herramientas y otro estado del runtime.
+
+Los nuevos comandos slash deben extender la plataforma agregando un descriptor y un handler, y luego
+registrando ese par en el builder del registry. No agregues nuevos `match` statements por superficie
+de ingreso para nombres de comandos: si un comando es alcanzable por usuarios, debe ser descubrible a
+través de la metadata del registry y despacharse por el entrypoint central del registry. El trabajo de
+seguimiento puede mover familias adicionales de comandos hacia el mismo punto de extensión sin
+cambiar el routing de ingreso.
+
 ### Memoria
 
 El sistema de memoria (`memory/`) es uno de los componentes más diferenciadores del Agent Runtime. A


### PR DESCRIPTION
## Related Issues

Fixes #539
Related to #527

---

## Summary

Adds the core slash command registry abstraction so runtime ingress uses one platform capability for command metadata, name/alias lookup, validation, and dispatch.

- Exposes registry discovery helpers for canonical names, aliases, and metadata iteration.
- Splits prompt-based ingress dispatch from raw parsed dispatch while preserving unknown slash fallthrough for existing ingress behavior.
- Adds targeted registry tests for registration, lookup, alias resolution, duplicate handling, metadata discovery, and central dispatch behavior.

Review path: start with `clients/agent-runtime/src/session_commands/registry.rs`, then check the small ingress and gateway adaptations. Out of scope: migrating additional command families beyond the existing session command set.

---

## Tested Information

- `rustfmt --edition 2021 --check src/session_commands/registry.rs src/session_commands/types.rs src/session_commands/mod.rs src/pre_execution/mod.rs src/pre_execution/session_command_adapter.rs src/gateway/mod.rs`
- `cargo test --lib session_commands::registry`
- `cargo test session_commands::registry` began passing the targeted registry tests across lib/main targets, but the broader filtered run timed out while continuing through unrelated integration targets.
- Pre-push hook initially failed on pre-existing `src/security/policy.rs` formatting; this branch includes a separate formatting-only commit for that hook blocker.
- Pre-push hook then caught one clippy simplification in `dispatch_prompt`; this branch includes the fix.

---

## Documentation Impact

- Docs updated in:
  - `clients/web/apps/docs/src/content/docs/clients/agent-runtime/architecture.md`
- I verified the documentation matches the current behavior.

---

## Breaking Changes

None.

---

## Checklist

- [x] I have checked that there isn’t already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
