### PR TITLE
docs: document pdf_inspect tool and plan mode

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -113,3 +113,15 @@ All three identified issues have been fixed:
 - Improved `cron_runs` and `cron_update` parameter documentation in `automation.md` (en/es).
 **Validation:** Results of `make docs-check` and `make docs-build` passed (84 pages built).
 **Notes:** Maintaining bilingual parity between root (English) and `es/` directory.
+
+## 2026-06-10 - PDF Inspection & Plan Mode Documentation - Complete
+
+**Verification:** Verified `pdf_inspect.rs` for tool contract and `policy.rs` for Plan Mode allowlist and security logic.
+**Changes:**
+- Updated `media.md` (en/es) with `pdf_inspect` tool documentation.
+- Updated `cli-reference.md` (en/es) with Plan Mode (`--plan`) details and allowed tools list.
+- Updated `runtime-sandbox-isolation.md` (en/es) to include Plan Mode as the third security layer.
+- Updated `index.mdx` (en/es) to categorize `pdf_inspect` and reference Plan Mode.
+- Updated all modified files' `lastReviewed` frontmatter to 2026-06-10.
+**Validation:** Results of `make docs-check` and `make docs-build` passed (84 pages built).
+**Notes:** `pdf_inspect` is not yet in the `PLAN_MODE_SAFE_TOOLS` allowlist in code, so it was excluded from the Plan Mode documentation list to maintain technical accuracy.

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/index.mdx
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/index.mdx
@@ -3,7 +3,7 @@ title: Tools Reference
 description: Overview of the Corvus Agent tool system, security model, and registration.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-05-06
+lastReviewed: 2026-06-10
 appliesTo: main
 docType: reference
 ---
@@ -22,7 +22,7 @@ Built-in tools are organized into six primary categories:
 - [**Web Tools**](web.md) — Web browsing (`browser`), search (`web_search_tool`), structured API calls (`http_request`), and read-only fetch parity (`WebFetch`).
 - [**Memory Tools**](memory.md) — Long-term persistence and retrieval of facts and preferences (`memory_store`, `memory_recall`).
 - [**Automation Tools**](automation.md) — Multi-agent delegation (`delegate`), managed app integrations (`composio`), Git repository management, scheduled tasks (Cron/Schedule), and notifications (`pushover`).
-- [**Media Tools**](media.md) — Vision-related capabilities including screen capture and image metadata extraction.
+- [**Media Tools**](media.md) — Vision-related capabilities including screen capture, image metadata extraction, and PDF inspection.
 - [**Hardware Tools**](hardware.md) — Board discovery (`hardware_board_info`), memory introspection (`hardware_memory_read`), and peripheral control (`gpio_write`, `arduino_upload`).
 
 ## Security Model
@@ -31,7 +31,11 @@ Every tool execution passes through the `SecurityPolicy` layer. Tools are classi
 
 ### Read-Only (Safe)
 These tools do not modify the system or external state. They are generally allowed even in low-autonomy modes.
-- *Examples:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `hardware_board_info`.
+- *Examples:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `pdf_inspect`, `hardware_board_info`.
+
+:::note[Plan Mode]
+In [Plan Mode](../../../guides/cli-reference.md#plan-mode), Corvus restricts tool execution to a specific allowlist of safe tools.
+:::
 
 ## Claude-style parity mapping
 

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
@@ -3,7 +3,7 @@ title: Media Tools
 description: Reference for vision and image-related tools in Corvus.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-03-26
+lastReviewed: 2026-06-10
 appliesTo: main
 docType: reference
 ---
@@ -44,3 +44,20 @@ Extracts metadata from an image file and optionally returns it as base64 for pro
 | :--- | :--- | :--- |
 | `path` | `string` | **Required.** Path to the image file. |
 | `include_base64` | `boolean` | Include the full image data in the output. Default: `false`. |
+
+---
+
+## `pdf_inspect`
+
+Inspects, classifies, and extracts text from a PDF file.
+
+- **Security Tier:** Read-Only (Safe).
+- **Execution:** Detects whether the PDF is text-based, scanned, image-based, or mixed.
+- **Constraints:** Max file size 50 MB. Timeout 60 seconds.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `path` | `string` | **Required.** Relative path to the PDF file within the workspace. |
+| `extract_text` | `boolean` | Whether to extract and convert text to Markdown (default: `true`). |

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/index.mdx
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/index.mdx
@@ -3,7 +3,7 @@ title: Referencia de Herramientas
 description: Descripción general del sistema de herramientas de Corvus Agent, modelo de seguridad y registro.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-05-06
+lastReviewed: 2026-06-10
 appliesTo: main
 docType: reference
 ---
@@ -22,7 +22,7 @@ Las herramientas integradas se organizan en seis categorías principales:
 - [**Herramientas Web**](web.md) — Navegación web (`browser`), búsqueda (`web_search_tool`), llamadas estructuradas a APIs (`http_request`) y fetch de solo lectura con paridad (`WebFetch`).
 - [**Herramientas de Memoria**](memory.md) — Persistencia a largo plazo y recuperación de hechos y preferencias (`memory_store`, `memory_recall`).
 - [**Herramientas de Automatización**](automation.md) — Delegación multi-agente (`delegate`), integraciones de aplicaciones gestionadas (`composio`), gestión de repositorios Git, tareas programadas (Cron/Schedule) y notificaciones (`pushover`).
-- [**Herramientas Multimedia**](media.md) — Capacidades relacionadas con la visión, incluyendo captura de pantalla y extracción de metadatos de imágenes.
+- [**Herramientas Multimedia**](media.md) — Capacidades relacionadas con la visión, incluyendo captura de pantalla, extracción de metadatos de imágenes e inspección de PDF.
 - [**Herramientas de Hardware**](hardware.md) — Descubrimiento de placas (`hardware_board_info`), introspección de memoria (`hardware_memory_read`) y control de periféricos (`gpio_write`, `arduino_upload`).
 
 ## Modelo de Seguridad
@@ -31,7 +31,11 @@ Cada ejecución de herramienta pasa por la capa de `SecurityPolicy`. Las herrami
 
 ### Solo Lectura (Seguras)
 Estas herramientas no modifican el sistema ni el estado externo. Generalmente están permitidas incluso en modos de baja autonomía.
-- *Ejemplos:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `hardware_board_info`.
+- *Ejemplos:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `pdf_inspect`, `hardware_board_info`.
+
+:::note[Modo de Plan]
+En el [Modo de Plan](../../../guides/cli-reference.md#modo-de-plan-plan-mode), Corvus restringe la ejecución de herramientas a una lista específica de herramientas seguras.
+:::
 
 ## Mapeo de paridad estilo Claude
 

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
@@ -3,7 +3,7 @@ title: Herramientas Multimedia
 description: Referencia para herramientas de visión e imágenes en Corvus.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-03-26
+lastReviewed: 2026-06-10
 appliesTo: main
 docType: reference
 ---
@@ -44,3 +44,20 @@ Extrae metadatos de un archivo de imagen y, opcionalmente, lo devuelve como base
 | :--- | :--- | :--- |
 | `path` | `string` | **Requerido.** Ruta al archivo de imagen. |
 | `include_base64` | `boolean` | Incluir los datos completos de la imagen en la salida. Por defecto: `false`. |
+
+---
+
+## `pdf_inspect`
+
+Inspecciona, clasifica y extrae texto de un archivo PDF.
+
+- **Nivel de Seguridad:** Solo Lectura (Segura).
+- **Ejecución:** Detecta si el PDF está basado en texto, escaneado, basado en imágenes o es mixto.
+- **Restricciones:** Tamaño máximo de archivo 50 MB. Tiempo de espera 60 segundos.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `path` | `string` | **Requerido.** Ruta relativa al archivo PDF dentro del workspace. |
+| `extract_text` | `boolean` | Si se debe extraer y convertir el texto a Markdown (por defecto: `true`). |

--- a/clients/web/apps/docs/src/content/docs/es/guides/cli-reference.md
+++ b/clients/web/apps/docs/src/content/docs/es/guides/cli-reference.md
@@ -3,7 +3,7 @@ title: Referencia de la CLI
 description: Guía completa de los comandos y opciones de la CLI del agente Corvus.
 owner: team-platform
 status: canonical
-lastReviewed: 2026-05-06
+lastReviewed: 2026-06-10
 appliesTo: main
 docType: reference
 ---
@@ -103,6 +103,27 @@ Inicia solo el servidor gateway (webhooks, websockets).
 ```bash
 corvus gateway --port 3001
 ```
+
+---
+
+## Modo de Plan (Plan Mode)
+
+El flag `--plan` (disponible para los comandos `agent` y `code`) habilita un modo de análisis de alta integridad donde el agente puede explorar el entorno pero no puede realizar acciones con efectos secundarios.
+
+Cuando el Modo de Plan está activo, Corvus impone una lista estricta de permitidos de herramientas de "solo análisis". Cualquier intento de utilizar una herramienta que no esté en esta lista será bloqueado por la política de seguridad.
+
+### Herramientas permitidas en el Modo de Plan
+
+- `Glob` / `glob`
+- `Grep` / `grep`
+- `WebFetch` / `web_fetch`
+- `code_search`
+- `file_read`
+- `image_info`
+- `memory_recall`
+- `web_search_tool`
+
+Todas las demás herramientas, incluidas `shell`, `file_write`, `git_operations` y `delegate`, están estrictamente deshabilitadas.
 
 ---
 

--- a/clients/web/apps/docs/src/content/docs/es/guides/runtime-sandbox-isolation.md
+++ b/clients/web/apps/docs/src/content/docs/es/guides/runtime-sandbox-isolation.md
@@ -3,21 +3,24 @@ title: Aislamiento del Sandbox del Runtime
 description: Modelo de seguridad, selección de backend, verificación del sidecar y expectativas de auditoría para el aislamiento del runtime en Corvus.
 owner: team-platform
 status: canonical
-lastReviewed: 2026-04-03
+lastReviewed: 2026-06-10
 appliesTo: main
 docType: guide
 ---
 
 # Aislamiento del Sandbox del Runtime
 
-Corvus usa **dos capas de seguridad** para la ejecución disparada por usuarios:
+Corvus usa **tres capas de seguridad** para la ejecución disparada por usuarios:
 
 1. **Política a nivel de aplicación** mediante `SecurityPolicy`
    - allowlists de comandos
    - restricciones de rutas
    - límites de tasa
    - clasificación de riesgo y compuertas de aprobación
-2. **Sandboxing a nivel de sistema operativo** mediante los backends `Sandbox` del runtime
+2. **Modo de Plan (solo análisis)**
+   - allowlist de herramientas de solo análisis
+   - bloqueo de efectos secundarios forzado
+3. **Sandboxing a nivel de sistema operativo** mediante los backends `Sandbox` del runtime
    - `landlock`
    - `firejail`
    - `bubblewrap`

--- a/clients/web/apps/docs/src/content/docs/guides/cli-reference.md
+++ b/clients/web/apps/docs/src/content/docs/guides/cli-reference.md
@@ -3,7 +3,7 @@ title: CLI Reference
 description: Comprehensive guide to the Corvus Agent CLI commands and options.
 owner: team-platform
 status: canonical
-lastReviewed: 2026-05-06
+lastReviewed: 2026-06-10
 appliesTo: main
 docType: reference
 ---
@@ -103,6 +103,27 @@ Start only the gateway server (webhooks, websockets).
 ```bash
 corvus gateway --port 3001
 ```
+
+---
+
+## Plan Mode
+
+The `--plan` flag (available for `agent` and `code` commands) enables a high-integrity analysis mode where the agent can explore the environment but cannot perform side-effecting actions.
+
+When Plan Mode is active, Corvus enforces a strict allowlist of "analysis-only" tools. Any attempt to use a tool not on this list will be blocked by the security policy.
+
+### Allowed Tools in Plan Mode
+
+- `Glob` / `glob`
+- `Grep` / `grep`
+- `WebFetch` / `web_fetch`
+- `code_search`
+- `file_read`
+- `image_info`
+- `memory_recall`
+- `web_search_tool`
+
+All other tools, including `shell`, `file_write`, `git_operations`, and `delegate`, are strictly disabled.
 
 ---
 

--- a/clients/web/apps/docs/src/content/docs/guides/runtime-sandbox-isolation.md
+++ b/clients/web/apps/docs/src/content/docs/guides/runtime-sandbox-isolation.md
@@ -3,21 +3,24 @@ title: Runtime Sandbox Isolation
 description: Security model, backend selection, sidecar verification, and audit expectations for runtime sandbox isolation in Corvus.
 owner: team-platform
 status: canonical
-lastReviewed: 2026-04-03
+lastReviewed: 2026-06-10
 appliesTo: main
 docType: guide
 ---
 
 # Runtime Sandbox Isolation
 
-Corvus uses **two security layers** for user-triggered execution:
+Corvus uses **three security layers** for user-triggered execution:
 
 1. **Application-layer policy** via `SecurityPolicy`
    - command allowlists
    - path restrictions
    - rate limits
    - risk classification and approval gates
-2. **OS-level sandboxing** via the runtime `Sandbox` backends
+2. **Analysis-only Plan Mode**
+   - analysis-only tool allowlist
+   - enforced side-effect blocking
+3. **OS-level sandboxing** via the runtime `Sandbox` backends
    - `landlock`
    - `firejail`
    - `bubblewrap`


### PR DESCRIPTION
This pull request updates the Corvus documentation to include technical references for the new `pdf_inspect` tool and the "Plan Mode" CLI feature.

Key changes:
1.  **PDF Inspection Tool:** Documented `pdf_inspect` in `clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md` (and Spanish counterpart). Included security tier (Read-Only), execution details, constraints, and parameters (`path`, `extract_text`).
2.  **Plan Mode:** Added a new "Plan Mode" section to `clients/web/apps/docs/src/content/docs/guides/cli-reference.md` (and Spanish counterpart), detailing the `--plan` flag behavior and the specific allowlist of safe tools permitted during analysis-only turns.
3.  **Security Architecture:** Updated `clients/web/apps/docs/src/content/docs/guides/runtime-sandbox-isolation.md` (and Spanish counterpart) to reflect Plan Mode as the third layer in Corvus's multi-tier security model.
4.  **Tools Index:** Updated the main tools reference index to categorize `pdf_inspect` under Media Tools and added it to the "Read-Only (Safe)" examples. Included a note and link for Plan Mode.
5.  **Bilingual Parity:** Maintained 1:1 parity between English and Spanish documentation.
6.  **Metadata:** Updated the `lastReviewed` field to `2026-06-10` for all modified files.

All changes have been validated using `make docs-check` and `make docs-build`.

---
*PR created automatically by Jules for task [5036687119288407507](https://jules.google.com/task/5036687119288407507) started by @yacosta738*