### PR TITLE
fix(security): harden argument validation and risk detection in SecurityPolicy

### DIFF
--- a/.agents/journal/sentinnel-journal.md
+++ b/.agents/journal/sentinnel-journal.md
@@ -31,3 +31,23 @@
 
 **Learning:** `SecurityPolicy` was vulnerable to path validation bypass using nested or partial quotes (e.g., `"/etc"/passwd`, `""/etc/passwd""`). The previous `strip_matching_quotes` only removed outer quotes, leaving internal quotes to disrupt prefix-based forbidden path and absolute path checks.
 **Action:** Implemented `strip_all_quotes` to normalize command arguments and paths by removing all single and double quotes. In `is_path_allowed`, `iterative_url_decode` is still applied before quote stripping so encoded quotes are exposed before later processing.
+
+## 2025-06-13 - Robust Argument Validation and Risk Detection
+
+**Learning:**  risk classification was bypassable by prefixing global flags before risky subcommands (e.g., `git -C . commit` was `Low` risk because only the first argument was checked). Additionally, lowercasing arguments before safety checks prevented distinguishing between case-sensitive flags like git's `-c` (dangerous config injection) and `-C` (safe path change). Missing coverage for `--config` flags in package managers and `cargo` left config injection gaps.
+
+**Action:**
+1. ✅ Updated `is_medium_risk_command` to use `args.iter().any()` to detect risky verbs regardless of position.
+2. ✅ Modified `is_segment_valid` to pass case-preserved normalized arguments to `is_args_safe` to enable correct flag differentiation.
+3. ✅ Expanded `is_args_safe` blocklist to include `--config`, `-c`, and joined variants (e.g., `starts_with("-c")`).
+4. ✅ Added `cargo build/check/fetch` to `Medium` risk classification to account for potential code execution in build scripts.
+
+## 2025-06-13 - Robust Argument Validation and Risk Detection
+
+**Learning:** `SecurityPolicy` risk classification was bypassable by prefixing global flags before risky subcommands (e.g., `git -C . commit` was `Low` risk because only the first argument was checked). Additionally, lowercasing arguments before safety checks prevented distinguishing between case-sensitive flags like git's `-c` (dangerous config injection) and `-C` (safe path change). Missing coverage for `--config` flags in package managers and `cargo` left config injection gaps.
+
+**Action:**
+1. ✅ Updated `is_medium_risk_command` to use `args.iter().any()` to detect risky verbs regardless of position.
+2. ✅ Modified `is_segment_valid` to pass case-preserved normalized arguments to `is_args_safe` to enable correct flag differentiation.
+3. ✅ Expanded `is_args_safe` blocklist to include `--config`, `-c`, and joined variants (e.g., `starts_with("-c")`).
+4. ✅ Added `cargo build/check/fetch` to `Medium` risk classification to account for potential code execution in build scripts.

--- a/clients/agent-runtime/src/security/policy.rs
+++ b/clients/agent-runtime/src/security/policy.rs
@@ -538,7 +538,7 @@ impl SecurityPolicy {
             }
         }
 
-        if !self.is_args_safe(base_raw, &args) {
+        if !self.is_args_safe(base_raw, &normalized_args) {
             return false;
         }
 
@@ -575,7 +575,9 @@ impl SecurityPolicy {
         match base.as_str() {
             "find" => {
                 // find -exec and find -ok allow arbitrary command execution
-                !args.iter().any(|arg| arg == "-exec" || arg == "-ok")
+                !args
+                    .iter()
+                    .any(|arg| arg == "-exec" || arg == "-ok" || arg == "--exec" || arg == "--ok")
             }
             "git" => {
                 // git config, alias, and -c can be used to set dangerous options
@@ -586,12 +588,28 @@ impl SecurityPolicy {
                         || arg == "alias"
                         || arg.starts_with("alias.")
                         || arg == "-c"
+                        || arg.starts_with("-c")
+                        || arg == "--config"
+                        || arg.starts_with("--config=")
                 })
             }
             "npm" | "pnpm" | "yarn" => {
                 // npm config and set can be used to set dangerous options
                 // (e.g. npm config set editor "rm -rf /")
-                !args.iter().any(|arg| arg == "config" || arg == "set")
+                !args.iter().any(|arg| {
+                    arg == "config"
+                        || arg == "set"
+                        || arg == "-c"
+                        || arg.starts_with("-c")
+                        || arg == "--config"
+                        || arg.starts_with("--config=")
+                })
+            }
+            "cargo" => {
+                // cargo --config can be used to override settings
+                !args
+                    .iter()
+                    .any(|arg| arg == "--config" || arg.starts_with("--config="))
             }
             _ => true,
         }
@@ -779,11 +797,15 @@ fn contains_high_risk_snippet(segment: &str) -> bool {
 
 fn is_medium_risk_command(base: &str, args: &[String]) -> bool {
     match base {
-        "git" => args.first().is_some_and(|verb| {
+        "git" => args.iter().any(|verb| {
             matches!(
                 verb.as_str(),
                 "commit"
                     | "push"
+                    | "pull"
+                    | "clone"
+                    | "fetch"
+                    | "init"
                     | "reset"
                     | "clean"
                     | "rebase"
@@ -796,10 +818,13 @@ fn is_medium_risk_command(base: &str, args: &[String]) -> bool {
                     | "tag"
             )
         }),
-        "npm" | "pnpm" | "yarn" => args.first().is_some_and(|verb| {
+        "npm" | "pnpm" | "yarn" => args.iter().any(|verb| {
             matches!(
                 verb.as_str(),
                 "install"
+                    | "ci"
+                    | "link"
+                    | "init"
                     | "add"
                     | "remove"
                     | "uninstall"
@@ -813,10 +838,24 @@ fn is_medium_risk_command(base: &str, args: &[String]) -> bool {
                     | "cit"
             )
         }),
-        "cargo" => args.first().is_some_and(|verb| {
+        "cargo" => args.iter().any(|verb| {
             matches!(
                 verb.as_str(),
-                "add" | "remove" | "install" | "clean" | "publish" | "run" | "r" | "test" | "t"
+                "build"
+                    | "check"
+                    | "update"
+                    | "init"
+                    | "new"
+                    | "fetch"
+                    | "add"
+                    | "remove"
+                    | "install"
+                    | "clean"
+                    | "publish"
+                    | "run"
+                    | "r"
+                    | "test"
+                    | "t"
             )
         }),
         "touch" | "mkdir" | "mv" | "cp" | "ln" => true,


### PR DESCRIPTION
Hardens the `SecurityPolicy` in the agent runtime to prevent bypasses of risk classification and configuration injection.

- **Security Impact:**
  - Prevents masking of risky operations (e.g., `git commit`) by prefixing global flags (e.g., `git -C . commit`).
  - Blocks configuration injection via `-c` and `--config` flags in `git`, `npm`, `pnpm`, `yarn`, and `cargo`.
  - Ensures case-sensitive flags (like git's `-C` vs `-c`) are correctly distinguished by preserving argument case during safety checks.
  - Expanded risk coverage for `cargo` to include `build`, `check`, and `fetch` as `Medium` risk due to potential code execution in build scripts or proc-macros.
- **Performance Impact:**
  - Negligible. Replaces single checks with iterator-based checks on typically short argument lists.
- **Verification:**
  - Logic verified with an isolated Rust script covering multiple bypass and case-sensitivity scenarios.
  - Changes reviewed and confirmed to follow "Security-First" mission rules.

---
*PR created automatically by Jules for task [12343196545949254071](https://jules.google.com/task/12343196545949254071) started by @yacosta738*