### PR TITLE
docs: document pdf_inspect tool and sync bilingual parity

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -91,6 +91,23 @@ All three identified issues have been fixed:
 - Glossary: "Firejail" = Linux user-space sandbox (confirmed implemented). "Landlock" = Linux kernel-level sandbox (confirmed). "Cerebro" = standalone MCP memory service client in `clients/cerebro/` (confirmed).
 - Remaining gap: `cost` command subcommands (`summary`, `history`, `reset`) exist in code but are not yet in the CLI reference doc. Low priority.
 
+## 2026-07-01 - PDF Inspection & Parity Sync - Complete
+
+**Verification:**
+- Verified `pdf_inspect` implementation in `clients/agent-runtime/src/tools/pdf_inspect.rs`.
+- Verified `Task*` parity tools and aliases in `clients/agent-runtime/src/tools/mod.rs`.
+**Changes:**
+- Added `pdf_inspect` documentation to `media.md` (en/es), including security tier, features, constraints, and parameters.
+- Added "Mapa de nombres de paridad" (Parity naming map) to `es/clients/agent-runtime/tools/core.md` to ensure bilingual parity with the English version.
+- Updated `index.mdx` (en/es) to include `pdf_inspect` in the Read-Only (Safe) examples.
+- Updated `lastReviewed` date for `media.md` (en/es) to 2026-07-01 to satisfy metadata validation rules.
+**Validation:**
+- `make docs-check` — ✅ PASSED (astro check + biome + metadata validation).
+- `make docs-build` — ✅ PASSED (84 pages built, search index generated).
+**Notes:**
+- `pdf_inspect` is a native tool requiring the `pdf-inspect` feature flag.
+- Parity mapping ensures developers can use Claude-style tool names (`glob`, `task_create`, etc.) which are aliased to Corvus-native implementations.
+
 ## 2026-04-15 - CLI Reference Update - Complete
 
 **Verification:** Verified `clients/agent-runtime/src/main.rs` for `code` and `cost` command implementations.

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/index.mdx
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/index.mdx
@@ -31,7 +31,7 @@ Every tool execution passes through the `SecurityPolicy` layer. Tools are classi
 
 ### Read-Only (Safe)
 These tools do not modify the system or external state. They are generally allowed even in low-autonomy modes.
-- *Examples:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `hardware_board_info`.
+- *Examples:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `pdf_inspect`, `hardware_board_info`.
 
 ## Claude-style parity mapping
 

--- a/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/clients/agent-runtime/tools/media.md
@@ -3,7 +3,7 @@ title: Media Tools
 description: Reference for vision and image-related tools in Corvus.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-03-26
+lastReviewed: 2026-07-01
 appliesTo: main
 docType: reference
 ---
@@ -44,3 +44,22 @@ Extracts metadata from an image file and optionally returns it as base64 for pro
 | :--- | :--- | :--- |
 | `path` | `string` | **Required.** Path to the image file. |
 | `include_base64` | `boolean` | Include the full image data in the output. Default: `false`. |
+
+---
+
+## `pdf_inspect`
+
+Inspects, classifies, and extracts text from a PDF file.
+
+- **Security Tier:** Read-Only (Safe).
+- **Features:** Detects PDF type (text, scanned, image, mixed), page count, and converts extractable text to Markdown.
+- **Constraints:**
+  - Maximum file size: 50 MB.
+  - Timeout: 60 seconds.
+
+### Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `path` | `string` | **Required.** Relative path to the PDF file within the workspace. |
+| `extract_text` | `boolean` | Whether to extract and convert text to Markdown (default: true). |

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/core.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/core.md
@@ -27,6 +27,20 @@ Consulta la página dedicada de [`code_search`](code-search.md) para el contrato
 
 ---
 
+## Mapa de nombres de paridad
+
+| Herramienta canónica | Alias de compatibilidad | Superficie del runtime que lo respalda | Notas |
+| --- | --- | --- | --- |
+| `Glob` | `glob` | Helpers de discovery del workspace | Alias de paridad aditivo |
+| `Grep` | `grep` | Internals de `code_search` | `code_search` se mantiene como contrato nativo |
+| `TaskCreate` | `task_create` | Servicio de tareas persistentes | Solo disponible con backend SQLite |
+| `TaskGet` | `task_get` | Servicio de tareas persistentes | Solo disponible con backend SQLite |
+| `TaskList` | `task_list` | Servicio de tareas persistentes | Orden determinístico por created_at/id |
+| `TaskUpdate` | `task_update` | Servicio de tareas persistentes | Actualiza solo campos mutables |
+| `TaskStop` | `task_stop` | Servicio de tareas persistentes | Ruta de cancelación semántica |
+
+---
+
 ## `Glob`
 
 Herramienta de paridad estilo Claude para descubrimiento seguro de archivos por patrón dentro del workspace.

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/index.mdx
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/index.mdx
@@ -31,7 +31,7 @@ Cada ejecución de herramienta pasa por la capa de `SecurityPolicy`. Las herrami
 
 ### Solo Lectura (Seguras)
 Estas herramientas no modifican el sistema ni el estado externo. Generalmente están permitidas incluso en modos de baja autonomía.
-- *Ejemplos:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `hardware_board_info`.
+- *Ejemplos:* `file_read`, `Glob`, `Grep`, `WebFetch`, `memory_recall`, `web_search_tool`, `image_info`, `pdf_inspect`, `hardware_board_info`.
 
 ## Mapeo de paridad estilo Claude
 

--- a/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
+++ b/clients/web/apps/docs/src/content/docs/es/clients/agent-runtime/tools/media.md
@@ -3,7 +3,7 @@ title: Herramientas Multimedia
 description: Referencia para herramientas de visión e imágenes en Corvus.
 owner: team-runtime
 status: canonical
-lastReviewed: 2026-03-26
+lastReviewed: 2026-07-01
 appliesTo: main
 docType: reference
 ---
@@ -44,3 +44,22 @@ Extrae metadatos de un archivo de imagen y, opcionalmente, lo devuelve como base
 | :--- | :--- | :--- |
 | `path` | `string` | **Requerido.** Ruta al archivo de imagen. |
 | `include_base64` | `boolean` | Incluir los datos completos de la imagen en la salida. Por defecto: `false`. |
+
+---
+
+## `pdf_inspect`
+
+Inspecciona, clasifica y extrae texto de un archivo PDF.
+
+- **Nivel de Seguridad:** Solo Lectura (Segura).
+- **Características:** Detecta el tipo de PDF (texto, escaneado, imagen, mixto), recuento de páginas y convierte el texto extraíble a Markdown.
+- **Restricciones:**
+  - Tamaño máximo de archivo: 50 MB.
+  - Tiempo de espera: 60 segundos.
+
+### Parámetros
+
+| Parámetro | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `path` | `string` | **Requerido.** Ruta relativa al archivo PDF dentro del workspace. |
+| `extract_text` | `boolean` | Indica si se debe extraer y convertir el texto a Markdown (por defecto: true). |


### PR DESCRIPTION
Documented the new pdf_inspect tool in both English and Spanish media tools references. Synchronized the Core tools parity naming map in Spanish and updated the tools index with the new tool. Validated metadata and confirmed build/check pass.

---
*PR created automatically by Jules for task [18331700847879161189](https://jules.google.com/task/18331700847879161189) started by @yacosta738*