### PR TITLE
Document pdf_inspect and enable for Plan Mode

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -91,6 +91,16 @@ All three identified issues have been fixed:
 - Glossary: "Firejail" = Linux user-space sandbox (confirmed implemented). "Landlock" = Linux kernel-level sandbox (confirmed). "Cerebro" = standalone MCP memory service client in `clients/cerebro/` (confirmed).
 - Remaining gap: `cost` command subcommands (`summary`, `history`, `reset`) exist in code but are not yet in the CLI reference doc. Low priority.
 
+## 2026-06-17 - PDF Inspect Tool Documentation & Plan Mode Enablement - Complete
+
+**Verification:** Verified `clients/agent-runtime/src/tools/pdf_inspect.rs` for tool implementation and parameters.
+**Changes:**
+- Added `pdf_inspect` to `PLAN_MODE_SAFE_TOOLS` in `clients/agent-runtime/src/security/policy.rs`.
+- Documented `pdf_inspect` in `clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md` (en/es).
+- Described security tier (Read-Only), Plan Mode safety, parameters, and constraints.
+**Validation:** Results of `make docs-web-check`, `make docs-web-build`, and `cargo check` in `agent-runtime`.
+**Notes:** Bilingual parity maintained. `pdf_inspect` is now available for analysis in Plan Mode.
+
 ## 2026-04-15 - CLI Reference Update - Complete
 
 **Verification:** Verified `clients/agent-runtime/src/main.rs` for `code` and `cost` command implementations.

--- a/clients/agent-runtime/src/security/policy.rs
+++ b/clients/agent-runtime/src/security/policy.rs
@@ -13,6 +13,7 @@ const PLAN_MODE_SAFE_TOOLS: &[&str] = &[
     "file_read",
     "image_info",
     "memory_recall",
+    "pdf_inspect",
     "web_search_tool",
 ];
 

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
@@ -44,3 +44,20 @@ Extracts metadata from an image file and optionally returns it as base64 for pro
 | :--- | :--- | :--- |
 | `path` | `string` | **Required.** Path to the image file. |
 | `include_base64` | `boolean` | Include the full image data in the output. Default: `false`. |
+
+---
+
+## `pdf_inspect`
+
+Inspects and extracts text from a PDF file. Detects whether the PDF is text-based, scanned, image-based, or mixed, and converts extractable text to Markdown.
+
+- **Security Tier:** Read-Only (Safe). ✅ Safe for Plan Mode.
+- **Features:** Returns PDF type, page count, pages needing OCR, title, and Markdown content.
+- **Constraints:** Path-sandboxed to the workspace; maximum file size 50 MB; 60s timeout.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `path` | `string` | **Required.** Relative path to the PDF file within the workspace. |
+| `extract_text` | `boolean` | Whether to extract and convert text to Markdown. Set to `false` for fast metadata classification. Default: `true`. |

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
@@ -44,3 +44,20 @@ Extrae metadatos de un archivo de imagen y, opcionalmente, lo devuelve como base
 | :--- | :--- | :--- |
 | `path` | `string` | **Requerido.** Ruta al archivo de imagen. |
 | `include_base64` | `boolean` | Incluir los datos completos de la imagen en la salida. Por defecto: `false`. |
+
+---
+
+## `pdf_inspect`
+
+Inspecciona y extrae texto de un archivo PDF. Detecta si el PDF es basado en texto, escaneado, basado en imágenes o mixto, y convierte el texto extraíble a Markdown.
+
+- **Nivel de Seguridad:** Solo Lectura (Segura). ✅ Seguro para Plan Mode.
+- **Funcionalidades:** Devuelve el tipo de PDF, el recuento de páginas, las páginas que necesitan OCR, el título y el contenido en Markdown.
+- **Restricciones:** Sandboxing de ruta al workspace; tamaño máximo de archivo 50 MB; tiempo de espera de 60s.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `path` | `string` | **Requerido.** Ruta relativa al archivo PDF dentro del workspace. |
+| `extract_text` | `boolean` | Indica si se debe extraer y convertir el texto a Markdown. Establézcalo en `false` para una clasificación rápida de metadatos. Por defecto: `true`. |


### PR DESCRIPTION
This PR documents the `pdf_inspect` tool in the Media Tools reference for both English and Spanish locales. It also adds `pdf_inspect` to the `PLAN_MODE_SAFE_TOOLS` list in the Rust agent runtime's `SecurityPolicy`, allowing the agent to use this read-only tool for analysis during its planning phase.

Changes:
- Modified `clients/agent-runtime/src/security/policy.rs` to include `pdf_inspect` in Plan Mode safe tools.
- Updated `clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md` with `pdf_inspect` details.
- Updated `clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md` with translated `pdf_inspect` details.
- Added a new entry to `.agents/journal/scribe-journal.md`.

---
*PR created automatically by Jules for task [2090339676350877550](https://jules.google.com/task/2090339676350877550) started by @yacosta738*