### PR TITLE
test(agent-runtime): add Dream trigger-only boundary and distilled persistence coverage

### DIFF
--- a/clients/agent-runtime/src/gateway/mod.rs
+++ b/clients/agent-runtime/src/gateway/mod.rs
@@ -3871,6 +3871,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn explicit_session_completion_does_not_record_or_trigger_dream() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let workspace = tmp.path().to_path_buf();
+        let mem = Arc::new(crate::memory::SqliteMemory::new(&workspace).unwrap());
+        end_session_for_test(
+            &(mem.clone() as Arc<dyn crate::memory::Memory>),
+            "sess-explicit",
+        )
+        .await;
+
+        let mut config = Config::default();
+        config.workspace_dir = workspace.clone();
+        let state = AppState {
+            config: Arc::new(Mutex::new(config)),
+            cost_tracker: None,
+            provider: Arc::new(MockProvider::default()),
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: mem.clone() as Arc<dyn crate::memory::Memory>,
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_mins(5), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            channel_runtime_handle: None,
+            observer: Arc::new(crate::observability::NoopObserver),
+            transcriber: None,
+            audio_config: crate::config::AudioConfig::default(),
+        };
+
+        finalize_generated_session_if_needed(
+            &state,
+            "sess-explicit",
+            webhook_dispatch::WebhookSessionSource::Explicit,
+        )
+        .await;
+
+        assert_eq!(
+            crate::memory::dream_eligibility(&workspace, "sess-explicit").unwrap(),
+            crate::memory::DreamEligibility::NotCompleted
+        );
+        assert!(crate::memory::run_dream_if_triggered(&workspace)
+            .unwrap()
+            .is_none());
+        assert!(!workspace.join("MEMORY.md").exists());
+        assert!(!workspace.join("state").join("dream_state.json").exists());
+    }
+
+    #[tokio::test]
     async fn generated_session_completion_blocks_dream_without_recorded_completion() {
         let tmp = tempfile::TempDir::new().unwrap();
         let workspace = tmp.path().to_path_buf();

--- a/clients/agent-runtime/src/memory/dream.rs
+++ b/clients/agent-runtime/src/memory/dream.rs
@@ -201,7 +201,7 @@ pub fn run_now(
     let mut merged_lines = extract_memory_lines(&existing);
     for file in &recent_signal_files {
         let content = fs::read_to_string(file)?;
-        for line in extract_memory_lines(&content) {
+        for line in extract_distilled_memory_lines(&content) {
             let normalized = normalize_relative_dates(&line, &mut normalized_dates);
             merged_lines.push(normalized);
         }
@@ -458,6 +458,16 @@ fn extract_memory_lines(content: &str) -> Vec<String> {
         .map(str::trim)
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .map(|line| line.trim_start_matches("- ").trim().to_string())
+        .collect()
+}
+
+fn extract_distilled_memory_lines(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("- "))
+        .map(|line| line.trim_start_matches("- ").trim().to_string())
+        .filter(|line| !line.is_empty())
         .collect()
 }
 
@@ -838,6 +848,30 @@ mod tests {
         assert!(report.duplicates_removed >= 1);
         assert!(memory.contains("on "));
         assert!(memory.contains("Dream summary for completed session sess-123"));
+    }
+
+    #[test]
+    fn dream_persists_distilled_daily_signals_not_raw_session_transcript() {
+        let tmp = TempDir::new().unwrap();
+        record_session_completion(tmp.path(), "sess-distilled").unwrap();
+        fs::create_dir_all(tmp.path().join("memory")).unwrap();
+        fs::write(
+            tmp.path().join("memory").join("2026-04-23.md"),
+            "# Daily Log\n\n- User prefers distilled memory\n\nRaw transcript: user said the secret phrase swordfish\nassistant replied with implementation details\n",
+        )
+        .unwrap();
+
+        let report = run_now(tmp.path(), DreamTriggerReason::Manual)
+            .unwrap()
+            .unwrap();
+        let memory = fs::read_to_string(tmp.path().join("MEMORY.md")).unwrap();
+
+        assert_eq!(report.sessions_processed, 1);
+        assert!(memory.contains("- User prefers distilled memory"));
+        assert!(memory.contains("- Dream summary for completed session sess-distilled"));
+        assert!(!memory.contains("Raw transcript"));
+        assert!(!memory.contains("secret phrase swordfish"));
+        assert!(!memory.contains("assistant replied with implementation details"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds gateway test verifying explicit sessions do NOT record or trigger Dream (boundary coverage per #690 verify warnings)
- Adds Dream runtime test verifying distilled signals persist but raw transcript lines do not appear in `MEMORY.md`
- Tightens recent-signal extraction to only include explicit distilled bullet lines

## Changes

- **gateway/mod.rs**: Add `explicit_session_completion_does_not_record_or_trigger_dream` test — validates explicit sessions don't affect Dream eligibility or trigger Dream
- **memory/dream.rs**: Add `dream_persists_distilled_daily_signals_not_raw_session_transcript` test — validates distilled bullet lines are persisted but raw transcript content is excluded from MEMORY.md

## Validation

```
cargo test explicit_session_completion_does_not_record_or_trigger_dream      # PASSED
cargo test dream_persists_distilled_daily_signals_not_raw_session_transcript   # PASSED
cargo fmt --all -- --check                                      # PASSED
```

Follows archived spec: Gateway is trigger-only integration point; Dream owns eligibility and persistence logic.