### PR TITLE
docs: document pdf_inspect tool

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -113,3 +113,13 @@ All three identified issues have been fixed:
 - Improved `cron_runs` and `cron_update` parameter documentation in `automation.md` (en/es).
 **Validation:** Results of `make docs-check` and `make docs-build` passed (84 pages built).
 **Notes:** Maintaining bilingual parity between root (English) and `es/` directory.
+
+## 2026-05-20 - PDF Inspection Tool Documentation - Complete
+
+**Verification:** Verified implementation of `pdf_inspect` tool in `clients/agent-runtime/src/tools/pdf_inspect.rs`.
+**Changes:**
+- Added `pdf_inspect` documentation to `clients/agent-runtime/tools/media.md` (en/es).
+- Updated `clients/agent-runtime/tools/index.mdx` (en/es) to include `pdf_inspect` in Media category and Read-Only tier.
+- Updated `lastReviewed` dates to 2026-05-20 for affected files.
+**Validation:** Results of `make docs-web-check` and `make docs-web-build` passed.
+**Notes:** `pdf_inspect` is a native tool requiring the `pdf-inspect` feature flag. It is classified as Read-Only (Safe) as it only extracts information from files within the workspace.

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/index.mdx
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/index.mdx
@@ -3,7 +3,7 @@ title: Tools Reference
 description: Overview of the Corvus Agent tool system, security model, and registration.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-05-06
+lastReviewed: 2026-05-20
 appliesTo: main
 docType: reference
 ---
@@ -22,7 +22,7 @@ Built-in tools are organized into six primary categories:
 - [**Web Tools**](web.md) — Web browsing (`browser`), search (`web_search_tool`), structured API calls (`http_request`), and read-only fetch parity (`WebFetch`).
 - [**Memory Tools**](memory.md) — Long-term persistence and retrieval of facts and preferences (`memory_store`, `memory_recall`).
 - [**Automation Tools**](automation.md) — Multi-agent delegation (`delegate`), managed app integrations (`composio`), Git repository management, scheduled tasks (Cron/Schedule), and notifications (`pushover`).
-- [**Media Tools**](media.md) — Vision-related capabilities including screen capture and image metadata extraction.
+- [**Media Tools**](media.md) — Vision and document-related capabilities including screen capture, image metadata extraction, and PDF inspection (`pdf_inspect`).
 - [**Hardware Tools**](hardware.md) — Board discovery (`hardware_board_info`), memory introspection (`hardware_memory_read`), and peripheral control (`gpio_write`, `arduino_upload`).
 
 ## Security Model
@@ -31,7 +31,7 @@ Every tool execution passes through the `SecurityPolicy` layer. Tools are classi
 
 ### Read-Only (Safe)
 These tools do not modify the system or external state. They are generally allowed even in low-autonomy modes.
-- *Examples:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `hardware_board_info`.
+- *Examples:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `pdf_inspect`, `hardware_board_info`.
 
 ## Claude-style parity mapping
 

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
@@ -3,12 +3,12 @@ title: Media Tools
 description: Reference for vision and image-related tools in Corvus.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-03-26
+lastReviewed: 2026-05-20
 appliesTo: main
 docType: reference
 ---
 
-Media tools provide the agent with visual capabilities, allowing it to "see" the host environment and process image files.
+Media tools provide the agent with visual capabilities, allowing it to "see" the host environment and process image and document files.
 
 ## `screenshot`
 
@@ -26,6 +26,23 @@ Captures a screenshot of the current screen or a specific region.
 | :--- | :--- | :--- |
 | `filename` | `string` | Optional filename. Saved in the workspace. |
 | `region` | `string` | (macOS only) `selection` for interactive crop, `window` for front window. |
+
+---
+
+## `pdf_inspect`
+
+Inspect, classify, and extract text from a PDF file.
+
+- **Security Tier:** Read-Only (Safe).
+- **Execution:** Native runtime tool (requires `pdf-inspect` feature flag).
+- **Capabilities:** Detects whether the PDF is text-based, scanned, image-based, or mixed, and converts extractable text to Markdown.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `path` | `string` | **Required.** Relative path to the PDF file within the workspace. |
+| `extract_text` | `boolean` | Whether to extract and convert text to Markdown (default: true). Set to `false` for metadata-only classification. |
 
 ---
 

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/index.mdx
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/index.mdx
@@ -3,7 +3,7 @@ title: Referencia de Herramientas
 description: Descripción general del sistema de herramientas de Corvus Agent, modelo de seguridad y registro.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-05-06
+lastReviewed: 2026-05-20
 appliesTo: main
 docType: reference
 ---
@@ -22,7 +22,7 @@ Las herramientas integradas se organizan en seis categorías principales:
 - [**Herramientas Web**](web.md) — Navegación web (`browser`), búsqueda (`web_search_tool`), llamadas estructuradas a APIs (`http_request`) y fetch de solo lectura con paridad (`WebFetch`).
 - [**Herramientas de Memoria**](memory.md) — Persistencia a largo plazo y recuperación de hechos y preferencias (`memory_store`, `memory_recall`).
 - [**Herramientas de Automatización**](automation.md) — Delegación multi-agente (`delegate`), integraciones de aplicaciones gestionadas (`composio`), gestión de repositorios Git, tareas programadas (Cron/Schedule) y notificaciones (`pushover`).
-- [**Herramientas Multimedia**](media.md) — Capacidades relacionadas con la visión, incluyendo captura de pantalla y extracción de metadatos de imágenes.
+- [**Herramientas Multimedia**](media.md) — Capacidades relacionadas con la visión y documentos, incluyendo captura de pantalla, extracción de metadatos de imágenes e inspección de PDF (`pdf_inspect`).
 - [**Herramientas de Hardware**](hardware.md) — Descubrimiento de placas (`hardware_board_info`), introspección de memoria (`hardware_memory_read`) y control de periféricos (`gpio_write`, `arduino_upload`).
 
 ## Modelo de Seguridad
@@ -31,7 +31,7 @@ Cada ejecución de herramienta pasa por la capa de `SecurityPolicy`. Las herrami
 
 ### Solo Lectura (Seguras)
 Estas herramientas no modifican el sistema ni el estado externo. Generalmente están permitidas incluso en modos de baja autonomía.
-- *Ejemplos:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `hardware_board_info`.
+- *Ejemplos:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `pdf_inspect`, `hardware_board_info`.
 
 ## Mapeo de paridad estilo Claude
 

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
@@ -3,12 +3,12 @@ title: Herramientas Multimedia
 description: Referencia para herramientas de visión e imágenes en Corvus.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-03-26
+lastReviewed: 2026-05-20
 appliesTo: main
 docType: reference
 ---
 
-Las herramientas multimedia proporcionan al agente capacidades visuales, permitiéndole "ver" el entorno del host y procesar archivos de imagen.
+Las herramientas multimedia proporcionan al agente capacidades visuales, permitiéndole "ver" el entorno del host y procesar archivos de imagen y documentos.
 
 ## `screenshot`
 
@@ -26,6 +26,23 @@ Captura una imagen de la pantalla actual o de una región específica.
 | :--- | :--- | :--- |
 | `filename` | `string` | Nombre de archivo opcional. Guardado en el workspace. |
 | `region` | `string` | (Solo macOS) `selection` para recorte interactivo, `window` para la ventana frontal. |
+
+---
+
+## `pdf_inspect`
+
+Inspecciona, clasifica y extrae texto de un archivo PDF.
+
+- **Nivel de Seguridad:** Solo Lectura (Segura).
+- **Ejecución:** Herramienta nativa del runtime (requiere el feature flag `pdf-inspect`).
+- **Capacidades:** Detecta si el PDF es basado en texto, escaneado, basado en imágenes o mixto, y convierte el texto extraíble a Markdown.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `path` | `string` | **Requerido.** Ruta relativa al archivo PDF dentro del workspace. |
+| `extract_text` | `boolean` | Indica si se debe extraer y convertir el texto a Markdown (por defecto: true). Establezca en `false` para una clasificación de solo metadatos. |
 
 ---
 


### PR DESCRIPTION
Documented the new native pdf_inspect tool in both English and Spanish locales. Updated media tools reference, tools index, and the Scribe journal. Verified bilingual parity and metadata.

---
*PR created automatically by Jules for task [1614381527399551213](https://jules.google.com/task/1614381527399551213) started by @yacosta738*