### PR TITLE
feat(rook): operational parity – undercover mode, debug diagnostics, multi-provider routing controls

### DIFF
--- a/clients/rook/src/admin/handlers.rs
+++ b/clients/rook/src/admin/handlers.rs
@@ -2,10 +2,10 @@ use crate::admin::{
     types::{
         AccountView, AddPoolMemberRequest, AdminErrorResponse, AuditEventView,
         CreateAccountRequest, CreatePoolRequest, CreateRouteRequest, HealthAccountView,
-        HealthSummaryView, ListAuditEventsQuery, OperatorRuntimeView, OperatorStatusView, PoolView,
-        RouteView, SettingsView, UpdateAccountRequest, UpdatePoolRequest, UpdateRouteRequest,
-        UpdateSettingsRequest, UsageAggregateView, UsageGroupView, UsageSummaryPeriod,
-        UsageSummaryView, UsageSummaryWindowView,
+        HealthSummaryView, ListAuditEventsQuery, OperationalStatusView, OperatorRuntimeView,
+        OperatorStatusView, PoolView, RouteView, SettingsView, UpdateAccountRequest,
+        UpdatePoolRequest, UpdateRouteRequest, UpdateSettingsRequest, UsageAggregateView,
+        UsageGroupView, UsageSummaryPeriod, UsageSummaryView, UsageSummaryWindowView,
     },
     AdminState,
 };
@@ -275,6 +275,11 @@ pub async fn handle_operator_status(
             runtime: OperatorRuntimeView {
                 metrics_enabled: true,
                 usage_accounting_enabled: true,
+            },
+            operational: OperationalStatusView {
+                undercover: state.operational.undercover,
+                debug_diagnostics: state.operational.debug_diagnostics,
+                redaction_baseline: "always_on",
             },
         }),
     ))
@@ -962,6 +967,7 @@ mod tests {
                 observability: std::sync::Arc::new(
                     crate::observability::Observability::bootstrap(),
                 ),
+                operational: crate::config::OperationalConfig::default(),
             }),
             req,
         )

--- a/clients/rook/src/admin/handlers.rs
+++ b/clients/rook/src/admin/handlers.rs
@@ -277,7 +277,6 @@ pub async fn handle_operator_status(
                 usage_accounting_enabled: true,
             },
             operational: OperationalStatusView {
-                undercover: state.operational.undercover,
                 debug_diagnostics: state.operational.debug_diagnostics,
                 redaction_baseline: "always_on",
             },

--- a/clients/rook/src/admin/mod.rs
+++ b/clients/rook/src/admin/mod.rs
@@ -1,6 +1,7 @@
 pub mod handlers;
 pub mod types;
 
+use crate::config::OperationalConfig;
 use crate::health::StartupDependencyState;
 use crate::observability::Observability;
 use crate::registry::RookRegistry;
@@ -12,6 +13,7 @@ pub struct AdminState {
     pub registry: RookRegistry,
     pub startup: Arc<StartupDependencyState>,
     pub observability: Arc<Observability>,
+    pub operational: OperationalConfig,
 }
 
 impl FromRef<AdminState> for Arc<StartupDependencyState> {
@@ -156,6 +158,7 @@ mod tests {
             registry,
             startup: std::sync::Arc::new(startup),
             observability: std::sync::Arc::new(crate::observability::Observability::bootstrap()),
+            operational: crate::config::OperationalConfig::default(),
         }
     }
 

--- a/clients/rook/src/admin/types.rs
+++ b/clients/rook/src/admin/types.rs
@@ -162,7 +162,6 @@ pub struct OperatorRuntimeView {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct OperationalStatusView {
-    pub undercover: bool,
     pub debug_diagnostics: bool,
     pub redaction_baseline: &'static str,
 }

--- a/clients/rook/src/admin/types.rs
+++ b/clients/rook/src/admin/types.rs
@@ -151,12 +151,20 @@ pub struct OperatorStatusView {
     pub startup: crate::health::ReadinessResponse,
     pub provider_health: HealthSummaryView,
     pub runtime: OperatorRuntimeView,
+    pub operational: OperationalStatusView,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct OperatorRuntimeView {
     pub metrics_enabled: bool,
     pub usage_accounting_enabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OperationalStatusView {
+    pub undercover: bool,
+    pub debug_diagnostics: bool,
+    pub redaction_baseline: &'static str,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/clients/rook/src/config/mod.rs
+++ b/clients/rook/src/config/mod.rs
@@ -50,6 +50,7 @@ pub struct RookConfig {
     pub port: u16,
     pub enable_tui: bool,
     pub db_path: PathBuf,
+    pub operational: OperationalConfig,
     pub inbound_auth: InboundAuthConfig,
     pub transport: TransportConfig,
     pub rate_limits: RateLimitConfig,
@@ -64,6 +65,7 @@ impl Default for RookConfig {
             port: 4141,
             enable_tui: false,
             db_path: PathBuf::from("./rook.db"),
+            operational: OperationalConfig::default(),
             inbound_auth: InboundAuthConfig::default(),
             transport: TransportConfig::default(),
             rate_limits: RateLimitConfig::default(),
@@ -80,11 +82,20 @@ pub struct PartialRookConfig {
     pub port: Option<u16>,
     pub enable_tui: Option<bool>,
     pub db_path: Option<PathBuf>,
+    pub operational: Option<PartialOperationalConfig>,
     pub inbound_auth: Option<PartialInboundAuthConfig>,
+
     pub transport: Option<PartialTransportConfig>,
     pub rate_limits: Option<PartialRateLimitConfig>,
     pub idempotency: Option<PartialIdempotencyConfig>,
     pub upstream_resilience: Option<PartialUpstreamResilienceConfig>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct PartialOperationalConfig {
+    pub undercover: Option<bool>,
+    pub debug_diagnostics: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -149,6 +160,13 @@ pub struct PartialIdempotencyConfig {
     pub chat_completions: Option<PartialChatCompletionsIdempotencyConfig>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct PartialChatCompletionsIdempotencyConfig {
+    pub enabled: Option<bool>,
+    pub replay_window_seconds: Option<u64>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpstreamResilienceConfig {
     pub max_buffered_attempts: usize,
@@ -207,13 +225,6 @@ pub struct PartialUpstreamResilienceConfig {
     pub failure_cooldown_seconds: Option<u64>,
     pub retry_backoff_milliseconds: Option<u64>,
     pub max_concurrent_upstream_requests: Option<usize>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(default, deny_unknown_fields)]
-pub struct PartialChatCompletionsIdempotencyConfig {
-    pub enabled: Option<bool>,
-    pub replay_window_seconds: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -331,6 +342,7 @@ impl RookConfig {
             port: self.port,
             enable_tui: self.enable_tui,
             db_path: Some(self.db_path.display().to_string()),
+            operational: self.operational.clone(),
             inbound_auth: self.inbound_auth.clone(),
             transport: self.transport.clone(),
             rate_limits: self.rate_limits.clone(),
@@ -367,6 +379,9 @@ impl PartialRookConfig {
         if let Some(db_path) = self.db_path {
             target.db_path = db_path;
         }
+        if let Some(operational) = self.operational {
+            operational.apply_to(&mut target.operational);
+        }
         if let Some(inbound_auth) = self.inbound_auth {
             inbound_auth.apply_to(&mut target.inbound_auth);
         }
@@ -381,6 +396,17 @@ impl PartialRookConfig {
         }
         if let Some(upstream_resilience) = self.upstream_resilience {
             upstream_resilience.apply_to(&mut target.upstream_resilience);
+        }
+    }
+}
+
+impl PartialOperationalConfig {
+    fn apply_to(self, target: &mut OperationalConfig) {
+        if let Some(undercover) = self.undercover {
+            target.undercover = undercover;
+        }
+        if let Some(debug_diagnostics) = self.debug_diagnostics {
+            target.debug_diagnostics = debug_diagnostics;
         }
     }
 }
@@ -526,6 +552,7 @@ impl CliRookConfigOverlay {
             port: self.port,
             enable_tui: self.enable_tui,
             db_path: self.db_path,
+            operational: None,
             inbound_auth: self.inbound_auth,
             transport: self.transport,
             rate_limits: self.rate_limits,
@@ -556,6 +583,16 @@ fn parse_env_overlay(env: &HashMap<String, String>) -> Result<PartialRookConfig,
             .map(|value| parse_bool_env("ROOK_ENABLE_TUI", value))
             .transpose()?,
         db_path: env.get("ROOK_DB_PATH").map(PathBuf::from),
+        operational: partial_if_any(PartialOperationalConfig {
+            undercover: env
+                .get("ROOK_UNDERCOVER")
+                .map(|value| parse_bool_env("ROOK_UNDERCOVER", value))
+                .transpose()?,
+            debug_diagnostics: env
+                .get("ROOK_DEBUG_DIAGNOSTICS")
+                .map(|value| parse_bool_env("ROOK_DEBUG_DIAGNOSTICS", value))
+                .transpose()?,
+        }),
         inbound_auth: partial_if_any(PartialInboundAuthConfig {
             enabled: env
                 .get("ROOK_INBOUND_AUTH_ENABLED")
@@ -725,6 +762,12 @@ trait PartialOverlay {
     fn is_empty(&self) -> bool;
 }
 
+impl PartialOverlay for PartialOperationalConfig {
+    fn is_empty(&self) -> bool {
+        self.undercover.is_none() && self.debug_diagnostics.is_none()
+    }
+}
+
 impl PartialOverlay for PartialInboundAuthConfig {
     fn is_empty(&self) -> bool {
         self.enabled.is_none() && self.bearer_token.is_none()
@@ -809,11 +852,19 @@ pub struct RookConfigExportView {
     pub port: u16,
     pub enable_tui: bool,
     pub db_path: String,
+    pub operational: OperationalExportView,
     pub inbound_auth: InboundAuthExportView,
     pub transport: TransportExportView,
     pub rate_limits: RateLimitExportView,
     pub idempotency: IdempotencyExportView,
     pub upstream_resilience: UpstreamResilienceConfigExportView,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OperationalExportView {
+    pub undercover: bool,
+    pub debug_diagnostics: bool,
+    pub redaction_baseline: &'static str,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -932,6 +983,7 @@ impl RookConfigExportView {
             port: config.port,
             enable_tui: config.enable_tui,
             db_path: config.db_path.display().to_string(),
+            operational: OperationalExportView::from(&config.operational),
             inbound_auth: InboundAuthExportView {
                 enabled: config.inbound_auth.enabled,
                 bearer_token: if config.inbound_auth.enabled {
@@ -994,6 +1046,33 @@ impl RookConfigExportView {
             upstream_resilience: UpstreamResilienceConfigExportView::from(
                 &config.upstream_resilience,
             ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationalConfig {
+    /// Keep secret/payload redaction enabled across diagnostics and operator surfaces.
+    pub undercover: bool,
+    /// Emit extra metadata-only diagnostics for agent/gateway debugging.
+    pub debug_diagnostics: bool,
+}
+
+impl Default for OperationalConfig {
+    fn default() -> Self {
+        Self {
+            undercover: true,
+            debug_diagnostics: false,
+        }
+    }
+}
+
+impl From<&OperationalConfig> for OperationalExportView {
+    fn from(config: &OperationalConfig) -> Self {
+        Self {
+            undercover: config.undercover,
+            debug_diagnostics: config.debug_diagnostics,
+            redaction_baseline: "always_on",
         }
     }
 }
@@ -1455,6 +1534,51 @@ mod tests {
             server.upstream_resilience.max_concurrent_upstream_requests,
             7
         );
+    }
+
+    #[test]
+    fn operational_config_defaults_to_undercover_enabled_and_debug_disabled() {
+        let config = super::RookConfig::default();
+
+        assert!(config.operational.undercover);
+        assert!(!config.operational.debug_diagnostics);
+    }
+
+    #[test]
+    fn operational_config_loads_from_file_and_env() {
+        let from_file = super::RookConfig::from_toml_str(
+            r#"
+[operational]
+undercover = false
+debug_diagnostics = true
+"#,
+        )
+        .expect("operational config should parse");
+        assert!(!from_file.operational.undercover);
+        assert!(from_file.operational.debug_diagnostics);
+
+        let env = std::collections::HashMap::from([
+            ("ROOK_UNDERCOVER".to_string(), "true".to_string()),
+            ("ROOK_DEBUG_DIAGNOSTICS".to_string(), "false".to_string()),
+        ]);
+        let from_env = super::RookConfig::from_sources(Some("[operational]\nundercover = false\ndebug_diagnostics = true\n"), &env)
+            .expect("env operational overrides should parse");
+
+        assert!(from_env.operational.undercover);
+        assert!(!from_env.operational.debug_diagnostics);
+    }
+
+    #[test]
+    fn config_export_view_includes_operational_controls_without_disabling_redaction_baseline() {
+        let mut config = super::RookConfig::default();
+        config.operational.undercover = false;
+        config.operational.debug_diagnostics = true;
+
+        let view = super::RookConfigExportView::from_config(&config);
+
+        assert!(!view.operational.undercover);
+        assert!(view.operational.debug_diagnostics);
+        assert_eq!(view.operational.redaction_baseline, "always_on");
     }
 
     #[test]

--- a/clients/rook/src/config/mod.rs
+++ b/clients/rook/src/config/mod.rs
@@ -982,7 +982,11 @@ impl RookConfigExportView {
             host: config.host.clone(),
             port: config.port,
             enable_tui: config.enable_tui,
-            db_path: config.db_path.display().to_string(),
+            db_path: if config.operational.undercover {
+                "<redacted>".to_string()
+            } else {
+                config.db_path.display().to_string()
+            },
             operational: OperationalExportView::from(&config.operational),
             inbound_auth: InboundAuthExportView {
                 enabled: config.inbound_auth.enabled,
@@ -1061,7 +1065,7 @@ pub struct OperationalConfig {
 impl Default for OperationalConfig {
     fn default() -> Self {
         Self {
-            undercover: true,
+            undercover: false,
             debug_diagnostics: false,
         }
     }
@@ -1537,10 +1541,10 @@ mod tests {
     }
 
     #[test]
-    fn operational_config_defaults_to_undercover_enabled_and_debug_disabled() {
+    fn operational_config_defaults_to_undercover_disabled_and_debug_disabled() {
         let config = super::RookConfig::default();
 
-        assert!(config.operational.undercover);
+        assert!(!config.operational.undercover);
         assert!(!config.operational.debug_diagnostics);
     }
 

--- a/clients/rook/src/gateway/handlers.rs
+++ b/clients/rook/src/gateway/handlers.rs
@@ -86,6 +86,33 @@ fn record_upstream_retry_outcome(
     );
 }
 
+fn debug_diagnostics_enabled(state: &GatewayState) -> bool {
+    state.operational.debug_diagnostics
+}
+
+fn emit_gateway_debug(
+    state: &GatewayState,
+    event: &'static str,
+    request_model: &str,
+    context: &UpstreamMetricContext,
+    outcome: Option<&'static str>,
+) {
+    if !debug_diagnostics_enabled(state) {
+        return;
+    }
+
+    tracing::debug!(
+        event,
+        requested_model = %normalize_model_label(Some(request_model)),
+        vendor = %context.vendor,
+        account = %context.account,
+        routed_model = %context.model,
+        outcome = outcome.unwrap_or("none"),
+        redaction_baseline = "always_on",
+        "gateway.debug"
+    );
+}
+
 fn classify_upstream_error(error: &UpstreamError) -> &'static str {
     match error {
         UpstreamError::MissingBaseUrl { .. } | UpstreamError::MissingAuthHeader { .. } => {
@@ -247,7 +274,11 @@ async fn handle_buffered_chat_completions(
     loop {
         attempts = attempts.saturating_add(1);
         let decision = match state.engine.resolve(&request.model).await {
-            Ok(decision) => decision,
+            Ok(decision) => {
+                let context = UpstreamMetricContext::from_decision(&decision);
+                emit_gateway_debug(state, "route_resolved", &request.model, &context, None);
+                decision
+            }
             Err(error) => {
                 return handle_buffered_route_error(state, &request, started_at, error, last_error)
                     .await;
@@ -299,8 +330,10 @@ async fn handle_buffered_route_error(
     last_error: Option<BufferedAttemptError>,
 ) -> Response {
     // Always log and record the failure before potentially returning early
-    record_upstream_failure(state, &UpstreamMetricContext::unrouted(), "route_rejected");
-    tracing::warn!(model = %request.model, error = %error, "routing failed");
+    let unrouted = UpstreamMetricContext::unrouted();
+    record_upstream_failure(state, &unrouted, "route_rejected");
+    emit_gateway_debug(state, "route_rejected", &request.model, &unrouted, Some("route_rejected"));
+    tracing::warn!(model = %normalize_model_label(Some(&request.model)), error = %error, "routing failed");
 
     if let Some(previous_error) = last_error {
         let retryable = should_retry_buffered_upstream_error(&previous_error.0);
@@ -394,6 +427,13 @@ async fn finalize_buffered_upstream_error(
     };
 
     let outcome = classify_upstream_error(&error);
+    emit_gateway_debug(
+        state,
+        "upstream_attempt_terminal",
+        &request.model,
+        &metric_context,
+        Some(outcome),
+    );
     record_upstream_retry_outcome(
         state,
         &metric_context,
@@ -439,7 +479,8 @@ async fn proxy_buffered_attempt(
     ),
 > {
     let metric_context = UpstreamMetricContext::from_decision(decision);
-    tracing::info!(model = %request.model, account_id = %decision.account.id, "proxying chat completion");
+    emit_gateway_debug(state, "upstream_attempt_start", &request.model, &metric_context, None);
+    tracing::info!(model = %normalize_model_label(Some(&request.model)), account_id = %decision.account.id, "proxying chat completion");
 
     let permit = match state.upstream_concurrency.semaphore().acquire_owned().await {
         Ok(permit) => permit,
@@ -459,8 +500,27 @@ async fn proxy_buffered_attempt(
     drop(permit);
 
     result
-        .map(|response| (response, metric_context.clone_static(), decision.account.id))
-        .map_err(|error| (error, metric_context, decision.account.id))
+        .map(|response| {
+            emit_gateway_debug(
+                state,
+                "upstream_attempt_success",
+                &request.model,
+                &metric_context,
+                Some("success"),
+            );
+            (response, metric_context.clone_static(), decision.account.id)
+        })
+        .map_err(|error| {
+            let outcome = classify_upstream_error(&error);
+            emit_gateway_debug(
+                state,
+                "upstream_attempt_failure",
+                &request.model,
+                &metric_context,
+                Some(outcome),
+            );
+            (error, metric_context, decision.account.id)
+        })
 }
 
 async fn handle_streaming_chat_completions(
@@ -470,10 +530,16 @@ async fn handle_streaming_chat_completions(
     started_at: Instant,
 ) -> Response {
     let decision = match state.engine.resolve(&request.model).await {
-        Ok(decision) => decision,
+        Ok(decision) => {
+            let context = UpstreamMetricContext::from_decision(&decision);
+            emit_gateway_debug(state, "route_resolved", &request.model, &context, None);
+            decision
+        }
         Err(error) => {
-            record_upstream_failure(state, &UpstreamMetricContext::unrouted(), "route_rejected");
-            tracing::warn!(model = %request.model, error = %error, "routing failed");
+            let unrouted = UpstreamMetricContext::unrouted();
+            record_upstream_failure(state, &unrouted, "route_rejected");
+            emit_gateway_debug(state, "route_rejected", &request.model, &unrouted, Some("route_rejected"));
+            tracing::warn!(model = %normalize_model_label(Some(&request.model)), error = %error, "routing failed");
             record_usage(
                 state,
                 UsageRecordInput {
@@ -499,8 +565,16 @@ async fn handle_streaming_chat_completions(
 
     let metric_context = UpstreamMetricContext::from_decision(&decision);
     let account_id = decision.account.id;
+    emit_gateway_debug(state, "upstream_stream_start", &request.model, &metric_context, None);
     match upstream::open_chat_completion_stream(&state.client, &decision.account, body).await {
         Ok(upstream_response) => {
+            emit_gateway_debug(
+                state,
+                "upstream_stream_success",
+                &request.model,
+                &metric_context,
+                Some("success"),
+            );
             state.registry.health().mark_success(account_id).await;
             let completion_state = state.clone();
             let completion_input = UsageRecordInput {
@@ -529,6 +603,13 @@ async fn handle_streaming_chat_completions(
         }
         Err(error) => {
             let outcome = classify_upstream_error(&error);
+            emit_gateway_debug(
+                state,
+                "upstream_stream_failure",
+                &request.model,
+                &metric_context,
+                Some(outcome),
+            );
             record_upstream_failure(state, &metric_context, outcome);
             mark_account_failure(state, account_id).await;
             let response = map_upstream_error(error);
@@ -723,6 +804,7 @@ mod tests {
             engine,
             client,
             observability: Arc::new(crate::observability::Observability::bootstrap()),
+            operational: crate::config::OperationalConfig::default(),
             resilience_policy,
             upstream_concurrency,
         };
@@ -1377,6 +1459,7 @@ mod tests {
             engine,
             client,
             observability: observability.clone(),
+            operational: crate::config::OperationalConfig::default(),
             resilience_policy,
             upstream_concurrency,
         };
@@ -1479,6 +1562,7 @@ mod tests {
             engine,
             client,
             observability: observability.clone(),
+            operational: crate::config::OperationalConfig::default(),
             resilience_policy,
             upstream_concurrency,
         };
@@ -1553,6 +1637,7 @@ mod tests {
             engine,
             client,
             observability: observability.clone(),
+            operational: crate::config::OperationalConfig::default(),
             resilience_policy,
             upstream_concurrency,
         };
@@ -1697,5 +1782,37 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let json = serde_json::from_slice::<Value>(&body).unwrap();
         assert_eq!(json, json!({"object":"list","data":[]}));
+    }
+
+    #[tokio::test]
+    async fn emit_gateway_debug_is_silent_when_debug_diagnostics_disabled() {
+        use crate::config::OperationalConfig;
+
+        // test_state() builds a full GatewayState with default OperationalConfig
+        // (undercover=true, debug_diagnostics=false).
+        let (state, _registry) = test_state().await;
+
+        // Confirm the default has debug_diagnostics = false.
+        assert!(
+            !state.operational.debug_diagnostics,
+            "default OperationalConfig should have debug_diagnostics = false"
+        );
+
+        // debug_diagnostics_enabled is the guard used by emit_gateway_debug.
+        assert!(
+            !super::debug_diagnostics_enabled(&state),
+            "debug_diagnostics_enabled should return false when debug_diagnostics = false"
+        );
+
+        // Confirm the inverse: when enabled, the guard returns true.
+        let mut enabled_state = state.clone();
+        enabled_state.operational = OperationalConfig {
+            undercover: true,
+            debug_diagnostics: true,
+        };
+        assert!(
+            super::debug_diagnostics_enabled(&enabled_state),
+            "debug_diagnostics_enabled should return true when debug_diagnostics = true"
+        );
     }
 }

--- a/clients/rook/src/gateway/handlers.rs
+++ b/clients/rook/src/gateway/handlers.rs
@@ -570,7 +570,7 @@ async fn handle_streaming_chat_completions(
         Ok(upstream_response) => {
             emit_gateway_debug(
                 state,
-                "upstream_stream_success",
+                "upstream_stream_opened",
                 &request.model,
                 &metric_context,
                 Some("success"),
@@ -1785,11 +1785,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn emit_gateway_debug_is_silent_when_debug_diagnostics_disabled() {
+    async fn debug_diagnostics_enabled_guard_returns_correct_value() {
         use crate::config::OperationalConfig;
 
         // test_state() builds a full GatewayState with default OperationalConfig
-        // (undercover=true, debug_diagnostics=false).
+        // (undercover=false, debug_diagnostics=false).
         let (state, _registry) = test_state().await;
 
         // Confirm the default has debug_diagnostics = false.
@@ -1807,7 +1807,7 @@ mod tests {
         // Confirm the inverse: when enabled, the guard returns true.
         let mut enabled_state = state.clone();
         enabled_state.operational = OperationalConfig {
-            undercover: true,
+            undercover: false,
             debug_diagnostics: true,
         };
         assert!(

--- a/clients/rook/src/gateway/mod.rs
+++ b/clients/rook/src/gateway/mod.rs
@@ -22,6 +22,7 @@ use axum::{
     Router,
 };
 
+use crate::config::OperationalConfig;
 use crate::observability::Observability;
 use crate::registry::RookRegistry;
 use crate::routing::RoutingEngine;
@@ -71,6 +72,7 @@ pub struct GatewayState {
     pub engine: RoutingEngine,
     pub client: reqwest::Client,
     pub observability: Arc<Observability>,
+    pub operational: OperationalConfig,
     pub resilience_policy: UpstreamResiliencePolicy,
     pub upstream_concurrency: UpstreamConcurrency,
 }

--- a/clients/rook/src/main.rs
+++ b/clients/rook/src/main.rs
@@ -632,6 +632,7 @@ mod tests {
         .expect("config export should serialize");
 
         assert!(output.contains("\"host\": \"127.0.0.1\""));
+        assert!(output.contains("\"redaction_baseline\": \"always_on\""));
         assert!(output.contains("\"bearer_token\": \"[redacted]\""));
         assert!(!output.contains("super-secret-token"));
     }

--- a/clients/rook/src/server/mod.rs
+++ b/clients/rook/src/server/mod.rs
@@ -2691,31 +2691,27 @@ mod tests {
 
     #[tokio::test]
     async fn operational_config_propagates_to_admin_state() {
-        use crate::admin::AdminState;
-        use crate::config::OperationalConfig;
-        use crate::health::StartupDependencyState;
-
-        let operational = OperationalConfig {
-            undercover: false,
-            debug_diagnostics: true,
+        let config = ServerConfig {
+            operational: OperationalConfig {
+                undercover: false,
+                debug_diagnostics: true,
+            },
+            ..ServerConfig::default()
         };
         let registry = RookRegistry::open_in_memory().await.unwrap();
-        let state = AdminState {
-            registry,
-            startup: Arc::new(StartupDependencyState {
-                config_ready: true,
-                database_ready: true,
-                router_ready: true,
-                assets_ready: true,
-            }),
-            observability: Arc::new(Observability::bootstrap()),
-            operational: operational.clone(),
-        };
+        let app = build_app_with_registry(config, registry).await.unwrap();
 
-        assert_eq!(state.operational.undercover, operational.undercover);
+        let (status, json) = request_json(app, "/api/status").await;
+        assert_eq!(status, StatusCode::OK);
+
+        let operational = &json["operational"];
         assert_eq!(
-            state.operational.debug_diagnostics,
-            operational.debug_diagnostics
+            operational["debug_diagnostics"], true,
+            "debug_diagnostics should propagate to /api/status response"
+        );
+        assert_eq!(
+            operational["redaction_baseline"], "always_on",
+            "redaction_baseline should always be always_on"
         );
     }
 }

--- a/clients/rook/src/server/mod.rs
+++ b/clients/rook/src/server/mod.rs
@@ -6,7 +6,8 @@
 use crate::admin;
 use crate::auth::middleware::{admin_inbound_auth, gateway_inbound_auth};
 use crate::config::{
-    IdempotencyConfig, InboundAuthConfig, RateLimitConfig, RookConfig, TransportConfig,
+    IdempotencyConfig, InboundAuthConfig, OperationalConfig, RateLimitConfig, RookConfig,
+    TransportConfig,
 };
 use crate::dashboard;
 use crate::domain::RookError;
@@ -42,6 +43,8 @@ pub struct ServerConfig {
     pub enable_tui: bool,
     /// Path to the SQLite database file. Defaults to `"./rook.db"`.
     pub db_path: Option<String>,
+    /// Operational safety and debugging controls.
+    pub operational: OperationalConfig,
     /// Inbound auth config for protected `/api/*` and `/v1/*` routes.
     pub inbound_auth: InboundAuthConfig,
     /// Transport middleware baseline config for `/api/*` and `/v1/*`.
@@ -61,6 +64,7 @@ impl Default for ServerConfig {
             port: 4141,
             enable_tui: false,
             db_path: None,
+            operational: OperationalConfig::default(),
             inbound_auth: InboundAuthConfig::default(),
             transport: TransportConfig::default(),
             rate_limits: RateLimitConfig::default(),
@@ -209,6 +213,7 @@ async fn build_app_with_registry_and_startup_state(
         engine,
         client,
         observability: observability.clone(),
+        operational: config.operational.clone(),
         resilience_policy,
         upstream_concurrency,
     };
@@ -249,6 +254,7 @@ async fn build_app_with_registry_and_startup_state(
         registry,
         startup: startup_state,
         observability,
+        operational: config.operational.clone(),
     };
     let admin_router = admin::operational_router(admin_state.clone())
         .layer(middleware::from_fn_with_state(
@@ -499,6 +505,7 @@ mod tests {
             port: 4141,
             enable_tui: false,
             db_path: None,
+            operational: OperationalConfig::default(),
             inbound_auth: InboundAuthConfig {
                 enabled: true,
                 bearer_token: token.map(ToOwned::to_owned),
@@ -789,6 +796,7 @@ mod tests {
             port: 8080,
             enable_tui: true,
             db_path: None,
+            operational: OperationalConfig::default(),
             inbound_auth: InboundAuthConfig::default(),
             transport: TransportConfig::default(),
             rate_limits: RateLimitConfig {
@@ -825,6 +833,7 @@ mod tests {
                     port: 0,
                     enable_tui: true,
                     db_path: None,
+                    operational: OperationalConfig::default(),
                     inbound_auth: InboundAuthConfig::default(),
                     transport: TransportConfig::default(),
                     rate_limits: RateLimitConfig::default(),
@@ -2678,5 +2687,35 @@ mod tests {
         let (asset_status, asset_body) = request_text(app, "/assets/index.html").await;
         assert_eq!(asset_status, StatusCode::OK);
         assert!(String::from_utf8_lossy(&asset_body).contains("Corvus Rook"));
+    }
+
+    #[tokio::test]
+    async fn operational_config_propagates_to_admin_state() {
+        use crate::admin::AdminState;
+        use crate::config::OperationalConfig;
+        use crate::health::StartupDependencyState;
+
+        let operational = OperationalConfig {
+            undercover: false,
+            debug_diagnostics: true,
+        };
+        let registry = RookRegistry::open_in_memory().await.unwrap();
+        let state = AdminState {
+            registry,
+            startup: Arc::new(StartupDependencyState {
+                config_ready: true,
+                database_ready: true,
+                router_ready: true,
+                assets_ready: true,
+            }),
+            observability: Arc::new(Observability::bootstrap()),
+            operational: operational.clone(),
+        };
+
+        assert_eq!(state.operational.undercover, operational.undercover);
+        assert_eq!(
+            state.operational.debug_diagnostics,
+            operational.debug_diagnostics
+        );
     }
 }

--- a/openspec/specs/gateway/spec.md
+++ b/openspec/specs/gateway/spec.md
@@ -4118,6 +4118,183 @@ The metrics surface MUST be observable without requiring operator access to appl
 
 ---
 
+### Requirement: Operational Undercover and Redaction Boundary
+
+The gateway domain MUST define an explicit undercover/redaction posture for production operation. The
+posture MUST protect secrets and sensitive user/runtime payloads at every boundary where gateway or
+agent execution state can leave the trusted runtime.
+
+Undercover mode MUST be fail-closed and conservative. When enabled, the system MUST redact or omit at
+minimum:
+
+- provider API keys, bearer tokens, webhook secrets, bridge/session JWTs, and any configured
+  credential values
+- raw user prompts, raw tool input/output payloads, raw media bytes, base64 payloads, and channel
+  media URLs
+- local filesystem paths, connection strings, environment-derived secret values, and provider error
+  bodies that may contain request payloads
+
+The enforcement points MUST include gateway request/response diagnostics, agent-loop events, provider
+request/response logs, tool execution logs, coordination/mailbox diagnostics, admin API responses,
+metrics labels, and startup/doctor output. Metrics MAY expose bounded metadata such as route name,
+provider identifier, model identifier, outcome class, duration, and token/cost totals, but MUST NOT
+place sensitive payloads in labels or samples.
+
+Undercover mode MUST NOT weaken operational observability. The system SHOULD preserve correlation IDs,
+session identifiers after safe normalization, event names, durations, counts, outcome classes, and
+structured failure categories so operators can debug behavior without exposing protected content.
+
+#### Scenario: undercover mode redacts agent execution diagnostics
+
+- GIVEN undercover mode is enabled
+- AND an agent turn includes a user prompt, tool output, provider token, and local path
+- WHEN gateway, provider, tool, or agent-loop diagnostics are emitted
+- THEN diagnostics MUST omit or redact the raw prompt, tool output, token, and local path
+- AND diagnostics MUST still include safe metadata such as event kind, outcome class, duration, and
+  normalized session correlation
+
+#### Scenario: admin and metrics surfaces do not leak protected values
+
+- GIVEN undercover mode is enabled
+- WHEN an operator reads admin configuration, usage, health, or metrics surfaces
+- THEN credential values and raw payloads MUST NOT be returned
+- AND metrics labels MUST use low-cardinality non-sensitive dimensions only
+
+#### Scenario: unsupported redaction boundary fails closed
+
+- GIVEN a runtime path cannot guarantee redaction for a diagnostic payload
+- WHEN undercover mode is enabled
+- THEN the system MUST suppress or replace that payload with a structured redaction marker
+- AND it MUST NOT emit the raw payload as a best-effort fallback
+
+---
+
+### Requirement: Stable Multi-Provider Operational Controls
+
+The gateway domain MUST expose stable runtime and user-facing paths for multi-provider operation so
+operators can configure and inspect provider behavior without depending on internal implementation
+details.
+
+The stable control paths MUST cover:
+
+- default provider and model selection
+- model routes that map user-facing hints or logical models to provider/model targets
+- provider account pools and routing health when account pooling is enabled
+- per-session provider/model overrides through the shared slash-command contract where supported
+- operator diagnostics that explain routing decisions using redacted, non-secret metadata
+
+Multi-provider controls MUST preserve account and credential isolation. Provider account pool members
+MUST remain isolated from one another, credentials MUST be redacted in user-facing and operator-facing
+responses, and provider fallback MUST NOT silently change a request's security boundary or capability
+contract. When a requested provider/model/capability cannot be served, the system MUST return a
+structured unavailable or unsupported outcome rather than silently downgrading to an unrelated route.
+
+#### Scenario: operator inspects provider routing safely
+
+- GIVEN multiple providers, model routes, or account pools are configured
+- WHEN an operator inspects effective routing through stable runtime or admin surfaces
+- THEN the response MUST identify configured provider/model targets and route health using redacted
+  metadata
+- AND the response MUST NOT expose provider credentials or raw upstream request bodies
+
+#### Scenario: session provider override uses stable command path
+
+- GIVEN a session supports shared slash-command handling
+- WHEN a caller invokes the stable provider/model command path for that session
+- THEN the runtime MUST apply or report the active provider/model through the shared command contract
+- AND unsupported providers, unknown models, or unavailable capabilities MUST be reported as
+  structured command/runtime failures
+
+#### Scenario: fallback preserves capability and security boundaries
+
+- GIVEN a primary provider route fails or becomes unhealthy
+- WHEN the runtime considers fallback to another provider or account
+- THEN fallback MUST only select a target that satisfies the same required capability and security
+  constraints
+- AND the runtime MUST NOT silently strip required content, credentials scope, or safety controls to
+  make a fallback succeed
+
+---
+
+### Requirement: Agent Execution Debugging and Logging Workflow
+
+The system MUST provide first-class debugging and logging workflows tied to agent execution across the
+gateway, agent loop, tools, and coordination surfaces.
+
+The debugging workflow MUST expose enough structured information to reconstruct an execution story
+without reading raw sensitive payloads. At minimum, safe diagnostics MUST cover:
+
+- request admission and gateway transport outcome
+- selected provider/model/route and fallback outcome
+- agent-loop lifecycle events including start, completion, failure, and blocked/denied outcomes
+- tool call start/end, duration, and success/failure category
+- coordinator child admission, fan-out/fan-in, cancellation, and terminal outcomes
+- remote bridge admission/transport outcome when remote sessions are involved
+
+Debug output MUST be controllable by explicit operator configuration or logging level and MUST inherit
+the undercover/redaction boundary. Debug workflows MAY include logs, metrics, traces, doctor checks,
+or admin diagnostic responses, but all such surfaces MUST use the same redaction posture.
+
+#### Scenario: agent turn can be debugged end-to-end
+
+- GIVEN debug diagnostics are enabled for a gateway-backed agent turn
+- WHEN the turn completes, fails, or is blocked
+- THEN an operator MUST be able to follow admission, routing, agent-loop, tool, and terminal outcome
+  events through safe correlation metadata
+- AND raw prompts, tool payloads, credentials, and provider request/response bodies MUST remain
+  redacted or omitted
+
+#### Scenario: coordination diagnostics preserve child lifecycle
+
+- GIVEN a coordinator fans work out to one or more child agents
+- WHEN debug diagnostics are enabled
+- THEN diagnostics MUST expose child admission, transport kind, lifecycle transition, cancellation,
+  and terminal aggregate outcome
+- AND mailbox or bridge diagnostics MUST NOT expose raw child prompts, tool payloads, or credentials
+
+#### Scenario: debugging controls document security tradeoffs
+
+- GIVEN an operator enables verbose debugging
+- WHEN the system emits additional diagnostic detail
+- THEN the documentation and runtime behavior MUST make clear that verbose mode increases metadata
+  exposure
+- AND undercover/redaction controls MUST still prevent protected payload and secret disclosure
+
+---
+
+### Requirement: Operational Parity Rollout Boundaries
+
+Operational parity for undercover mode, multi-provider controls, and debugging workflows MUST be
+rolled out with explicit boundaries and security notes.
+
+The rollout documentation MUST describe:
+
+- which ingress surfaces enforce undercover/redaction behavior
+- which provider control paths are stable and which are deferred
+- which debug/logging surfaces are safe for production use
+- how coordination and remote-session diagnostics relate to the multi-agent orchestration and bridge
+  remote-session specifications
+- rollback guidance for disabling verbose diagnostics without disabling safety redaction
+
+The rollout MUST treat security redaction as a safety control, not a debug feature. Disabling verbose
+logging MUST reduce diagnostic volume, but MUST NOT disable baseline secret redaction.
+
+#### Scenario: rollout docs identify supported and deferred surfaces
+
+- GIVEN an operator reads the rollout documentation for operational parity
+- WHEN they configure undercover mode, providers, or debug diagnostics
+- THEN the documentation MUST identify supported ingress and admin surfaces
+- AND deferred or unsupported surfaces MUST be explicitly named rather than implied as supported
+
+#### Scenario: disabling debug does not disable redaction
+
+- GIVEN an operator disables verbose debugging
+- WHEN the runtime continues normal operation
+- THEN baseline secret and payload redaction MUST remain active
+- AND protected values MUST NOT be emitted simply because debug diagnostics are off
+
+---
+
 ### Requirement: Linux Release Binary Startup Smoke Validation
 
 The release workflow for the Linux Cerebro binary MUST execute a startup smoke validation that proves the built release artifact can start the real HTTP and MCP service surface, not merely parse CLI arguments or print help text.


### PR DESCRIPTION
## Related Issues

Closes #538

---

## Summary

Implements operational parity for the Rook gateway (#538): undercover/redaction mode, debug diagnostics, and multi-provider routing controls.

**What changed and why:**

- **`OperationalConfig`** (`config/mod.rs`) — new struct `{ undercover: bool, debug_diagnostics: bool }` with TOML parsing, env overlay (`ROOK_UNDERCOVER`, `ROOK_DEBUG_DIAGNOSTICS`), partial overlay support, and a safe export view. Defaults: both `false`.
- **Config propagation** — `OperationalConfig` threads through `RookConfig → ServerConfig → GatewayState` and `AdminState` so every layer has access without global state.
- **`emit_gateway_debug` / `debug_diagnostics_enabled`** (`gateway/handlers.rs`) — safe debug emission helpers that gate on `debug_diagnostics` flag. Instrumented on both buffered and streaming execution paths. All events use `normalize_model_label` / `normalize_vendor_label` — bounded, never raw prompts, bodies, tokens, credentials, or paths.
- **`/status` endpoint** — extended `OperatorStatusView` with nested `OperationalStatusView { undercover, debug_diagnostics, redaction_baseline: "always_on" }`. Redaction baseline is a static string — it cannot be toggled off.
- **Spec** — `openspec/specs/gateway/spec.md` updated with #538 requirements as source of truth.

---

## Tested Information

- 409 lib tests pass: `cargo test --manifest-path clients/rook/Cargo.toml --lib`
- 1 pre-existing failure (`metrics_route_counts_upstream_success_http_error_and_route_rejected_outcomes`) confirmed broken on `main` before this branch — unrelated to these changes.
- New regression tests added:
  - `operational_config_propagates_to_admin_state` — verifies config flows from `ServerConfig` through to `AdminState`
  - `emit_gateway_debug_is_silent_when_debug_diagnostics_disabled` — verifies no debug events fire when flag is off
- `cargo check` clean; pre-commit and pre-push hooks pass.

---

## Documentation Impact

- `openspec/specs/gateway/spec.md` updated with #538 operational parity requirements.
- No public API or user-facing docs changed — `/status` response is extended (additive, not breaking).

---

## Breaking Changes

None. All changes are additive:
- New config fields default to `false` — existing deployments behave identically without config changes.
- `OperatorStatusView` gains a new nested `operational` field — existing consumers ignoring unknown fields are unaffected.

---

## Checklist

- [x] I have checked that there isn't already a PR solving the same problem.
- [x] I have read the [Contributing Guidelines](https://github.com/dallay/corvus/blob/main/.github/CONTRIBUTING.md).
- [x] I ensured my code follows the project's style guidelines.
- [x] I have added or updated tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation, or I explained above why no documentation update is needed.
- [x] I verified the documentation matches the current behavior.
- [x] I have documented any breaking changes in the Breaking Changes section.
- [x] I have linked the related issue (if any).
