### PR TITLE
Harden SecurityPolicy against dangerous flags and missing medium-risk operations

### DIFF
--- a/.agents/journal/sentinnel-journal.md
+++ b/.agents/journal/sentinnel-journal.md
@@ -31,3 +31,13 @@
 
 **Learning:** `SecurityPolicy` was vulnerable to path validation bypass using nested or partial quotes (e.g., `"/etc"/passwd`, `""/etc/passwd""`). The previous `strip_matching_quotes` only removed outer quotes, leaving internal quotes to disrupt prefix-based forbidden path and absolute path checks.
 **Action:** Implemented `strip_all_quotes` to normalize command arguments and paths by removing all single and double quotes. In `is_path_allowed`, `iterative_url_decode` is still applied before quote stripping so encoded quotes are exposed before later processing.
+
+## 2025-05-23 - Robust Verb Detection in SecurityPolicy
+
+**Learning:**  was using  to identify subcommands, which was easily bypassed or confused by global flags (e.g., ). Simply skipping arguments starting with '-' is insufficient because path-based flag values (like ) can be mistaken for verbs.
+**Action:** Implement a more robust "verb" detection that skips arguments starting with '-' AND ignores arguments that look like paths (containing '/', '\', or '.'). This ensures that subcommands like 'commit' are correctly identified even when preceded by options with complex values.
+
+## 2025-05-23 - Robust Verb Detection in SecurityPolicy
+
+**Learning:** `is_medium_risk_command` was using `args.first()` to identify subcommands, which was easily bypassed or confused by global flags (e.g., `git -C /tmp status`). Simply skipping arguments starting with '-' is insufficient because path-based flag values (like `/tmp`) can be mistaken for verbs.
+**Action:** Implement a more robust "verb" detection that skips arguments starting with '-' AND ignores arguments that look like paths (containing '/', '\', or '.'). This ensures that subcommands like 'commit' are correctly identified even when preceded by options with complex values.

--- a/clients/agent-runtime/src/security/policy.rs
+++ b/clients/agent-runtime/src/security/policy.rs
@@ -574,24 +574,33 @@ impl SecurityPolicy {
         let base = base.to_ascii_lowercase();
         match base.as_str() {
             "find" => {
-                // find -exec and find -ok allow arbitrary command execution
-                !args.iter().any(|arg| arg == "-exec" || arg == "-ok")
+                // find -exec and find -ok variants allow arbitrary command execution
+                !args
+                    .iter()
+                    .any(|arg| arg == "-exec" || arg == "-ok" || arg == "-execdir" || arg == "-okdir")
             }
             "git" => {
-                // git config, alias, and -c can be used to set dangerous options
-                // (e.g. git config core.editor "rm -rf /")
+                // git config, alias, -c, and --exec-path can be used to set dangerous options
+                // or execute arbitrary code.
                 !args.iter().any(|arg| {
                     arg == "config"
                         || arg.starts_with("config.")
                         || arg == "alias"
                         || arg.starts_with("alias.")
                         || arg == "-c"
+                        || arg == "--exec-path"
+                        || arg.starts_with("--exec-path=")
                 })
             }
             "npm" | "pnpm" | "yarn" => {
-                // npm config and set can be used to set dangerous options
-                // (e.g. npm config set editor "rm -rf /")
-                !args.iter().any(|arg| arg == "config" || arg == "set")
+                // npm config, set, and -c/--config can be used to set dangerous options
+                !args.iter().any(|arg| {
+                    arg == "config" || arg == "set" || arg == "--config" || arg == "-c"
+                })
+            }
+            "cargo" => {
+                // cargo --config and -c can be used to inject dangerous settings
+                !args.iter().any(|arg| arg == "--config" || arg == "-c")
             }
             _ => true,
         }
@@ -778,12 +787,26 @@ fn contains_high_risk_snippet(segment: &str) -> bool {
 }
 
 fn is_medium_risk_command(base: &str, args: &[String]) -> bool {
+    let verb = args.iter().find(|arg| {
+        !arg.starts_with('-')
+            && !arg.contains('/')
+            && !arg.contains('\\')
+            && !arg.contains('.')
+            && *arg != ".."
+    });
+
     match base {
-        "git" => args.first().is_some_and(|verb| {
+        "git" => verb.is_some_and(|v| {
             matches!(
-                verb.as_str(),
+                v.as_str(),
                 "commit"
                     | "push"
+                    | "pull"
+                    | "fetch"
+                    | "clone"
+                    | "init"
+                    | "remote"
+                    | "submodule"
                     | "reset"
                     | "clean"
                     | "rebase"
@@ -796,9 +819,9 @@ fn is_medium_risk_command(base: &str, args: &[String]) -> bool {
                     | "tag"
             )
         }),
-        "npm" | "pnpm" | "yarn" => args.first().is_some_and(|verb| {
+        "npm" | "pnpm" | "yarn" => verb.is_some_and(|v| {
             matches!(
-                verb.as_str(),
+                v.as_str(),
                 "install"
                     | "add"
                     | "remove"
@@ -811,14 +834,33 @@ fn is_medium_risk_command(base: &str, args: &[String]) -> bool {
                     | "t"
                     | "it"
                     | "cit"
+                    | "init"
+                    | "link"
+                    | "unlink"
             )
         }),
-        "cargo" => args.first().is_some_and(|verb| {
+        "cargo" => verb.is_some_and(|v| {
             matches!(
-                verb.as_str(),
-                "add" | "remove" | "install" | "clean" | "publish" | "run" | "r" | "test" | "t"
+                v.as_str(),
+                "add"
+                    | "remove"
+                    | "install"
+                    | "clean"
+                    | "publish"
+                    | "run"
+                    | "r"
+                    | "test"
+                    | "t"
+                    | "build"
+                    | "b"
+                    | "check"
+                    | "c"
+                    | "update"
+                    | "init"
+                    | "new"
             )
         }),
+        "find" => args.iter().any(|arg| arg == "-delete"),
         "touch" | "mkdir" | "mv" | "cp" | "ln" => true,
         _ => false,
     }


### PR DESCRIPTION
This PR hardens the `SecurityPolicy` in the Rust agent runtime. It addresses potential bypasses in subcommand detection by implementing a more robust "verb" identification logic that skips global flags and path-like arguments. It also expands the blocklist for dangerous CLI flags (like `git --exec-path` and `cargo --config`) and ensures that more sensitive operations (like `git clone` or `cargo build`) are correctly classified as Medium risk.

Security Impact:
- Risk reduced: Prevents arbitrary code execution via configuration injection or binary shadowing.
- Attack surface change: Significantly narrowed by blocking dangerous flags and improving subcommand detection accuracy.
- Why this remains safe: The changes are isolated to policy logic and use fail-closed defaults.

Verification:
- Logic verified via isolated Rust test script (due to environment timeouts).
- Kotlin modules compilation verified.
- Format checks verified.

---
*PR created automatically by Jules for task [9921240660924713436](https://jules.google.com/task/9921240660924713436) started by @yacosta738*