### PR TITLE
fix(security): harden git -c check and fix -C false positive

### DIFF
--- a/.agents/journal/sentinnel-journal.md
+++ b/.agents/journal/sentinnel-journal.md
@@ -31,3 +31,8 @@
 
 **Learning:** `SecurityPolicy` was vulnerable to path validation bypass using nested or partial quotes (e.g., `"/etc"/passwd`, `""/etc/passwd""`). The previous `strip_matching_quotes` only removed outer quotes, leaving internal quotes to disrupt prefix-based forbidden path and absolute path checks.
 **Action:** Implemented `strip_all_quotes` to normalize command arguments and paths by removing all single and double quotes. In `is_path_allowed`, `iterative_url_decode` is still applied before quote stripping so encoded quotes are exposed before later processing.
+
+## 2025-06-01 - Optimizing SecurityPolicy and Fixing Case-Sensitive Bypasses
+
+**Learning:** Mandatory global lowercasing of command arguments for security validation caused both false positives (e.g., blocking `git -C` because it was treated as `git -c`) and security gaps (e.g., missing joined flags like `git -cconfig=value`). It also introduced unnecessary $O(N)$ string allocations for every command execution.
+**Action:** Transitioned to passing case-preserving arguments to `is_args_safe`. Implemented case-insensitive checks for subcommands and case-sensitive prefix matching for sensitive flags (like `git -c`). This improves performance by avoiding allocations in the common path and increases security by correctly identifying complex flag forms.

--- a/clients/agent-runtime/src/security/policy.rs
+++ b/clients/agent-runtime/src/security/policy.rs
@@ -526,11 +526,6 @@ impl SecurityPolicy {
             Some(args) => args,
             None => return false,
         };
-        let args: Vec<String> = normalized_args
-            .iter()
-            .map(|arg| arg.to_ascii_lowercase())
-            .collect();
-
         for arg in &normalized_args {
             let effective_arg = Self::effective_path_arg(arg);
             if !self.is_path_argument_safe(effective_arg) {
@@ -538,7 +533,7 @@ impl SecurityPolicy {
             }
         }
 
-        if !self.is_args_safe(base_raw, &args) {
+        if !self.is_args_safe(base_raw, &normalized_args) {
             return false;
         }
 
@@ -575,23 +570,31 @@ impl SecurityPolicy {
         match base.as_str() {
             "find" => {
                 // find -exec and find -ok allow arbitrary command execution
-                !args.iter().any(|arg| arg == "-exec" || arg == "-ok")
+                !args.iter().any(|arg| {
+                    let l = arg.to_ascii_lowercase();
+                    l == "-exec" || l == "-ok"
+                })
             }
             "git" => {
                 // git config, alias, and -c can be used to set dangerous options
                 // (e.g. git config core.editor "rm -rf /")
                 !args.iter().any(|arg| {
-                    arg == "config"
-                        || arg.starts_with("config.")
-                        || arg == "alias"
-                        || arg.starts_with("alias.")
+                    let l = arg.to_ascii_lowercase();
+                    l == "config"
+                        || l.starts_with("config.")
+                        || l == "alias"
+                        || l.starts_with("alias.")
                         || arg == "-c"
+                        || arg.starts_with("-c")
                 })
             }
             "npm" | "pnpm" | "yarn" => {
                 // npm config and set can be used to set dangerous options
                 // (e.g. npm config set editor "rm -rf /")
-                !args.iter().any(|arg| arg == "config" || arg == "set")
+                !args.iter().any(|arg| {
+                    let l = arg.to_ascii_lowercase();
+                    l == "config" || l == "set"
+                })
             }
             _ => true,
         }


### PR DESCRIPTION
Hardened the `SecurityPolicy` in `agent-runtime` to correctly handle case-sensitive flags and improve performance.

Key changes:
1. **Fixed `git -C` False Positive:** Removed global argument lowercasing in `is_segment_valid`, which previously caused the safe `-C` flag to be treated as the forbidden `-c` flag.
2. **Hardened `git -c` Check:** Added prefix matching (`starts_with("-c")`) to catch joined flags like `git -cconfig=...` which were previously bypassed.
3. **Performance Optimization:** Eliminated mandatory $O(N)$ string allocations for lowercasing all arguments in every command check. Lowercasing is now done lazily only for commands that require further validation.
4. **Case-Insensitive Subcommands:** Preserved and improved case-insensitivity for subcommands like `GIT CONFIG` and `npm SET`.

Verification:
- Logic verified via isolated Rust script `repro.rs` (covering safe `-C`, forbidden `-c`, joined flags, and case-insensitive subcommands).
- `make format` and `spotlessCheck` passed.
- Kotlin JVM tests passed.
- Learnings documented in `.agents/journal/sentinnel-journal.md`.

---
*PR created automatically by Jules for task [10303631169805964720](https://jules.google.com/task/10303631169805964720) started by @yacosta738*