### PR TITLE
docs: document pdf_inspect tool in English and Spanish

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -113,3 +113,14 @@ All three identified issues have been fixed:
 - Improved `cron_runs` and `cron_update` parameter documentation in `automation.md` (en/es).
 **Validation:** Results of `make docs-check` and `make docs-build` passed (84 pages built).
 **Notes:** Maintaining bilingual parity between root (English) and `es/` directory.
+
+## 2026-06-24 - PDF Inspection Tool Documentation - Complete
+
+**Verification:** Verified `clients/agent-runtime/src/tools/pdf_inspect.rs` for tool implementation details, including parameters, constraints (50MB limit, 60s timeout), and security tier (Read-Only).
+**Changes:**
+- Updated `clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md` (en) and `es/` counterpart.
+- Added `pdf_inspect` documentation section with parameter tables and constraints.
+- Updated `clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/index.mdx` (en) and `es/` counterpart to include `pdf_inspect` in Read-Only examples.
+- Updated `lastReviewed` date to 2026-05-15 for all modified files (aligned with recent audit cycle).
+**Validation:** Results of `node scripts/validate-docs-metadata.mjs` passed for all 4 files. Bilingual parity and frontmatter integrity confirmed.
+**Notes:** Bilingual parity maintained. `pdf_inspect` is gated by the `pdf-inspect` feature flag in Rust.

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/index.mdx
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/index.mdx
@@ -3,7 +3,7 @@ title: Tools Reference
 description: Overview of the Corvus Agent tool system, security model, and registration.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-05-06
+lastReviewed: 2026-05-15
 appliesTo: main
 docType: reference
 ---
@@ -31,7 +31,7 @@ Every tool execution passes through the `SecurityPolicy` layer. Tools are classi
 
 ### Read-Only (Safe)
 These tools do not modify the system or external state. They are generally allowed even in low-autonomy modes.
-- *Examples:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `hardware_board_info`.
+- *Examples:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `pdf_inspect`, `hardware_board_info`.
 
 ## Claude-style parity mapping
 

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
@@ -3,7 +3,7 @@ title: Media Tools
 description: Reference for vision and image-related tools in Corvus.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-03-26
+lastReviewed: 2026-05-15
 appliesTo: main
 docType: reference
 ---
@@ -44,3 +44,23 @@ Extracts metadata from an image file and optionally returns it as base64 for pro
 | :--- | :--- | :--- |
 | `path` | `string` | **Required.** Path to the image file. |
 | `include_base64` | `boolean` | Include the full image data in the output. Default: `false`. |
+
+---
+
+## `pdf_inspect`
+
+Inspect, classify, and extract text from a PDF file. Detects whether the PDF is text-based, scanned, image-based, or mixed.
+
+- **Security Tier:** Read-Only (Safe).
+- **Functionality:** Converts extractable text to Markdown. Returns PDF type, page count, pages needing OCR, title, and Markdown content.
+- **Constraints:**
+  - Maximum file size: 50 MB.
+  - Timeout: 60 seconds.
+  - Path-sandboxed to the workspace.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `path` | `string` | **Required.** Relative path to the PDF file within the workspace. |
+| `extract_text` | `boolean` | Whether to extract and convert text to Markdown (default: `true`). Set to `false` for metadata-only classification. |

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/index.mdx
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/index.mdx
@@ -3,7 +3,7 @@ title: Referencia de Herramientas
 description: Descripción general del sistema de herramientas de Corvus Agent, modelo de seguridad y registro.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-05-06
+lastReviewed: 2026-05-15
 appliesTo: main
 docType: reference
 ---
@@ -31,7 +31,7 @@ Cada ejecución de herramienta pasa por la capa de `SecurityPolicy`. Las herrami
 
 ### Solo Lectura (Seguras)
 Estas herramientas no modifican el sistema ni el estado externo. Generalmente están permitidas incluso en modos de baja autonomía.
-- *Ejemplos:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `hardware_board_info`.
+- *Ejemplos:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `pdf_inspect`, `hardware_board_info`.
 
 ## Mapeo de paridad estilo Claude
 

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
@@ -3,7 +3,7 @@ title: Herramientas Multimedia
 description: Referencia para herramientas de visión e imágenes en Corvus.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-03-26
+lastReviewed: 2026-05-15
 appliesTo: main
 docType: reference
 ---
@@ -44,3 +44,23 @@ Extrae metadatos de un archivo de imagen y, opcionalmente, lo devuelve como base
 | :--- | :--- | :--- |
 | `path` | `string` | **Requerido.** Ruta al archivo de imagen. |
 | `include_base64` | `boolean` | Incluir los datos completos de la imagen en la salida. Por defecto: `false`. |
+
+---
+
+## `pdf_inspect`
+
+Inspecciona, clasifica y extrae texto de un archivo PDF. Detecta si el PDF está basado en texto, escaneado, basado en imágenes o es mixto.
+
+- **Nivel de Seguridad:** Solo Lectura (Segura).
+- **Funcionalidad:** Convierte el texto extraíble a Markdown. Devuelve el tipo de PDF, número de páginas, páginas que necesitan OCR, título y contenido en Markdown.
+- **Restricciones:**
+  - Tamaño máximo de archivo: 50 MB.
+  - Tiempo de espera: 60 segundos.
+  - Sandboxing de ruta al workspace.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `path` | `string` | **Requerido.** Ruta relativa al archivo PDF dentro del workspace. |
+| `extract_text` | `boolean` | Indica si se debe extraer y convertir el texto a Markdown (por defecto: `true`). Establécelo en `false` para una clasificación solo de metadatos. |


### PR DESCRIPTION
This PR adds comprehensive documentation for the `pdf_inspect` tool in both English and Spanish.

Key changes:
- Detailed documentation of `pdf_inspect` in the Media Tools section, including parameters, constraints (50MB size limit, 60s timeout), and security tier (Read-Only).
- Updated the Tools Reference index to include `pdf_inspect` as a canonical example of a safe, read-only tool.
- Maintained 1:1 bilingual parity between root (English) and `es/` directories.
- Updated `lastReviewed` dates and Scribe Documentation Journal.

Verification:
- Metadata validation script (`node scripts/validate-docs-metadata.mjs`) passed for all modified files.
- Technical details (parameters, constraints) verified against `clients/agent-runtime/src/tools/pdf_inspect.rs`.

---
*PR created automatically by Jules for task [14796930275564716734](https://jules.google.com/task/14796930275564716734) started by @yacosta738*