### PR TITLE
feat(tools): add pdf_inspect tool via pdf-inspector

### DIFF
--- a/clients/agent-runtime/Cargo.lock
+++ b/clients/agent-runtime/Cargo.lock
@@ -3269,16 +3269,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3338,7 +3328,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6877,9 +6867,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -6887,12 +6877,12 @@ dependencies = [
  "http 1.4.0",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]

--- a/clients/agent-runtime/Cargo.lock
+++ b/clients/agent-runtime/Cargo.lock
@@ -1141,6 +1141,7 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "pdf-extract",
+ "pdf-inspector",
  "probe-rs",
  "prometheus",
  "prost",
@@ -1937,6 +1938,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -3303,6 +3327,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3516,6 +3581,36 @@ dependencies = [
  "sha2 0.10.9",
  "stringprep",
  "thiserror 2.0.18",
+ "ttf-parser",
+ "weezl",
+]
+
+[[package]]
+name = "lopdf"
+version = "0.40.0"
+source = "git+https://github.com/J-F-Liu/lopdf?rev=7a05512d831415b1f2b1ce522391d6beab8a1284#7a05512d831415b1f2b1ce522391d6beab8a1284"
+dependencies = [
+ "aes",
+ "bitflags 2.11.1",
+ "cbc",
+ "chrono",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom 0.4.2",
+ "indexmap",
+ "itoa",
+ "jiff",
+ "log",
+ "md-5 0.10.6",
+ "nom 8.0.0",
+ "rand 0.10.1",
+ "rangemap",
+ "rayon",
+ "sha2 0.10.9",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
  "ttf-parser",
  "weezl",
 ]
@@ -4291,9 +4386,25 @@ dependencies = [
  "encoding_rs",
  "euclid",
  "log",
- "lopdf",
+ "lopdf 0.38.0",
  "postscript",
  "type1-encoding-parser",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "pdf-inspector"
+version = "0.1.0"
+source = "git+https://github.com/firecrawl/pdf-inspector#88844d18be9983c5d5f70cc23abe33f07b35dc6c"
+dependencies = [
+ "env_logger",
+ "log",
+ "lopdf 0.40.0",
+ "once_cell",
+ "rayon",
+ "regex",
+ "thiserror 2.0.18",
+ "ttf-parser",
  "unicode-normalization",
 ]
 

--- a/clients/agent-runtime/Cargo.lock
+++ b/clients/agent-runtime/Cargo.lock
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "pdf-inspector"
 version = "0.1.0"
-source = "git+https://github.com/firecrawl/pdf-inspector#88844d18be9983c5d5f70cc23abe33f07b35dc6c"
+source = "git+https://github.com/firecrawl/pdf-inspector?rev=20f24d1f8d4ade4f76224ef7c930c83f4423390a#20f24d1f8d4ade4f76224ef7c930c83f4423390a"
 dependencies = [
  "env_logger",
  "log",

--- a/clients/agent-runtime/Cargo.toml
+++ b/clients/agent-runtime/Cargo.toml
@@ -160,6 +160,9 @@ probe-rs = { version = "0.31", optional = true }
 # PDF extraction for datasheet RAG (optional, enable with --features rag-pdf)
 pdf-extract = { version = "0.10", optional = true }
 
+# PDF inspection, classification, and text extraction
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", optional = true }
+
 # Raspberry Pi GPIO / Landlock (Linux only) — target-specific to avoid compile failure on macOS
 [target.'cfg(target_os = "linux")'.dependencies]
 rppal = { version = "0.22", optional = true }
@@ -192,6 +195,8 @@ landlock = ["sandbox-landlock"]
 probe = ["dep:probe-rs"]
 # rag-pdf = PDF ingestion for datasheet RAG
 rag-pdf = ["dep:pdf-extract"]
+# pdf-inspect = PDF inspection, classification, and text extraction tool
+pdf-inspect = ["dep:pdf-inspector"]
 [profile.release]
 opt-level = "z"      # Optimize for size
 lto = "thin"         # Lower memory use during release builds

--- a/clients/agent-runtime/Cargo.toml
+++ b/clients/agent-runtime/Cargo.toml
@@ -161,7 +161,9 @@ probe-rs = { version = "0.31", optional = true }
 pdf-extract = { version = "0.10", optional = true }
 
 # PDF inspection, classification, and text extraction
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", optional = true }
+# Pinned to v0.7.0 (latest stable tag as of 2026-05-06); no LICENSE file in upstream repo —
+# treat as proprietary/all-rights-reserved until clarified; re-evaluate before publishing.
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "20f24d1f8d4ade4f76224ef7c930c83f4423390a", optional = true }
 
 # Raspberry Pi GPIO / Landlock (Linux only) — target-specific to avoid compile failure on macOS
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/clients/agent-runtime/src/tools/file_read.rs
+++ b/clients/agent-runtime/src/tools/file_read.rs
@@ -1,3 +1,4 @@
+use super::security_helpers::{check_and_resolve_path, PathCheckOutcome};
 use super::traits::{Tool, ToolResult};
 use crate::security::SecurityPolicy;
 use async_trait::async_trait;
@@ -46,63 +47,10 @@ impl Tool for FileReadTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing 'path' parameter"))?;
 
-        if self.security.is_rate_limited() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
-                structured: None,
-            });
-        }
-
-        // Security check: validate path is within workspace
-        if !self.security.is_path_allowed(path) {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some(format!("Path not allowed by security policy: {path}")),
-                structured: None,
-            });
-        }
-
-        // Record action BEFORE canonicalization so that every non-trivially-rejected
-        // request consumes rate limit budget. This prevents attackers from probing
-        // path existence (via canonicalize errors) without rate limit cost.
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".into()),
-                structured: None,
-            });
-        }
-
-        let full_path = self.security.workspace_dir.join(path);
-
-        // Resolve path before reading to block symlink escapes.
-        let resolved_path = match tokio::fs::canonicalize(&full_path).await {
-            Ok(p) => p,
-            Err(e) => {
-                return Ok(ToolResult {
-                    success: false,
-                    output: String::new(),
-                    error: Some(format!("Failed to resolve file path: {e}")),
-                    structured: None,
-                });
-            }
+        let resolved_path = match check_and_resolve_path(&self.security, path).await {
+            PathCheckOutcome::Resolved(p) => p,
+            PathCheckOutcome::Rejected(result) => return Ok(result),
         };
-
-        if !self.security.is_resolved_path_allowed(&resolved_path) {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some(format!(
-                    "Resolved path escapes workspace: {}",
-                    resolved_path.display()
-                )),
-                structured: None,
-            });
-        }
 
         // Check file size AFTER canonicalization to prevent TOCTOU symlink bypass
         match tokio::fs::metadata(&resolved_path).await {

--- a/clients/agent-runtime/src/tools/mod.rs
+++ b/clients/agent-runtime/src/tools/mod.rs
@@ -27,6 +27,7 @@ pub mod image_info;
 pub mod mcp;
 pub mod memory_forget;
 pub(crate) mod memory_helpers;
+pub(crate) mod security_helpers;
 pub mod memory_recall;
 pub mod memory_store;
 #[cfg(feature = "pdf-inspect")]

--- a/clients/agent-runtime/src/tools/mod.rs
+++ b/clients/agent-runtime/src/tools/mod.rs
@@ -29,6 +29,8 @@ pub mod memory_forget;
 pub(crate) mod memory_helpers;
 pub mod memory_recall;
 pub mod memory_store;
+#[cfg(feature = "pdf-inspect")]
+pub mod pdf_inspect;
 pub mod pushover;
 pub mod schedule;
 pub mod schema;
@@ -43,8 +45,6 @@ pub mod traits;
 pub(crate) mod url_safety;
 pub mod web_fetch;
 pub mod web_search_tool;
-#[cfg(feature = "pdf-inspect")]
-pub mod pdf_inspect;
 
 pub const PARITY_TOOL_ALIASES: &[(&str, &str)] = &[
     ("Glob", "glob"),
@@ -118,6 +118,8 @@ pub use image_info::ImageInfoTool;
 pub use memory_forget::MemoryForgetTool;
 pub use memory_recall::MemoryRecallTool;
 pub use memory_store::MemoryStoreTool;
+#[cfg(feature = "pdf-inspect")]
+pub use pdf_inspect::PdfInspectTool;
 pub use pushover::PushoverTool;
 pub use schedule::ScheduleTool;
 #[allow(unused_imports)]
@@ -134,8 +136,6 @@ pub use traits::Tool;
 pub use traits::{ToolResult, ToolSpec};
 pub use web_fetch::WebFetchTool;
 pub use web_search_tool::WebSearchTool;
-#[cfg(feature = "pdf-inspect")]
-pub use pdf_inspect::PdfInspectTool;
 
 use crate::agent::coordinator::SupervisedOrchestrationService;
 use crate::agent::mailbox::{MailboxBackedChildRunner, MailboxWakeupHub, SqliteMailboxStore};

--- a/clients/agent-runtime/src/tools/mod.rs
+++ b/clients/agent-runtime/src/tools/mod.rs
@@ -43,6 +43,8 @@ pub mod traits;
 pub(crate) mod url_safety;
 pub mod web_fetch;
 pub mod web_search_tool;
+#[cfg(feature = "pdf-inspect")]
+pub mod pdf_inspect;
 
 pub const PARITY_TOOL_ALIASES: &[(&str, &str)] = &[
     ("Glob", "glob"),
@@ -132,6 +134,8 @@ pub use traits::Tool;
 pub use traits::{ToolResult, ToolSpec};
 pub use web_fetch::WebFetchTool;
 pub use web_search_tool::WebSearchTool;
+#[cfg(feature = "pdf-inspect")]
+pub use pdf_inspect::PdfInspectTool;
 
 use crate::agent::coordinator::SupervisedOrchestrationService;
 use crate::agent::mailbox::{MailboxBackedChildRunner, MailboxWakeupHub, SqliteMailboxStore};
@@ -513,6 +517,10 @@ pub fn all_tools_with_runtime(
     // Vision tools are always available
     tools.push(Box::new(ScreenshotTool::new(security.clone())));
     tools.push(Box::new(ImageInfoTool::new(security.clone())));
+
+    // PDF inspection (optional feature)
+    #[cfg(feature = "pdf-inspect")]
+    tools.push(Box::new(PdfInspectTool::new(security.clone())));
 
     add_composio_tool(&mut tools, security, composio_key, composio_entity_id);
 

--- a/clients/agent-runtime/src/tools/mod.rs
+++ b/clients/agent-runtime/src/tools/mod.rs
@@ -27,7 +27,6 @@ pub mod image_info;
 pub mod mcp;
 pub mod memory_forget;
 pub(crate) mod memory_helpers;
-pub(crate) mod security_helpers;
 pub mod memory_recall;
 pub mod memory_store;
 #[cfg(feature = "pdf-inspect")]
@@ -36,6 +35,7 @@ pub mod pushover;
 pub mod schedule;
 pub mod schema;
 pub mod screenshot;
+pub(crate) mod security_helpers;
 pub mod shell;
 pub mod task_create;
 pub mod task_get;

--- a/clients/agent-runtime/src/tools/pdf_inspect.rs
+++ b/clients/agent-runtime/src/tools/pdf_inspect.rs
@@ -107,6 +107,13 @@ impl Tool for PdfInspectTool {
             }
         }
 
+        // KNOWN LIMITATION: `spawn_blocking` tasks cannot be aborted once started.
+        // `tokio::time::timeout` will stop awaiting the result, but the PDF parse
+        // continues on a blocking thread until it finishes or the process exits.
+        // A pathological PDF can therefore hold a blocking-pool thread past the
+        // timeout window. Cooperative cancellation would require changes to the
+        // upstream `pdf_inspector` crate (e.g. a periodic cancellation flag).
+        // Tracked in: https://github.com/dallay/corvus/issues/XXX
         let path_clone = resolved_path.clone();
         let task = tokio::task::spawn_blocking(move || {
             if extract_text {

--- a/clients/agent-runtime/src/tools/pdf_inspect.rs
+++ b/clients/agent-runtime/src/tools/pdf_inspect.rs
@@ -1,3 +1,4 @@
+use super::security_helpers::{check_and_resolve_path, PathCheckOutcome};
 use super::traits::{Tool, ToolResult};
 use crate::security::SecurityPolicy;
 use async_trait::async_trait;
@@ -69,58 +70,10 @@ impl Tool for PdfInspectTool {
                 .ok_or_else(|| anyhow::anyhow!("'extract_text' must be a boolean"))?,
         };
 
-        if self.security.is_rate_limited() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
-                structured: None,
-            });
-        }
-
-        if !self.security.is_path_allowed(path) {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some(format!("Path not allowed by security policy: {path}")),
-                structured: None,
-            });
-        }
-
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".into()),
-                structured: None,
-            });
-        }
-
-        let full_path = self.security.workspace_dir.join(path);
-
-        let resolved_path = match tokio::fs::canonicalize(&full_path).await {
-            Ok(p) => p,
-            Err(e) => {
-                return Ok(ToolResult {
-                    success: false,
-                    output: String::new(),
-                    error: Some(format!("Failed to resolve file path: {e}")),
-                    structured: None,
-                });
-            }
+        let resolved_path = match check_and_resolve_path(&self.security, path).await {
+            PathCheckOutcome::Resolved(p) => p,
+            PathCheckOutcome::Rejected(result) => return Ok(result),
         };
-
-        if !self.security.is_resolved_path_allowed(&resolved_path) {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some(format!(
-                    "Resolved path escapes workspace: {}",
-                    resolved_path.display()
-                )),
-                structured: None,
-            });
-        }
 
         match tokio::fs::metadata(&resolved_path).await {
             Ok(meta) => {

--- a/clients/agent-runtime/src/tools/pdf_inspect.rs
+++ b/clients/agent-runtime/src/tools/pdf_inspect.rs
@@ -3,6 +3,9 @@ use crate::security::SecurityPolicy;
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
+use std::time::Duration;
+
+const PDF_PROCESSING_TIMEOUT: Duration = Duration::from_secs(60);
 
 const MAX_PDF_SIZE_BYTES: u64 = 50 * 1024 * 1024;
 
@@ -118,6 +121,14 @@ impl Tool for PdfInspectTool {
 
         match tokio::fs::metadata(&resolved_path).await {
             Ok(meta) => {
+                if !meta.is_file() {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some("Not a regular file".into()),
+                        structured: None,
+                    });
+                }
                 if meta.len() > MAX_PDF_SIZE_BYTES {
                     return Ok(ToolResult {
                         success: false,
@@ -141,7 +152,7 @@ impl Tool for PdfInspectTool {
         }
 
         let path_clone = resolved_path.clone();
-        let result = tokio::task::spawn_blocking(move || {
+        let task = tokio::task::spawn_blocking(move || {
             if extract_text {
                 pdf_inspector::process_pdf(&path_clone)
             } else {
@@ -150,8 +161,22 @@ impl Tool for PdfInspectTool {
                     pdf_inspector::PdfOptions::detect_only(),
                 )
             }
-        })
-        .await;
+        });
+
+        let result = match tokio::time::timeout(PDF_PROCESSING_TIMEOUT, task).await {
+            Ok(inner) => inner,
+            Err(_) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!(
+                        "PDF processing timed out after {}s",
+                        PDF_PROCESSING_TIMEOUT.as_secs()
+                    )),
+                    structured: None,
+                });
+            }
+        };
 
         match result {
             Ok(Ok(info)) => {
@@ -203,6 +228,7 @@ mod tests {
     use super::*;
     use crate::security::{AutonomyLevel, SecurityPolicy};
     use serde_json::json;
+    use tempfile::TempDir;
 
     fn test_security(workspace: std::path::PathBuf) -> Arc<SecurityPolicy> {
         Arc::new(SecurityPolicy {
@@ -226,13 +252,15 @@ mod tests {
 
     #[test]
     fn pdf_inspect_name() {
-        let tool = PdfInspectTool::new(test_security(std::env::temp_dir()));
+        let dir = TempDir::new().unwrap();
+        let tool = PdfInspectTool::new(test_security(dir.path().to_path_buf()));
         assert_eq!(tool.name(), "pdf_inspect");
     }
 
     #[test]
     fn pdf_inspect_schema_has_path() {
-        let tool = PdfInspectTool::new(test_security(std::env::temp_dir()));
+        let dir = TempDir::new().unwrap();
+        let tool = PdfInspectTool::new(test_security(dir.path().to_path_buf()));
         let schema = tool.parameters_schema();
         assert!(schema["properties"]["path"].is_object());
         assert!(schema["required"]
@@ -243,7 +271,8 @@ mod tests {
 
     #[test]
     fn pdf_inspect_schema_has_extract_text() {
-        let tool = PdfInspectTool::new(test_security(std::env::temp_dir()));
+        let dir = TempDir::new().unwrap();
+        let tool = PdfInspectTool::new(test_security(dir.path().to_path_buf()));
         let schema = tool.parameters_schema();
         assert!(schema["properties"]["extract_text"].is_object());
         assert_eq!(schema["properties"]["extract_text"]["type"], "boolean");
@@ -251,31 +280,28 @@ mod tests {
 
     #[tokio::test]
     async fn pdf_inspect_missing_path_param() {
-        let tool = PdfInspectTool::new(test_security(std::env::temp_dir()));
+        let dir = TempDir::new().unwrap();
+        let tool = PdfInspectTool::new(test_security(dir.path().to_path_buf()));
         let result = tool.execute(json!({})).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn pdf_inspect_blocks_path_traversal() {
-        let dir = std::env::temp_dir().join("corvus_test_pdf_inspect_traversal");
-        let _ = tokio::fs::remove_dir_all(&dir).await;
-        tokio::fs::create_dir_all(&dir).await.unwrap();
-
-        let tool = PdfInspectTool::new(test_security(dir.clone()));
+        let dir = TempDir::new().unwrap();
+        let tool = PdfInspectTool::new(test_security(dir.path().to_path_buf()));
         let result = tool
             .execute(json!({"path": "../../../etc/passwd"}))
             .await
             .unwrap();
         assert!(!result.success);
         assert!(result.error.as_ref().unwrap().contains("not allowed"));
-
-        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 
     #[tokio::test]
     async fn pdf_inspect_blocks_absolute_path() {
-        let tool = PdfInspectTool::new(test_security(std::env::temp_dir()));
+        let dir = TempDir::new().unwrap();
+        let tool = PdfInspectTool::new(test_security(dir.path().to_path_buf()));
         let result = tool.execute(json!({"path": "/etc/passwd"})).await.unwrap();
         assert!(!result.success);
         assert!(result.error.as_ref().unwrap().contains("not allowed"));
@@ -283,25 +309,17 @@ mod tests {
 
     #[tokio::test]
     async fn pdf_inspect_nonexistent_file() {
-        let dir = std::env::temp_dir().join("corvus_test_pdf_inspect_missing");
-        let _ = tokio::fs::remove_dir_all(&dir).await;
-        tokio::fs::create_dir_all(&dir).await.unwrap();
-
-        let tool = PdfInspectTool::new(test_security(dir.clone()));
+        let dir = TempDir::new().unwrap();
+        let tool = PdfInspectTool::new(test_security(dir.path().to_path_buf()));
         let result = tool.execute(json!({"path": "nope.pdf"})).await.unwrap();
         assert!(!result.success);
         assert!(result.error.as_ref().unwrap().contains("Failed to resolve"));
-
-        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 
     #[tokio::test]
     async fn pdf_inspect_blocks_when_rate_limited() {
-        let dir = std::env::temp_dir().join("corvus_test_pdf_inspect_rate_limited");
-        let _ = tokio::fs::remove_dir_all(&dir).await;
-        tokio::fs::create_dir_all(&dir).await.unwrap();
-
-        let tool = PdfInspectTool::new(test_security_with(dir.clone(), 0));
+        let dir = TempDir::new().unwrap();
+        let tool = PdfInspectTool::new(test_security_with(dir.path().to_path_buf(), 0));
         let result = tool.execute(json!({"path": "test.pdf"})).await.unwrap();
         assert!(!result.success);
         assert!(result
@@ -309,25 +327,34 @@ mod tests {
             .as_deref()
             .unwrap_or("")
             .contains("Rate limit exceeded"));
-
-        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 
     #[tokio::test]
     async fn pdf_inspect_rejects_oversized_file() {
-        let dir = std::env::temp_dir().join("corvus_test_pdf_inspect_large");
-        let _ = tokio::fs::remove_dir_all(&dir).await;
-        tokio::fs::create_dir_all(&dir).await.unwrap();
-
-        // Create a fake file just over 50 MB
+        let dir = TempDir::new().unwrap();
         let big = vec![b'x'; 50 * 1024 * 1024 + 1];
-        tokio::fs::write(dir.join("huge.pdf"), &big).await.unwrap();
-
-        let tool = PdfInspectTool::new(test_security(dir.clone()));
+        tokio::fs::write(dir.path().join("huge.pdf"), &big)
+            .await
+            .unwrap();
+        let tool = PdfInspectTool::new(test_security(dir.path().to_path_buf()));
         let result = tool.execute(json!({"path": "huge.pdf"})).await.unwrap();
         assert!(!result.success);
         assert!(result.error.as_ref().unwrap().contains("File too large"));
+    }
 
-        let _ = tokio::fs::remove_dir_all(&dir).await;
+    #[tokio::test]
+    async fn pdf_inspect_rejects_directory() {
+        let dir = TempDir::new().unwrap();
+        tokio::fs::create_dir(dir.path().join("subdir"))
+            .await
+            .unwrap();
+        let tool = PdfInspectTool::new(test_security(dir.path().to_path_buf()));
+        let result = tool.execute(json!({"path": "subdir"})).await.unwrap();
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_ref()
+            .unwrap()
+            .contains("Not a regular file"));
     }
 }

--- a/clients/agent-runtime/src/tools/pdf_inspect.rs
+++ b/clients/agent-runtime/src/tools/pdf_inspect.rs
@@ -276,10 +276,7 @@ mod tests {
     #[tokio::test]
     async fn pdf_inspect_blocks_absolute_path() {
         let tool = PdfInspectTool::new(test_security(std::env::temp_dir()));
-        let result = tool
-            .execute(json!({"path": "/etc/passwd"}))
-            .await
-            .unwrap();
+        let result = tool.execute(json!({"path": "/etc/passwd"})).await.unwrap();
         assert!(!result.success);
         assert!(result.error.as_ref().unwrap().contains("not allowed"));
     }
@@ -291,10 +288,7 @@ mod tests {
         tokio::fs::create_dir_all(&dir).await.unwrap();
 
         let tool = PdfInspectTool::new(test_security(dir.clone()));
-        let result = tool
-            .execute(json!({"path": "nope.pdf"}))
-            .await
-            .unwrap();
+        let result = tool.execute(json!({"path": "nope.pdf"})).await.unwrap();
         assert!(!result.success);
         assert!(result.error.as_ref().unwrap().contains("Failed to resolve"));
 
@@ -308,10 +302,7 @@ mod tests {
         tokio::fs::create_dir_all(&dir).await.unwrap();
 
         let tool = PdfInspectTool::new(test_security_with(dir.clone(), 0));
-        let result = tool
-            .execute(json!({"path": "test.pdf"}))
-            .await
-            .unwrap();
+        let result = tool.execute(json!({"path": "test.pdf"})).await.unwrap();
         assert!(!result.success);
         assert!(result
             .error
@@ -333,10 +324,7 @@ mod tests {
         tokio::fs::write(dir.join("huge.pdf"), &big).await.unwrap();
 
         let tool = PdfInspectTool::new(test_security(dir.clone()));
-        let result = tool
-            .execute(json!({"path": "huge.pdf"}))
-            .await
-            .unwrap();
+        let result = tool.execute(json!({"path": "huge.pdf"})).await.unwrap();
         assert!(!result.success);
         assert!(result.error.as_ref().unwrap().contains("File too large"));
 

--- a/clients/agent-runtime/src/tools/pdf_inspect.rs
+++ b/clients/agent-runtime/src/tools/pdf_inspect.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
 
-const PDF_PROCESSING_TIMEOUT: Duration = Duration::from_secs(60);
+const PDF_PROCESSING_TIMEOUT: Duration = Duration::from_mins(1);
 
 const MAX_PDF_SIZE_BYTES: u64 = 50 * 1024 * 1024;
 
@@ -51,7 +51,8 @@ impl Tool for PdfInspectTool {
                                    Set to false for a fast metadata-only classification."
                 }
             },
-            "required": ["path"]
+            "required": ["path"],
+            "additionalProperties": false
         })
     }
 
@@ -61,10 +62,12 @@ impl Tool for PdfInspectTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing 'path' parameter"))?;
 
-        let extract_text = args
-            .get("extract_text")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true);
+        let extract_text = match args.get("extract_text") {
+            None => true,
+            Some(v) => v
+                .as_bool()
+                .ok_or_else(|| anyhow::anyhow!("'extract_text' must be a boolean"))?,
+        };
 
         if self.security.is_rate_limited() {
             return Ok(ToolResult {
@@ -181,11 +184,12 @@ impl Tool for PdfInspectTool {
         match result {
             Ok(Ok(info)) => {
                 let pdf_type = format!("{:?}", info.pdf_type);
-                let pages_needing_ocr = info.pages_needing_ocr.clone();
-                let markdown = info.markdown.clone().unwrap_or_default();
+                let has_markdown = info.markdown.is_some();
+                let pages_needing_ocr = info.pages_needing_ocr;
+                let markdown = info.markdown.unwrap_or_default();
 
                 let output = if extract_text && !markdown.is_empty() {
-                    markdown.clone()
+                    markdown
                 } else {
                     format!(
                         "PDF type: {pdf_type}\nPages: {}\nProcessing time: {}ms",
@@ -203,7 +207,7 @@ impl Tool for PdfInspectTool {
                         "processing_time_ms": info.processing_time_ms,
                         "pages_needing_ocr": pages_needing_ocr,
                         "title": info.title,
-                        "has_markdown": info.markdown.is_some(),
+                        "has_markdown": has_markdown,
                     })),
                 })
             }

--- a/clients/agent-runtime/src/tools/pdf_inspect.rs
+++ b/clients/agent-runtime/src/tools/pdf_inspect.rs
@@ -1,0 +1,345 @@
+use super::traits::{Tool, ToolResult};
+use crate::security::SecurityPolicy;
+use async_trait::async_trait;
+use serde_json::json;
+use std::sync::Arc;
+
+const MAX_PDF_SIZE_BYTES: u64 = 50 * 1024 * 1024;
+
+/// Inspect, classify, and extract text from a PDF file.
+///
+/// Detects whether the PDF is text-based, scanned, image-based, or mixed, and
+/// converts extractable text to Markdown. Returns a structured result with the
+/// detected type, page count, pages needing OCR, and optional Markdown output.
+pub struct PdfInspectTool {
+    security: Arc<SecurityPolicy>,
+}
+
+impl PdfInspectTool {
+    pub fn new(security: Arc<SecurityPolicy>) -> Self {
+        Self { security }
+    }
+}
+
+#[async_trait]
+impl Tool for PdfInspectTool {
+    fn name(&self) -> &str {
+        "pdf_inspect"
+    }
+
+    fn description(&self) -> &str {
+        "Inspect and extract text from a PDF file. Detects whether the PDF is \
+        text-based, scanned, image-based, or mixed, and converts extractable \
+        text to Markdown. Returns PDF type, page count, pages needing OCR, \
+        title, and Markdown content when available."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Relative path to the PDF file within the workspace"
+                },
+                "extract_text": {
+                    "type": "boolean",
+                    "description": "Whether to extract and convert text to Markdown (default: true). \
+                                   Set to false for a fast metadata-only classification."
+                }
+            },
+            "required": ["path"]
+        })
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        let path = args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("Missing 'path' parameter"))?;
+
+        let extract_text = args
+            .get("extract_text")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        if self.security.is_rate_limited() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
+                structured: None,
+            });
+        }
+
+        if !self.security.is_path_allowed(path) {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Path not allowed by security policy: {path}")),
+                structured: None,
+            });
+        }
+
+        if !self.security.record_action() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("Rate limit exceeded: action budget exhausted".into()),
+                structured: None,
+            });
+        }
+
+        let full_path = self.security.workspace_dir.join(path);
+
+        let resolved_path = match tokio::fs::canonicalize(&full_path).await {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!("Failed to resolve file path: {e}")),
+                    structured: None,
+                });
+            }
+        };
+
+        if !self.security.is_resolved_path_allowed(&resolved_path) {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Resolved path escapes workspace: {}",
+                    resolved_path.display()
+                )),
+                structured: None,
+            });
+        }
+
+        match tokio::fs::metadata(&resolved_path).await {
+            Ok(meta) => {
+                if meta.len() > MAX_PDF_SIZE_BYTES {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some(format!(
+                            "File too large: {} bytes (limit: {MAX_PDF_SIZE_BYTES} bytes)",
+                            meta.len()
+                        )),
+                        structured: None,
+                    });
+                }
+            }
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!("Failed to read file metadata: {e}")),
+                    structured: None,
+                });
+            }
+        }
+
+        let path_clone = resolved_path.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            if extract_text {
+                pdf_inspector::process_pdf(&path_clone)
+            } else {
+                pdf_inspector::process_pdf_with_options(
+                    &path_clone,
+                    pdf_inspector::PdfOptions::detect_only(),
+                )
+            }
+        })
+        .await;
+
+        match result {
+            Ok(Ok(info)) => {
+                let pdf_type = format!("{:?}", info.pdf_type);
+                let pages_needing_ocr = info.pages_needing_ocr.clone();
+                let markdown = info.markdown.clone().unwrap_or_default();
+
+                let output = if extract_text && !markdown.is_empty() {
+                    markdown.clone()
+                } else {
+                    format!(
+                        "PDF type: {pdf_type}\nPages: {}\nProcessing time: {}ms",
+                        info.page_count, info.processing_time_ms
+                    )
+                };
+
+                Ok(ToolResult {
+                    success: true,
+                    output,
+                    error: None,
+                    structured: Some(json!({
+                        "pdf_type": pdf_type,
+                        "page_count": info.page_count,
+                        "processing_time_ms": info.processing_time_ms,
+                        "pages_needing_ocr": pages_needing_ocr,
+                        "title": info.title,
+                        "has_markdown": info.markdown.is_some(),
+                    })),
+                })
+            }
+            Ok(Err(e)) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Failed to process PDF: {e}")),
+                structured: None,
+            }),
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("PDF processing task panicked: {e}")),
+                structured: None,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::security::{AutonomyLevel, SecurityPolicy};
+    use serde_json::json;
+
+    fn test_security(workspace: std::path::PathBuf) -> Arc<SecurityPolicy> {
+        Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Supervised,
+            workspace_dir: workspace,
+            ..SecurityPolicy::default()
+        })
+    }
+
+    fn test_security_with(
+        workspace: std::path::PathBuf,
+        max_actions_per_hour: u32,
+    ) -> Arc<SecurityPolicy> {
+        Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Supervised,
+            workspace_dir: workspace,
+            max_actions_per_hour,
+            ..SecurityPolicy::default()
+        })
+    }
+
+    #[test]
+    fn pdf_inspect_name() {
+        let tool = PdfInspectTool::new(test_security(std::env::temp_dir()));
+        assert_eq!(tool.name(), "pdf_inspect");
+    }
+
+    #[test]
+    fn pdf_inspect_schema_has_path() {
+        let tool = PdfInspectTool::new(test_security(std::env::temp_dir()));
+        let schema = tool.parameters_schema();
+        assert!(schema["properties"]["path"].is_object());
+        assert!(schema["required"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("path")));
+    }
+
+    #[test]
+    fn pdf_inspect_schema_has_extract_text() {
+        let tool = PdfInspectTool::new(test_security(std::env::temp_dir()));
+        let schema = tool.parameters_schema();
+        assert!(schema["properties"]["extract_text"].is_object());
+        assert_eq!(schema["properties"]["extract_text"]["type"], "boolean");
+    }
+
+    #[tokio::test]
+    async fn pdf_inspect_missing_path_param() {
+        let tool = PdfInspectTool::new(test_security(std::env::temp_dir()));
+        let result = tool.execute(json!({})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn pdf_inspect_blocks_path_traversal() {
+        let dir = std::env::temp_dir().join("corvus_test_pdf_inspect_traversal");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let tool = PdfInspectTool::new(test_security(dir.clone()));
+        let result = tool
+            .execute(json!({"path": "../../../etc/passwd"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("not allowed"));
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn pdf_inspect_blocks_absolute_path() {
+        let tool = PdfInspectTool::new(test_security(std::env::temp_dir()));
+        let result = tool
+            .execute(json!({"path": "/etc/passwd"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("not allowed"));
+    }
+
+    #[tokio::test]
+    async fn pdf_inspect_nonexistent_file() {
+        let dir = std::env::temp_dir().join("corvus_test_pdf_inspect_missing");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let tool = PdfInspectTool::new(test_security(dir.clone()));
+        let result = tool
+            .execute(json!({"path": "nope.pdf"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("Failed to resolve"));
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn pdf_inspect_blocks_when_rate_limited() {
+        let dir = std::env::temp_dir().join("corvus_test_pdf_inspect_rate_limited");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let tool = PdfInspectTool::new(test_security_with(dir.clone(), 0));
+        let result = tool
+            .execute(json!({"path": "test.pdf"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("Rate limit exceeded"));
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn pdf_inspect_rejects_oversized_file() {
+        let dir = std::env::temp_dir().join("corvus_test_pdf_inspect_large");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        // Create a fake file just over 50 MB
+        let big = vec![b'x'; 50 * 1024 * 1024 + 1];
+        tokio::fs::write(dir.join("huge.pdf"), &big).await.unwrap();
+
+        let tool = PdfInspectTool::new(test_security(dir.clone()));
+        let result = tool
+            .execute(json!({"path": "huge.pdf"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("File too large"));
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+}

--- a/clients/agent-runtime/src/tools/security_helpers.rs
+++ b/clients/agent-runtime/src/tools/security_helpers.rs
@@ -1,0 +1,159 @@
+use crate::security::SecurityPolicy;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use super::traits::ToolResult;
+
+/// Outcome of the shared path security check.
+///
+/// A successful check returns the canonicalized, workspace-confined path
+/// ready for use. A rejected check returns an early `ToolResult` that the
+/// caller must immediately return to the agent.
+pub(crate) enum PathCheckOutcome {
+    Resolved(PathBuf),
+    Rejected(ToolResult),
+}
+
+/// Run the five mandatory security guards that every file-accessing tool must
+/// perform before touching the filesystem:
+///
+/// 1. Pre-check rate limit (fast path, no budget consumed).
+/// 2. Validate the raw path against the security policy allowlist.
+/// 3. Record the action (consumes one budget token, preventing path-probing).
+/// 4. Canonicalize the joined path to resolve symlinks.
+/// 5. Verify the canonical path is still within the workspace.
+///
+/// The `max_size` check and any tool-specific validation (e.g. `is_file()`)
+/// are intentionally left to the caller because the limits differ per tool.
+///
+/// # Ordering rationale
+/// `record_action` is called BEFORE `canonicalize` so that every
+/// non-trivially-rejected request consumes rate-limit budget. This prevents
+/// an attacker from probing path existence (via canonicalize I/O errors)
+/// without paying the rate-limit cost.
+pub(crate) async fn check_and_resolve_path(
+    security: &Arc<SecurityPolicy>,
+    path: &str,
+) -> PathCheckOutcome {
+    if security.is_rate_limited() {
+        return PathCheckOutcome::Rejected(ToolResult {
+            success: false,
+            output: String::new(),
+            error: Some("Rate limit exceeded: too many actions in the last hour".into()),
+            structured: None,
+        });
+    }
+
+    if !security.is_path_allowed(path) {
+        return PathCheckOutcome::Rejected(ToolResult {
+            success: false,
+            output: String::new(),
+            error: Some(format!("Path not allowed by security policy: {path}")),
+            structured: None,
+        });
+    }
+
+    // Record action BEFORE canonicalization so that every non-trivially-rejected
+    // request consumes rate limit budget. This prevents attackers from probing
+    // path existence (via canonicalize errors) without rate limit cost.
+    if !security.record_action() {
+        return PathCheckOutcome::Rejected(ToolResult {
+            success: false,
+            output: String::new(),
+            error: Some("Rate limit exceeded: action budget exhausted".into()),
+            structured: None,
+        });
+    }
+
+    let full_path = security.workspace_dir.join(path);
+
+    let resolved_path = match tokio::fs::canonicalize(&full_path).await {
+        Ok(p) => p,
+        Err(e) => {
+            return PathCheckOutcome::Rejected(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Failed to resolve file path: {e}")),
+                structured: None,
+            });
+        }
+    };
+
+    if !security.is_resolved_path_allowed(&resolved_path) {
+        return PathCheckOutcome::Rejected(ToolResult {
+            success: false,
+            output: String::new(),
+            error: Some(format!(
+                "Resolved path escapes workspace: {}",
+                resolved_path.display()
+            )),
+            structured: None,
+        });
+    }
+
+    PathCheckOutcome::Resolved(resolved_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::security::{AutonomyLevel, SecurityPolicy};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn make_security(dir: &std::path::Path) -> Arc<SecurityPolicy> {
+        Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::ReadOnly,
+            workspace_dir: dir.to_path_buf(),
+            ..SecurityPolicy::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn resolves_valid_path() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("hello.txt");
+        std::fs::write(&file, "hi").unwrap();
+
+        let security = make_security(dir.path());
+        let outcome = check_and_resolve_path(&security, "hello.txt").await;
+
+        assert!(matches!(outcome, PathCheckOutcome::Resolved(_)));
+    }
+
+    #[tokio::test]
+    async fn rejects_path_outside_workspace() {
+        let dir = TempDir::new().unwrap();
+        let security = make_security(dir.path());
+
+        let outcome = check_and_resolve_path(&security, "../etc/passwd").await;
+
+        match outcome {
+            PathCheckOutcome::Rejected(result) => {
+                assert!(!result.success);
+                let err = result.error.unwrap();
+                assert!(
+                    err.contains("Path not allowed") || err.contains("escapes workspace"),
+                    "unexpected error: {err}"
+                );
+            }
+            PathCheckOutcome::Resolved(_) => panic!("expected rejection"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_nonexistent_file() {
+        let dir = TempDir::new().unwrap();
+        let security = make_security(dir.path());
+
+        let outcome = check_and_resolve_path(&security, "no_such_file.txt").await;
+
+        match outcome {
+            PathCheckOutcome::Rejected(result) => {
+                assert!(!result.success);
+                assert!(result.error.unwrap().contains("Failed to resolve file path"));
+            }
+            PathCheckOutcome::Resolved(_) => panic!("expected rejection"),
+        }
+    }
+}

--- a/clients/agent-runtime/src/tools/security_helpers.rs
+++ b/clients/agent-runtime/src/tools/security_helpers.rs
@@ -151,7 +151,10 @@ mod tests {
         match outcome {
             PathCheckOutcome::Rejected(result) => {
                 assert!(!result.success);
-                assert!(result.error.unwrap().contains("Failed to resolve file path"));
+                assert!(result
+                    .error
+                    .unwrap()
+                    .contains("Failed to resolve file path"));
             }
             PathCheckOutcome::Resolved(_) => panic!("expected rejection"),
         }

--- a/clients/cerebro/Cargo.lock
+++ b/clients/cerebro/Cargo.lock
@@ -2267,16 +2267,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4974,20 +4964,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]


### PR DESCRIPTION
## Related Issues

Closes #548

---

## Summary

Integrates [firecrawl/pdf-inspector](https://github.com/firecrawl/pdf-inspector) as an optional tool (`pdf-inspect` feature flag) in the Corvus agent-runtime.

The tool detects PDF type (text-based, scanned, image-based, mixed), extracts text, and converts it to Markdown — allowing the agent to process PDFs locally and skip unnecessary OCR for documents that already contain extractable text.

**Changes:**
- `Cargo.toml`: add `pdf-inspector` git dependency (optional) + `pdf-inspect` feature flag
- `src/tools/pdf_inspect.rs`: new `PdfInspectTool` implementation
- `src/tools/mod.rs`: module declaration, `pub use`, and factory registration (all `#[cfg(feature = "pdf-inspect")]`)

**Tool behavior:**
- `path` (required): workspace-relative path to the PDF file
- `extract_text` (optional bool, default `true`): full pipeline (detect + extract + Markdown) vs. fast detect-only mode
- Returns structured JSON: `pdf_type`, `page_count`, `processing_time_ms`, `pages_needing_ocr`, `title`, `has_markdown`
- Hard limits: 50 MB file cap, workspace path sandboxing, rate limiting via `SecurityPolicy`

---

## Tested Information

- `cargo check --features pdf-inspect` passes with zero errors
- 8 unit tests added covering: tool name/schema, path traversal block, absolute path block, rate limit enforcement, 50 MB size cap, and missing file error
- Individual test `cargo test --lib` passes for all new tests
- Note: full `cargo test --no-run` linking times out due to surrealdb (known heavy dep, unrelated to this change)

---

## Documentation Impact

- No docs update required because this adds a new optional runtime tool behind a feature flag; it does not change any existing behavior, API contracts, or configuration surface.

---

## Breaking Changes

None. The tool is entirely opt-in via `--features pdf-inspect`. Default builds are unaffected.

---

## Checklist

- [x] I have checked that there isn't already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
