### PR TITLE
perf(compose): reduce allocations and recompositions in Chat UI

### DIFF
--- a/.agents/journal/bolt-journal.md
+++ b/.agents/journal/bolt-journal.md
@@ -13,6 +13,26 @@
 
 ---
 
+## 2026-05-06 - Compose - UI Runtime & Recomposition Optimization
+
+**Location:** `clients/composeApp/src/commonMain/kotlin/com/profiletailors/corvus/ui/chat/ChatInputField.kt`, `clients/composeApp/src/commonMain/kotlin/com/profiletailors/corvus/ui/chat/ChatWorkspace.kt`, `clients/composeApp/src/commonMain/kotlin/com/profiletailors/corvus/ui/chat/ChatComponents.kt`
+**Issue:**
+- `OutlinedTextField` colors and placeholder lambda were being re-allocated on every keystroke.
+- `sendMessage` function and `ChatUiState` were being re-instantiated on every recomposition of `ChatWorkspace`, even when their logical inputs hadn't changed.
+- `BorderStroke` and `SessionHistoryItemStyle` were being re-allocated during list rendering and UI updates.
+**Solution:**
+- Wrapped `OutlinedTextField` colors, placeholder lambda, and `TextStyle` in `remember` blocks in `ChatInputField.kt`.
+- Memoized `sendMessage` and `ChatUiState` in `ChatWorkspace.kt` using `remember` with appropriate keys.
+- Applied `remember` to `BorderStroke` and `sessionHistoryItemStyle` across `ChatComponents.kt`.
+**Impact:**
+- **Reduced GC Pressure:** Significant reduction in ephemeral object allocations (colors, lambdas, styles, strokes) during typing and list interactions.
+- **Improved Interaction Smoothness:** Lower CPU overhead during high-frequency recompositions.
+- **Optimized UI Stability:** Ensures stable references for state and actions, enabling Compose to skip redundant recompositions of child components.
+**Benchmark:**
+- Baseline Compilation: 55s (`compileKotlinJvm`)
+- Post-Optimization Compilation: 55s (`compileKotlinJvm`)
+- *Note:* These runtime optimizations focus on UI smoothness and power efficiency. Incremental builds and JVM tests confirmed successful.
+
 ## 2025-05-23 - Compose - Chat UI Recomposition Optimization
 
 **Location:** `clients/composeApp/src/commonMain/kotlin/com/profiletailors/corvus/ui/chat/ChatWorkspace.kt`

--- a/clients/composeApp/src/commonMain/kotlin/com/profiletailors/corvus/ui/chat/ChatComponents.kt
+++ b/clients/composeApp/src/commonMain/kotlin/com/profiletailors/corvus/ui/chat/ChatComponents.kt
@@ -507,13 +507,10 @@ private fun LazyListScope.sessionHistoryItems(
 
 @Composable
 private fun sessionHistoryItem(session: RuntimeSession, isActive: Boolean, onSwitch: () -> Unit) {
-  val style = sessionHistoryItemStyle(isActive)
+  val style = remember(isActive) { sessionHistoryItemStyle(isActive) }
+  val borderStroke = remember(style.borderColor) { BorderStroke(1.dp, style.borderColor) }
 
-  Surface(
-    shape = RoundedCornerShape(14.dp),
-    color = style.surfaceColor,
-    border = BorderStroke(1.dp, style.borderColor),
-  ) {
+  Surface(shape = RoundedCornerShape(14.dp), color = style.surfaceColor, border = borderStroke) {
     Row(
       modifier =
         Modifier.fillMaxWidth()
@@ -670,11 +667,14 @@ fun ApprovalCard(
   modifier: Modifier = Modifier,
 ) {
   val corvusColors = CorvusTheme.colors
+  val borderStroke =
+    remember(corvusColors.glassOverlay) { BorderStroke(1.dp, corvusColors.glassOverlay) }
+
   Surface(
     modifier = modifier,
     shape = RoundedCornerShape(16.dp),
     color = corvusColors.glassSurface,
-    border = BorderStroke(1.dp, corvusColors.glassOverlay),
+    border = borderStroke,
   ) {
     Column(
       modifier = Modifier.fillMaxWidth().padding(16.dp),
@@ -718,6 +718,8 @@ fun diagnosticsCard(
     remember(corvusColors.gradientPrimary) {
       Brush.horizontalGradient(corvusColors.gradientPrimary)
     }
+  val borderStroke =
+    remember(corvusColors.glassOverlay) { BorderStroke(1.dp, corvusColors.glassOverlay) }
 
   Box(
     modifier =
@@ -732,7 +734,7 @@ fun diagnosticsCard(
     Surface(
       shape = DiagnosticsCardShape,
       color = corvusColors.glassSurface,
-      border = BorderStroke(1.dp, corvusColors.glassOverlay),
+      border = borderStroke,
     ) {
       Column(
         modifier = Modifier.fillMaxWidth().padding(16.dp),

--- a/clients/composeApp/src/commonMain/kotlin/com/profiletailors/corvus/ui/chat/ChatInputField.kt
+++ b/clients/composeApp/src/commonMain/kotlin/com/profiletailors/corvus/ui/chat/ChatInputField.kt
@@ -56,32 +56,43 @@ fun ChatInputField(props: ChatInputFieldProps, modifier: Modifier = Modifier) {
     }
   val isEnabled = props.enabled && props.value.trim().isNotBlank()
 
+  val borderStroke =
+    remember(corvusColors.glassOverlay) { BorderStroke(1.dp, corvusColors.glassOverlay) }
+  val textFieldColors =
+    remember(colors) {
+      OutlinedTextFieldDefaults.colors(
+        focusedBorderColor = Color.Transparent,
+        unfocusedBorderColor = Color.Transparent,
+        focusedTextColor = colors.onSurface,
+        unfocusedTextColor = colors.onSurface,
+        disabledBorderColor = Color.Transparent,
+        disabledTextColor = colors.onSurfaceVariant,
+      )
+    }
+  val textStyle = remember { TextStyle(fontFamily = FontFamily.SansSerif) }
+  val placeholder =
+    remember(props.placeholder, colors.onSurfaceVariant) {
+      @Composable {
+        Text(text = props.placeholder, color = colors.onSurfaceVariant.copy(alpha = 0.6f))
+      }
+    }
+
   Row(modifier = modifier.fillMaxWidth(), verticalAlignment = Alignment.Bottom) {
     Surface(
       modifier = Modifier.weight(1f),
       shape = RoundedCornerShape(16.dp),
       color = corvusColors.glassSurface,
-      border = BorderStroke(1.dp, corvusColors.glassOverlay),
+      border = borderStroke,
     ) {
       OutlinedTextField(
         value = props.value,
         onValueChange = props.onValueChange,
         modifier = Modifier.fillMaxWidth(),
         enabled = props.enabled,
-        placeholder = {
-          Text(text = props.placeholder, color = colors.onSurfaceVariant.copy(alpha = 0.6f))
-        },
-        colors =
-          OutlinedTextFieldDefaults.colors(
-            focusedBorderColor = Color.Transparent,
-            unfocusedBorderColor = Color.Transparent,
-            focusedTextColor = colors.onSurface,
-            unfocusedTextColor = colors.onSurface,
-            disabledBorderColor = Color.Transparent,
-            disabledTextColor = colors.onSurfaceVariant,
-          ),
+        placeholder = placeholder,
+        colors = textFieldColors,
         maxLines = 4,
-        textStyle = TextStyle(fontFamily = FontFamily.SansSerif),
+        textStyle = textStyle,
       )
     }
 

--- a/clients/composeApp/src/commonMain/kotlin/com/profiletailors/corvus/ui/chat/ChatWorkspace.kt
+++ b/clients/composeApp/src/commonMain/kotlin/com/profiletailors/corvus/ui/chat/ChatWorkspace.kt
@@ -160,12 +160,15 @@ fun ChatWorkspace(
       MobileBridgeUiState(platformName = content.platformName, snapshot = content.bridgeSnapshot)
     }
 
-  fun sendMessage(prompt: String) {
-    if (!bridgeState.isChatReady) return
-    if (prompt.trim().isBlank()) return
-    callbacks.onSendMessage(prompt)
-    callbacks.onQueryChange("")
-  }
+  val sendMessage: (String) -> Unit =
+    remember(bridgeState.isChatReady, callbacks) {
+      { prompt ->
+        if (bridgeState.isChatReady && prompt.trim().isNotBlank()) {
+          callbacks.onSendMessage(prompt)
+          callbacks.onQueryChange("")
+        }
+      }
+    }
 
   val displayMessages =
     remember(content.messages, state.welcomeMessage) {
@@ -181,12 +184,13 @@ fun ChatWorkspace(
       bridgeState,
       bridgeActions,
       callbacks,
+      sendMessage,
       content.showConfig,
       content.showSessionHistory,
     ) {
       ChatWorkspaceActions(
         onQueryChange = callbacks.onQueryChange,
-        onSend = ::sendMessage,
+        onSend = sendMessage,
         onToggleConfig = { callbacks.onShowConfigChange(!content.showConfig) },
         onToggleSessionHistory = {
           callbacks.onShowSessionHistoryChange(!content.showSessionHistory)
@@ -196,18 +200,31 @@ fun ChatWorkspace(
     }
 
   val uiState =
-    ChatUiState(
-      workspaceState = state,
-      bridgeState = bridgeState,
-      messages = displayMessages,
-      resumableSessions = content.resumableSessions,
-      pendingApproval = content.pendingApproval,
-      targetLabel = content.targetLabel,
-      activeSessionId = content.activeSessionId,
-      query = content.query,
-      showConfig = content.showConfig,
-      showSessionHistory = content.showSessionHistory,
-    )
+    remember(
+      state,
+      bridgeState,
+      displayMessages,
+      content.resumableSessions,
+      content.pendingApproval,
+      content.targetLabel,
+      content.activeSessionId,
+      content.query,
+      content.showConfig,
+      content.showSessionHistory,
+    ) {
+      ChatUiState(
+        workspaceState = state,
+        bridgeState = bridgeState,
+        messages = displayMessages,
+        resumableSessions = content.resumableSessions,
+        pendingApproval = content.pendingApproval,
+        targetLabel = content.targetLabel,
+        activeSessionId = content.activeSessionId,
+        query = content.query,
+        showConfig = content.showConfig,
+        showSessionHistory = content.showSessionHistory,
+      )
+    }
 
   ChatWorkspaceScreen(uiState = uiState, actions = actions, modifier = modifier)
 }


### PR DESCRIPTION
This PR implements several performance optimizations for the Compose Multiplatform Chat UI.
Specifically, it focuses on reducing object allocations during frequent UI updates (like typing) and stabilizing references to enable better recomposition skipping by the Compose compiler.

Key changes:
- Memoized `OutlinedTextField` properties (colors, placeholder lambda, text style) in `ChatInputField.kt`.
- Wrapped the `sendMessage` function and `ChatUiState` in `remember` blocks in `ChatWorkspace.kt`.
- Applied `remember` to `BorderStroke` and `SessionHistoryItemStyle` in `ChatComponents.kt`.
- Updated the Bolt performance journal with the new entry.

These changes reduce GC pressure and improve UI smoothness during user interactions. Verified with JVM compilation and tests.

---
*PR created automatically by Jules for task [12653546725398676431](https://jules.google.com/task/12653546725398676431) started by @yacosta738*