### PR TITLE
docs: add pdf_inspect tool to media reference

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -113,3 +113,21 @@ All three identified issues have been fixed:
 - Improved `cron_runs` and `cron_update` parameter documentation in `automation.md` (en/es).
 **Validation:** Results of `make docs-check` and `make docs-build` passed (84 pages built).
 **Notes:** Maintaining bilingual parity between root (English) and `es/` directory.
+
+## 2026-05-12 - Media Tools Update & Hardware Audit - Complete
+
+**Verification:**
+- Verified `pdf_inspect` implementation in `clients/agent-runtime/src/tools/pdf_inspect.rs`.
+- Audited hardware tools implementation in `clients/agent-runtime/src/tools/` and `clients/agent-runtime/src/peripherals/`.
+- Confirmed that `hardware_board_info`, `hardware_capabilities`, `hardware_memory_map`, `hardware_memory_read`, `gpio_read`, `gpio_write`, and `arduino_upload` are all implemented and correctly documented in `hardware.md`.
+
+**Changes:**
+- Added `pdf_inspect` tool section to `clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md` (en/es).
+- Updated `lastReviewed` date to `2026-05-12` in `media.md` (en/es).
+
+**Validation:**
+- `astro check` — ✅ PASSED.
+- `node scripts/validate-docs-metadata.mjs` — ✅ PASSED for affected files.
+- Manual verification of bilingual parity for the new `pdf_inspect` section.
+
+**Notes:** Bilingual parity maintained. `pdf_inspect` is classified as Read-Only (Safe).

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
@@ -3,7 +3,7 @@ title: Media Tools
 description: Reference for vision and image-related tools in Corvus.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-03-26
+lastReviewed: 2026-05-12
 appliesTo: main
 docType: reference
 ---
@@ -44,3 +44,20 @@ Extracts metadata from an image file and optionally returns it as base64 for pro
 | :--- | :--- | :--- |
 | `path` | `string` | **Required.** Path to the image file. |
 | `include_base64` | `boolean` | Include the full image data in the output. Default: `false`. |
+
+---
+
+## `pdf_inspect`
+
+Inspect, classify, and extract text from a PDF file.
+
+- **Security Tier:** Read-Only (Safe).
+- **Execution:** Native runtime tool with isolated parsing and Markdown conversion.
+- **Functionality:** Detects whether the PDF is text-based, scanned, image-based, or mixed.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `path` | `string` | **Required.** Relative path to the PDF file within the workspace. |
+| `extract_text` | `boolean` | Whether to extract and convert text to Markdown (default: true). Set to false for a fast metadata-only classification. |

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
@@ -3,7 +3,7 @@ title: Herramientas Multimedia
 description: Referencia para herramientas de visión e imágenes en Corvus.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-03-26
+lastReviewed: 2026-05-12
 appliesTo: main
 docType: reference
 ---
@@ -44,3 +44,20 @@ Extrae metadatos de un archivo de imagen y, opcionalmente, lo devuelve como base
 | :--- | :--- | :--- |
 | `path` | `string` | **Requerido.** Ruta al archivo de imagen. |
 | `include_base64` | `boolean` | Incluir los datos completos de la imagen en la salida. Por defecto: `false`. |
+
+---
+
+## `pdf_inspect`
+
+Inspecciona, clasifica y extrae texto de un archivo PDF.
+
+- **Nivel de Seguridad:** Solo Lectura (Segura).
+- **Ejecución:** Herramienta nativa del runtime con análisis aislado y conversión a Markdown.
+- **Funcionalidad:** Detecta si el PDF es basado en texto, escaneado, basado en imágenes o mixto.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `path` | `string` | **Requerido.** Ruta relativa al archivo PDF dentro del workspace. |
+| `extract_text` | `boolean` | Indica si se debe extraer y convertir el texto a Markdown (por defecto: true). Establézcalo en false para una clasificación rápida solo de metadatos. |


### PR DESCRIPTION
This PR adds the missing `pdf_inspect` tool to the Media Tools reference documentation. 

### Changes:
- **English Docs:** Added `pdf_inspect` section to `clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md`.
- **Spanish Docs:** Added translated `pdf_inspect` section to `clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md`.
- **Audit:** Conducted a full audit of hardware tools (`hardware_board_info`, `hardware_capabilities`, `hardware_memory_map`, `hardware_memory_read`, `gpio_read`, `gpio_write`, `arduino_upload`). All were found to be correctly documented in `hardware.md`.
- **Journal:** Updated `.agents/journal/scribe-journal.md` with 2026-05-12 entry.

### Verification:
- Implementation verified in `clients/agent-runtime/src/tools/pdf_inspect.rs`.
- Hardware implementations verified in `src/tools/` and `src/peripherals/`.
- `astro check` passed.
- `scripts/validate-docs-metadata.mjs` passed.
- Bilingual parity maintained.

---
*PR created automatically by Jules for task [5693163374476646820](https://jules.google.com/task/5693163374476646820) started by @yacosta738*